### PR TITLE
Remove vulndb file before pkg audit

### DIFF
--- a/scan/freebsd.go
+++ b/scan/freebsd.go
@@ -76,8 +76,16 @@ func (o *bsd) scanInstalledPackages() ([]models.PackageInfo, error) {
 }
 
 func (o *bsd) scanUnsecurePackages() (cvePacksList []CvePacksInfo, err error) {
-	cmd := util.PrependProxyEnv("pkg audit -F -f /tmp/vuln.db -r")
+	const vulndbPath = "/tmp/vuln.db"
+	cmd := "rm -f " + vulndbPath
 	r := o.ssh(cmd, noSudo)
+	if !r.isSuccess(0) {
+		return nil, fmt.Errorf("Failed to %s. status: %d, stdout:%s, Stderr: %s",
+			cmd, r.ExitStatus, r.Stdout, r.Stderr)
+	}
+
+	cmd = util.PrependProxyEnv("pkg audit -F -r -f " + vulndbPath)
+	r = o.ssh(cmd, noSudo)
 	if !r.isSuccess(0, 1) {
 		return nil, fmt.Errorf("Failed to %s. status: %d, stdout:%s, Stderr: %s",
 			cmd, r.ExitStatus, r.Stdout, r.Stderr)


### PR DESCRIPTION
An error occurred when the old vuln db file is remaining . 
```
[Jun 27 05:04:00] ERROR [localhost] Failed to scan. err: kanbe@192.168.11.11:22: Failed to pkg audit -F -f /tmp/vuln.dbFetching vuln.xml.bz2: 100%  605 KiB 206.5kB/s    00:03
pkg: pkg_audit_fetch(open out fd): Permission denied
, Stderr:
```

Remove the vuln db file before pkg audit -F.
