### PR TITLE
Fix scan command help

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -246,7 +246,7 @@ see https://github.com/future-architect/vuls/tree/master/setup/docker
 
 ![Vuls-Architecture](img/vuls-architecture.png)
 
-## [go-cve-dictinary](https://github.com/kotakanbe/go-cve-dictionary)  
+## [go-cve-dictionary](https://github.com/kotakanbe/go-cve-dictionary)  
 - NVDとJVN(日本語)から脆弱性データベースを取得し、SQLite3に格納する。
 
 ## Vuls

--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ $ ./vuls history | peco | ./vuls tui
 
 [![asciicast](https://asciinema.org/a/emi7y7docxr60bq080z10t7v8.png)](https://asciinema.org/a/emi7y7docxr60bq080z10t7v8)
 
-# Usage: go-cve-dictonary on different server 
+# Usage: go-cve-dictionary on different server 
 
 Run go-cve-dictionary as server mode before scanning on 192.168.10.1
 ```

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -81,6 +81,7 @@ func (*ScanCmd) Synopsis() string { return "Scan vulnerabilities" }
 func (*ScanCmd) Usage() string {
 	return `scan:
 	scan
+		[SERVER]...
 		[-lang=en|ja]
 		[-config=/path/to/config.toml]
 		[-dbpath=/path/to/vuls.sqlite3]


### PR DESCRIPTION
This change adds to help to specify server option on `vuls scan` command.

In passing this change fix trivial typo too.