### PR TITLE
Fix README wrong links

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -867,7 +867,7 @@ slack, emailは日本語対応済み TUIは日本語表示未対応
 # Deploy With Glide
 
 If an error occurred while go get, try deploying with glide.  
-- Install [Glide](https://github.com/bumptech/glide)
+- Install [Glide](https://github.com/Masterminds/glide)
 - Deploy go-cve-dictionary
 ```
 $ go get -d github.com/kotakanbe/go-cve-dictionary

--- a/README.md
+++ b/README.md
@@ -808,7 +808,7 @@ $ go-cve-dictionary fetchnvd -last2y
 # Deploy With Glide
 
 If an error occurred while go get, try deploying with glide.  
-- Install [Glide](https://github.com/bumptech/glide)
+- Install [Glide](https://github.com/Masterminds/glide)
 - Deploy go-cve-dictionary
 ```
 $ go get -d github.com/kotakanbe/go-cve-dictionary


### PR DESCRIPTION
Fix wrong link in README 

```
- github.com/bumptech/glide
+ github.com/Masterminds/glide
```