### PR TITLE
[WIP]Support scanning with external ssh command

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,11 +427,17 @@ You can customize your configuration using this template.
     #]
     #containers = ["${running}"]
     ```
+
     You can overwrite the default value specified in default section.  
-    Vuls supports multiple SSH authentication methods.  
+
+    Vuls supports two types of SSH. One is native go implementation. The other is external SSH command. For details, see [-ssh-external option](https://github.com/future-architect/vuls#-ssh-external-option)
+    
+    Multiple SSH authentication methods are supported.  
     - SSH agent
     - SSH public key authentication (with password, empty password)
     - Password authentication
+
+
 
 ----
 
@@ -484,6 +490,7 @@ scan:
                 [-cve-dictionary-url=http://127.0.0.1:1323]
                 [-cvss-over=7]
                 [-ignore-unscored-cves]
+                [-ssh-external]
                 [-report-json]
                 [-report-mail]
                 [-report-s3]
@@ -538,12 +545,24 @@ scan:
         Send report via Slack
   -report-text
         Write report to text files ($PWD/results/current)
+  -ssh-external
+        Use external ssh command. Default: Use the Go native implementation
   -use-unattended-upgrades
         [Deprecated] For Ubuntu. Scan by unattended-upgrades or not (use apt-get upgrade --dry-run by default)
   -use-yum-plugin-security
         [Deprecated] For CentOS 5. Scan by yum-plugin-security or not (use yum check-update by default)
 
 ```
+
+## -ssh-external option
+
+Vuls supports different types of SSH.  
+
+By Defaut, using a native Go implementation from crypto/ssh.   
+This is useful in situations where you may not have access to traditional UNIX tools.
+
+To use external ssh command, specify this option.   
+This is useful If you want to use ProxyCommand or chiper algorithm of SSH that is not supported by native go implementation.  
 
 ## -ask-key-password option 
 
@@ -558,6 +577,7 @@ scan:
 |:-----------------|:-------|:------|
 | NOPASSWORD       | - | defined as NOPASSWORD in /etc/sudoers on target servers |
 | with password    | required | . |
+
 
 ## -report-json , -report-text option
 

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -67,6 +67,8 @@ type ScanCmd struct {
 	awsProfile  string
 	awsS3Bucket string
 	awsRegion   string
+
+	sshExternal bool
 }
 
 // Name return subcommand name
@@ -86,6 +88,7 @@ func (*ScanCmd) Usage() string {
 		[-cve-dictionary-url=http://127.0.0.1:1323]
 		[-cvss-over=7]
 		[-ignore-unscored-cves]
+		[-ssh-external]
 		[-report-json]
 		[-report-mail]
 		[-report-s3]
@@ -140,6 +143,12 @@ func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 		"ignore-unscored-cves",
 		false,
 		"Don't report the unscored CVEs")
+
+	f.BoolVar(
+		&p.sshExternal,
+		"ssh-external",
+		false,
+		"Use external ssh command. Default: Use the Go native implementation")
 
 	f.StringVar(
 		&p.httpProxy,
@@ -292,6 +301,7 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	c.Conf.CveDictionaryURL = p.cveDictionaryURL
 	c.Conf.CvssScoreOver = p.cvssScoreOver
 	c.Conf.IgnoreUnscoredCves = p.ignoreUnscoredCves
+	c.Conf.SSHExternal = p.sshExternal
 	c.Conf.HTTPProxy = p.httpProxy
 	c.Conf.UseYumPluginSecurity = p.useYumPluginSecurity
 	c.Conf.UseUnattendedUpgrades = p.useUnattendedUpgrades

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,8 @@ type Config struct {
 	CvssScoreOver      float64
 	IgnoreUnscoredCves bool
 
+	SSHExternal bool
+
 	HTTPProxy string `valid:"url"`
 	DBPath    string
 	CveDBPath string

--- a/scan/freebsd.go
+++ b/scan/freebsd.go
@@ -35,6 +35,7 @@ func detectFreebsd(c config.ServerInfo) (itsMe bool, bsd osTypeInterface) {
 			}
 		}
 	}
+	Log.Debugf("Not FreeBSD. Host: %s:%s", c.Host, c.Port)
 	return false, bsd
 }
 


### PR DESCRIPTION
## -ssh-external option

Vuls supports different types of SSH.  

By Defaut, using a native Go implementation from crypto/ssh.   
This is useful in situations where you may not have access to traditional UNIX tools.

To use external ssh command, specify this option.   
This is useful If you want to use ProxyCommand or chiper algorithm of SSH that is not supported by native go implementation.  