### PR TITLE
[WIP]Add optional key-values that will be outputted to JSON in config

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -336,6 +336,13 @@ subjectPrefix = "[vuls]"
 #port        = "22"
 #user        = "username"
 #keyPath     = "/home/username/.ssh/id_rsa"
+#cpeNames = [
+#  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
+#]
+#containers = ["${running}"]
+#optional = [
+#    ["key", "value"],
+#]
 
 [servers]
 
@@ -348,6 +355,9 @@ host         = "172.31.4.82"
 #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
 #]
 #containers = ["${running}"]
+#optional = [
+#    ["key", "value"],
+#]
 ```
 
 このテンプレート使ってVulsの設定フィアルを作ってもよい。
@@ -414,6 +424,9 @@ host         = "172.31.4.82"
     #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
     #]
     #containers = ["${running}"]
+    #optional = [
+    #    ["key", "value"],
+    #]
     ```
     下記serversセクションで値が指定されなかった場合のデフォルト値
 
@@ -430,13 +443,25 @@ host         = "172.31.4.82"
     #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
     #]
     #containers = ["${running}"]
+    #optional = [
+    #    ["key", "value"],
+    #]
     ```
 
     serversセクションの値は、defaultセクションの値よりも優先される。
     defaultセクションの値を使いたい場合は `#` でコメントアウトする。
 
+    - host: IP address or hostname of target server
+    - port: SSH Port number
+    - user: SSH username
+    - keyPath: SSH private key path
+    - cpeNames: see [Usage: Scan vulnerability of non-OS package](https://github.com/future-architect/vuls/blob/master/README.ja.md#usage-scan-vulnerability-of-non-os-package)
+    - containers: see [Usage: Scan Docker containers](https://github.com/future-architect/vuls/blob/master/README.ja.md#usage-scan-docker-containers)
+    - optional: JSONレポートに含めたい追加情報
+
+
     Vulsは各サーバにSSHで接続するが、Goのネイティブ実装と、OSコマンドの２種類のSSH接続方法をサポートしている。
-    詳細は [-ssh-external option](https://github.com/future-architect/vuls#-ssh-external-option) を参照。
+    詳細は [-ssh-external option](https://github.com/future-architect/vuls/blob/master/README.ja.md#-ssh-external-option) を参照。
     
     また、以下のSSH認証をサポートしている。
     - SSH agent
@@ -688,6 +713,46 @@ $ vuls scan \
       -cve-dictionary-dbpath=$PWD/cve.sqlite3 \ 
       -report-azure-blob \
       -azure-container=vuls
+```
+
+## Example: Add optional key-value pairs to JSON
+
+追加情報をJSONに含めることができる。  
+デフォルトセクションのkey-valueはserversセクションのもので上書きされる。  
+使い方の例として、AzureリソースグループやVM名を指定しておくことで、結果のJSONをスクリプトでパースしてAzure VMの操作をする、などが可能。
+
+- config.toml
+```toml
+[default]
+optional = [
+	["key1", "default_value"],
+	["key3", "val3"],
+]
+
+[servers.bsd]
+host     = "192.168.11.11"
+user     = "kanbe"
+optional = [
+	["key1", "val1"],
+	["key2", "val2"],
+]
+```
+
+- bsd.json
+```json
+[
+  {
+    "ServerName": "bsd",
+    "Family": "FreeBSD",
+    "Release": "10.3-RELEASE",
+    .... snip ...
+    "Optional": [
+      [  "key1", "val1" ],
+      [  "key2", "val2" ],
+      [  "key3", "val3" ]
+    ]
+  }
+]
 ```
 
 ----

--- a/README.md
+++ b/README.md
@@ -351,6 +351,13 @@ subjectPrefix = "[vuls]"
 #port        = "22"
 #user        = "username"
 #keyPath     = "/home/username/.ssh/id_rsa"
+#cpeNames = [
+#  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
+#]
+#containers = ["${running}"]
+#optional = [
+#    ["key", "value"],
+#]
 
 [servers]
 
@@ -363,6 +370,9 @@ host         = "172.31.4.82"
 #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
 #]
 #containers = ["${running}"]
+#optional = [
+#    ["key", "value"],
+#]
 ```
 
 You can customize your configuration using this template.
@@ -432,6 +442,9 @@ You can customize your configuration using this template.
     #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
     #]
     #containers = ["${running}"]
+    #optional = [
+    #    ["key", "value"],
+    #]
     ```
     Items of the default section will be used if not specified.
 
@@ -448,9 +461,20 @@ You can customize your configuration using this template.
     #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
     #]
     #containers = ["${running}"]
+    #optional = [
+    #    ["key", "value"],
+    #]
     ```
 
     You can overwrite the default value specified in default section.  
+
+    - host: IP address or hostname of target server
+    - port: SSH Port number
+    - user: SSH username
+    - keyPath: SSH private key path
+    - cpeNames: see [Usage: Scan vulnerability of non-OS package](https://github.com/future-architect/vuls#usage-scan-vulnerability-of-non-os-package)
+    - containers: see [Usage: Scan Docker containers](https://github.com/future-architect/vuls#usage-scan-docker-containers)
+    - optional: Add additional information to JSON report.
 
     Vuls supports two types of SSH. One is native go implementation. The other is external SSH command. For details, see [-ssh-external option](https://github.com/future-architect/vuls#-ssh-external-option)
     
@@ -458,6 +482,8 @@ You can customize your configuration using this template.
     - SSH agent
     - SSH public key authentication (with password, empty password)
     - Password authentication
+
+    
 
 
 
@@ -551,7 +577,7 @@ scan:
         Azure storage container name
   -azure-key string
         Azure account key to use. AZURE_STORAGE_ACCESS_KEY environment variable is used if not specified
-   -config string
+  -config string
         /path/to/toml (default "$PWD/config.toml")
   -cve-dictionary-dbpath string
         /path/to/sqlite3 (For get cve detail from cve.sqlite3)        
@@ -698,6 +724,45 @@ $ vuls scan \
       -azure-container=vuls
 ```
 
+## Example: Add optional key-value pairs to JSON
+
+Optional key-value can be outputted to JSON.  
+The key-value in the default section will be overwritten by servers section's key-value.  
+For instance, you can use this field for Azure ResourceGroup name, Azure VM Name and so on.
+
+- config.toml
+```toml
+[default]
+optional = [
+	["key1", "default_value"],
+	["key3", "val3"],
+]
+
+[servers.bsd]
+host     = "192.168.11.11"
+user     = "kanbe"
+optional = [
+	["key1", "val1"],
+	["key2", "val2"],
+]
+```
+
+- bsd.json
+```json
+[
+  {
+    "ServerName": "bsd",
+    "Family": "FreeBSD",
+    "Release": "10.3-RELEASE",
+    .... snip ...
+    "Optional": [
+      [  "key1", "val1" ],
+      [  "key2", "val2" ],
+      [  "key3", "val3" ]
+    ]
+  }
+]
+```
 
 ----
 

--- a/commands/discover.go
+++ b/commands/discover.go
@@ -116,6 +116,9 @@ subjectPrefix = "[vuls]"
 #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
 #]
 #containers = ["${running}"]
+#optional = [
+#    ["key", "value"],
+#]
 
 [servers]
 {{- $names:=  .Names}}
@@ -129,6 +132,9 @@ host         = "{{$ip}}"
 #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
 #]
 #containers = ["${running}"]
+#optional = [
+#    ["key", "value"],
+#]
 {{end}}
 
 `

--- a/config/config.go
+++ b/config/config.go
@@ -227,6 +227,9 @@ type ServerInfo struct {
 	// Container Names or IDs
 	Containers []string
 
+	// Optional key-value set that will be outputted to JSON
+	Optional [][]interface{}
+
 	// used internal
 	LogMsgAnsiColor string // DebugLog Color
 	SudoOpt         SudoOption

--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -118,6 +118,20 @@ func (c TOMLLoader) Load(pathToToml, keyPass, sudoPass string) (err error) {
 			s.Containers = d.Containers
 		}
 
+		s.Optional = v.Optional
+		for _, dkv := range d.Optional {
+			found := false
+			for _, kv := range s.Optional {
+				if dkv[0] == kv[0] {
+					found = true
+					break
+				}
+			}
+			if !found {
+				s.Optional = append(s.Optional, dkv)
+			}
+		}
+
 		s.LogMsgAnsiColor = Colors[i%len(Colors)]
 		i++
 

--- a/models/models.go
+++ b/models/models.go
@@ -88,6 +88,8 @@ type ScanResult struct {
 	//  NWLinks     []NWLink
 	KnownCves   []CveInfo
 	UnknownCves []CveInfo
+
+	Optional [][]interface{} `gorm:"-"`
 }
 
 // ServerInfo returns server name one line

--- a/scan/base.go
+++ b/scan/base.go
@@ -245,6 +245,7 @@ func (l *base) convertToModel() (models.ScanResult, error) {
 		Platform:    l.Platform,
 		KnownCves:   scoredCves,
 		UnknownCves: unscoredCves,
+		Optional:    l.ServerInfo.Optional,
 	}, nil
 }
 

--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -180,8 +180,8 @@ func (o *redhat) checkRequiredPackagesInstalled() error {
 	if config.Conf.UseYumPluginSecurity {
 		// check if yum-plugin-security is installed.
 		// Amazon Linux, REHL can execute 'yum updateinfo --security updates' without yum-plugin-security
-		cmd := "rpm -q yum-plugin-security"
 		if o.Family == "centos" {
+			cmd := "rpm -q yum-plugin-security"
 			if r := o.ssh(cmd, noSudo); !r.isSuccess() {
 				msg := "yum-plugin-security is not installed"
 				o.log.Errorf(msg)


### PR DESCRIPTION
Optional key-value will be outputted to JSON.
The key-value in the default section will be overwritten by servers section's key-value.
For instance, you can use this option for Azure ResourceGroup name,  Azure VM Name and so on

- config.toml
```toml
[default]
optional = [
	["key1", "default_value"],
	["key3", "val3"],
]

[servers.bsd]
host     = "192.168.11.11"
user     = "kanbe"
optional = [
	["key1", "val1"],
	["key2", "val2"],
]
```

- all.json
```json
[
  {
    "ServerName": "bsd",
    "Family": "FreeBSD",
    "Release": "10.3-RELEASE",
    .... snip ...
    "Optional": [
      [  "key1", "val1" ],
      [  "key2", "val2" ],
      [  "key3", "val3" ]
    ]
  }
]
```

- [x] FIx Source

- [ ] FIx README

