### PR TITLE
fix rhel check-update format and add *config.toml into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ issues/
 vendor/
 log/
 results/
+*config.toml

--- a/scan/redhat_test.go
+++ b/scan/redhat_test.go
@@ -648,7 +648,7 @@ python-libs.i686    2.6.6-64.el6   rhui-REGION-rhel-server-releases
 
 func TestParseYumCheckUpdateLinesAmazon(t *testing.T) {
 	r := newRedhat(config.ServerInfo{})
-	r.Family = "amzon"
+	r.Family = "amazon"
 	stdout := `Loaded plugins: priorities, update-motd, upgrade-helper
 34 package(s) needed for security, out of 71 available
 

--- a/scan/sshutil.go
+++ b/scan/sshutil.go
@@ -167,7 +167,7 @@ func sshExec(c conf.ServerInfo, cmd string, sudo bool, log ...*logrus.Entry) (re
 		ssh.TTY_OP_ISPEED: 14400, // input speed = 14.4kbaud
 		ssh.TTY_OP_OSPEED: 14400, // output speed = 14.4kbaud
 	}
-	if err = session.RequestPty("xterm", 400, 120, modes); err != nil {
+	if err = session.RequestPty("xterm", 400, 256, modes); err != nil {
 		logger.Errorf("Failed to request for pseudo terminal. err: %s, c: %s",
 			err,
 			pp.Sprintf("%v", c))


### PR DESCRIPTION
I fixed the following error of scaning RHEL servers.

```
 % go run main.go scan
INFO[0000] Start scanning
INFO[0000] config: /Users/matsunosadayuki/go/plugins/src/github.com/future-architect/vuls/config.toml
INFO[0000] cve-dictionary: http://127.0.0.1:1323
[Jun  5 12:59:22]  INFO [localhost] Validating Config...
[Jun  5 12:59:22]  INFO [localhost] Detecting Server OS...
[Jun  5 12:59:26]  INFO [localhost] (1/1) Detected vuls-dev-rhel: rhel 6.5
[Jun  5 12:59:26]  INFO [localhost] Detecting Container OS...
[Jun  5 12:59:26]  INFO [localhost] Scanning vulnerabilities...
[Jun  5 12:59:26]  INFO [localhost] Check required packages for scanning...
[Jun  5 12:59:26]  INFO [localhost] Scanning vulnerable OS packages...
[Jun  5 13:00:36] ERROR [vuls-dev-rhel] Failed to scan vulnerable packages
[Jun  5 13:00:36] ERROR [localhost] Failed to scan. err: ec2-user@54.199.248.145:22: Failed to parse LANG=en_US.UTF-8 yum --color=never check-update. err: Unknown format: Red_Hat_Enterprise_Linux-Release_Notes-6-en-US.noarch
```

This error is caused by check-update format.
https://github.com/future-architect/vuls/blob/master/scan/redhat.go#L265
Specifically, vuls should check a few lines when the line field is not 3. 