### PR TITLE
Add JSONWriter, Fix CVE sort order of report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 coverage.out
 issues/
 *.txt
+*.json
 vendor/
 log/
 .gitmodules

--- a/README.md
+++ b/README.md
@@ -480,8 +480,9 @@ scan:
                 [-cve-dictionary-url=http://127.0.0.1:1323]
                 [-cvss-over=7]
                 [-ignore-unscored-cves]
-                [-report-slack]
+                [-report-json]
                 [-report-mail]
+                [-report-slack]
                 [-http-proxy=http://192.168.0.1:8080]
                 [-ask-sudo-password]
                 [-ask-key-password]
@@ -509,10 +510,12 @@ scan:
         Don't report the unscored CVEs
   -lang string
         [en|ja] (default "en")
+  -report-json
+        Write report to JSON files ($PWD/results/current)
   -report-mail
-        Email report
+        Send report via Email
   -report-slack
-        Slack report
+        Send report via Slack
   -use-unattended-upgrades
         [Deprecated] For Ubuntu. Scan by unattended-upgrades or not (use apt-get upgrade --dry-run by default)
   -use-yum-plugin-security
@@ -520,20 +523,24 @@ scan:
 
 ```
 
-## ask-key-password option 
+## -ask-key-password option 
 
 | SSH key password |  -ask-key-password | |
 |:-----------------|:-------------------|:----|
 | empty password   |                 -  | |
 | with password    |           required | or use ssh-agent |
 
-## ask-sudo-password option
+## -ask-sudo-password option
 
 | sudo password on target servers | -ask-sudo-password | |
 |:-----------------|:-------|:------|
 | NOPASSWORD       | - | defined as NOPASSWORD in /etc/sudoers on target servers |
 | with password    | required | . |
 
+## -report-json option
+
+At the end of the scan, scan results will be available in JSON format in the $PWD/result/current/ directory.  
+all.json includes the scan results of all servres and servername.json includes the scan result of the server.
 
 ## example
 
@@ -562,6 +569,8 @@ With this sample command, it will ..
 - Sudo with no password (without -ask-sudo-password option)
 - Scan only 2 servers (server1, server2)
 - Print scan result to terminal
+
+
 
 ----
 

--- a/models/models.go
+++ b/models/models.go
@@ -72,8 +72,8 @@ func (s ScanResults) FilterByCvssOver() (filtered ScanResults) {
 
 // ScanResult has the result of scanned CVE information.
 type ScanResult struct {
-	gorm.Model
-	ScanHistoryID uint
+	gorm.Model    `json:"-"`
+	ScanHistoryID uint `json:"-"`
 
 	ServerName string // TOML Section key
 	//  Hostname    string
@@ -161,8 +161,8 @@ func (r ScanResult) CveSummary() string {
 
 // NWLink has network link information.
 type NWLink struct {
-	gorm.Model
-	ScanResultID uint
+	gorm.Model   `json:"-"`
+	ScanResultID uint `json:"-"`
 
 	IPAddress string
 	Netmask   string
@@ -183,13 +183,16 @@ func (c CveInfos) Swap(i, j int) {
 
 func (c CveInfos) Less(i, j int) bool {
 	lang := config.Conf.Lang
+	if c[i].CveDetail.CvssScore(lang) == c[j].CveDetail.CvssScore(lang) {
+		return c[i].CveDetail.CveID < c[j].CveDetail.CveID
+	}
 	return c[i].CveDetail.CvssScore(lang) > c[j].CveDetail.CvssScore(lang)
 }
 
 // CveInfo has Cve Information.
 type CveInfo struct {
-	gorm.Model
-	ScanResultID uint
+	gorm.Model   `json:"-"`
+	ScanResultID uint `json:"-"`
 
 	CveDetail        cve.CveDetail
 	Packages         []PackageInfo
@@ -199,8 +202,8 @@ type CveInfo struct {
 
 // CpeName has CPE name
 type CpeName struct {
-	gorm.Model
-	CveInfoID uint
+	gorm.Model `json:"-"`
+	CveInfoID  uint `json:"-"`
 
 	Name string
 }
@@ -265,8 +268,8 @@ func (ps PackageInfoList) FindByName(name string) (result PackageInfo, found boo
 
 // PackageInfo has installed packages.
 type PackageInfo struct {
-	gorm.Model
-	CveInfoID uint
+	gorm.Model `json:"-"`
+	CveInfoID  uint `json:"-"`
 
 	Name    string
 	Version string
@@ -302,8 +305,8 @@ func (p PackageInfo) ToStringNewVersion() string {
 
 // DistroAdvisory has Amazon Linux AMI Security Advisory information.
 type DistroAdvisory struct {
-	gorm.Model
-	CveInfoID uint
+	gorm.Model `json:"-"`
+	CveInfoID  uint `json:"-"`
 
 	AdvisoryID string
 	Severity   string
@@ -313,8 +316,8 @@ type DistroAdvisory struct {
 
 // Container has Container information
 type Container struct {
-	gorm.Model
-	ScanResultID uint
+	gorm.Model   `json:"-"`
+	ScanResultID uint `json:"-"`
 
 	ContainerID string
 	Name        string

--- a/report/slack.go
+++ b/report/slack.go
@@ -113,9 +113,8 @@ func toSlackAttachments(scanResult models.ScanResult) (attaches []*attachment) {
 	if !config.Conf.IgnoreUnscoredCves {
 		cves = append(cves, scanResult.UnknownCves...)
 	}
-	scanResult.KnownCves = cves
 
-	for _, cveInfo := range scanResult.KnownCves {
+	for _, cveInfo := range cves {
 		cveID := cveInfo.CveDetail.CveID
 
 		curentPackages := []string{}
@@ -176,8 +175,7 @@ func attachmentText(cveInfo models.CveInfo, osFamily string) string {
 
 	switch {
 	case config.Conf.Lang == "ja" &&
-		cveInfo.CveDetail.Jvn.ID != 0 &&
-		0 < cveInfo.CveDetail.CvssScore("ja"):
+		0 < cveInfo.CveDetail.Jvn.CvssScore():
 
 		jvn := cveInfo.CveDetail.Jvn
 		return fmt.Sprintf("*%4.1f (%s)* <%s|%s>\n%s\n%s",

--- a/report/writer.go
+++ b/report/writer.go
@@ -37,3 +37,5 @@ const (
 type ResultWriter interface {
 	Write([]models.ScanResult) error
 }
+
+var resultDirPath string

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -20,7 +20,6 @@ package scan
 import (
 	"fmt"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -526,7 +525,6 @@ func (o *debian) scanPackageCveInfos(unsecurePacks []models.PackageInfo) (cvePac
 			//  CvssScore: cinfo.CvssScore(conf.Lang),
 		})
 	}
-	sort.Sort(CvePacksList(cvePacksList))
 	return
 }
 

--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -395,7 +395,6 @@ func (o *redhat) scanUnsecurePackagesUsingYumCheckUpdate() (CvePacksList, error)
 			//  CvssScore: cinfo.CvssScore(conf.Lang),
 		})
 	}
-	sort.Sort(CvePacksList(cvePacksList))
 	return cvePacksList, nil
 }
 

--- a/scan/serverapi.go
+++ b/scan/serverapi.go
@@ -98,7 +98,8 @@ func (s CvePacksList) Swap(i, j int) {
 
 // Less implement Sort Interface
 func (s CvePacksList) Less(i, j int) bool {
-	return s[i].CveDetail.CvssScore("en") > s[j].CveDetail.CvssScore("en")
+	return s[i].CveDetail.CvssScore(config.Conf.Lang) >
+		s[j].CveDetail.CvssScore(config.Conf.Lang)
 }
 
 func detectOS(c config.ServerInfo) (osType osTypeInterface) {


### PR DESCRIPTION
- Add -report-json option. 
Scan results will be available in JSON format in the $PWD/result/current/ directory. 
- Fix sort order of scan report (order by score, CVE-ID)