### PR TITLE
Add ignore-unscored-cves option

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,7 @@ scan:
                 [-dbpath=/path/to/vuls.sqlite3]
                 [-cve-dictionary-url=http://127.0.0.1:1323]
                 [-cvss-over=7]
+                [-ignore-unscored-cves]
                 [-report-slack]
                 [-report-mail]
                 [-http-proxy=http://192.168.0.1:8080]
@@ -504,6 +505,8 @@ scan:
         SQL debug mode
   -http-proxy string
         http://proxy-url:port (default: empty)
+  -ignore-unscored-cves
+        Don't report the unscored CVEs
   -lang string
         [en|ja] (default "en")
   -report-mail

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -43,8 +43,11 @@ type ScanCmd struct {
 
 	dbpath           string
 	cveDictionaryURL string
-	cvssScoreOver    float64
-	httpProxy        string
+
+	cvssScoreOver      float64
+	ignoreUnscoredCves bool
+
+	httpProxy string
 
 	// reporting
 	reportSlack bool
@@ -72,6 +75,7 @@ func (*ScanCmd) Usage() string {
 		[-dbpath=/path/to/vuls.sqlite3]
 		[-cve-dictionary-url=http://127.0.0.1:1323]
 		[-cvss-over=7]
+		[-ignore-unscored-cves]
 		[-report-slack]
 		[-report-mail]
 		[-http-proxy=http://192.168.0.1:8080]
@@ -108,6 +112,12 @@ func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 		"cvss-over",
 		0,
 		"-cvss-over=6.5 means reporting CVSS Score 6.5 and over (default: 0 (means report all))")
+
+	f.BoolVar(
+		&p.ignoreUnscoredCves,
+		"ignore-unscored-cves",
+		false,
+		"Don't report the unscored CVEs")
 
 	f.StringVar(
 		&p.httpProxy,
@@ -216,6 +226,7 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	c.Conf.DBPath = p.dbpath
 	c.Conf.CveDictionaryURL = p.cveDictionaryURL
 	c.Conf.CvssScoreOver = p.cvssScoreOver
+	c.Conf.IgnoreUnscoredCves = p.ignoreUnscoredCves
 	c.Conf.HTTPProxy = p.httpProxy
 	c.Conf.UseYumPluginSecurity = p.useYumPluginSecurity
 	c.Conf.UseUnattendedUpgrades = p.useUnattendedUpgrades

--- a/config/config.go
+++ b/config/config.go
@@ -41,9 +41,11 @@ type Config struct {
 
 	CveDictionaryURL string `valid:"url"`
 
-	CvssScoreOver float64
-	HTTPProxy     string `valid:"url"`
-	DBPath        string
+	CvssScoreOver      float64
+	IgnoreUnscoredCves bool
+
+	HTTPProxy string `valid:"url"`
+	DBPath    string
 	//  CpeNames      []string
 	//  SummaryMode          bool
 	UseYumPluginSecurity  bool

--- a/models/models.go
+++ b/models/models.go
@@ -150,10 +150,13 @@ func (r ScanResult) CveSummary() string {
 			unknown++
 		}
 	}
+
+	if config.Conf.IgnoreUnscoredCves {
+		return fmt.Sprintf("Total: %d (High:%d Middle:%d Low:%d)",
+			high+middle+low, high, middle, low)
+	}
 	return fmt.Sprintf("Total: %d (High:%d Middle:%d Low:%d ?:%d)",
-		high+middle+low+unknown,
-		high, middle, low, unknown,
-	)
+		high+middle+low+unknown, high, middle, low, unknown)
 }
 
 // NWLink has network link information.

--- a/report/slack.go
+++ b/report/slack.go
@@ -109,7 +109,12 @@ func msgText(r models.ScanResult) string {
 
 func toSlackAttachments(scanResult models.ScanResult) (attaches []*attachment) {
 
-	scanResult.KnownCves = append(scanResult.KnownCves, scanResult.UnknownCves...)
+	cves := scanResult.KnownCves
+	if !config.Conf.IgnoreUnscoredCves {
+		cves = append(cves, scanResult.UnknownCves...)
+	}
+	scanResult.KnownCves = cves
+
 	for _, cveInfo := range scanResult.KnownCves {
 		cveID := cveInfo.CveDetail.CveID
 

--- a/report/util.go
+++ b/report/util.go
@@ -48,7 +48,12 @@ No unsecure packages.
 	scoredReport, unscoredReport = toPlainTextDetails(scanResult, scanResult.Family)
 
 	scored := strings.Join(scoredReport, "\n\n")
-	unscored := strings.Join(unscoredReport, "\n\n")
+
+	unscored := ""
+	if !config.Conf.IgnoreUnscoredCves {
+		unscored = strings.Join(unscoredReport, "\n\n")
+	}
+
 	detail := fmt.Sprintf(`
 %s
 
@@ -67,7 +72,12 @@ func ToPlainTextSummary(r models.ScanResult) string {
 	stable := uitable.New()
 	stable.MaxColWidth = 84
 	stable.Wrap = true
-	cves := append(r.KnownCves, r.UnknownCves...)
+
+	cves := r.KnownCves
+	if !config.Conf.IgnoreUnscoredCves {
+		cves = append(cves, r.UnknownCves...)
+	}
+
 	for _, d := range cves {
 		var scols []string
 


### PR DESCRIPTION
If you don't want to display unscored CVEs. (displayed ? at cvss score), scan with -ignore-unscored-cves option.