### PR TITLE
Fix no tty error while executing with -external-ssh option

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -669,7 +669,11 @@ Vulsは２種類のSSH接続方法をサポートしている。
 これは、SSHコマンドがインストールされていない環境でも動作する（Windowsなど）  
 
 外部SSHコマンドを使ってスキャンするためには、`-ssh-external`を指定する。
-SSH Configが使えるので、ProxyCommandを使った多段SSHなどが可能。
+SSH Configが使えるので、ProxyCommandを使った多段SSHなどが可能。  
+CentOSでは、スキャン対象サーバの/etc/sudoersに以下を追加する必要がある(user: vuls)
+```
+Defaults:vuls !requiretty
+```
 
 ## -ask-key-password option 
 

--- a/README.md
+++ b/README.md
@@ -669,6 +669,11 @@ This is useful in situations where you may not have access to traditional UNIX t
 
 To use external ssh command, specify this option.   
 This is useful If you want to use ProxyCommand or chiper algorithm of SSH that is not supported by native go implementation.  
+Don't forget to add below line to /etc/sudoers on the target servers. (username: vuls)
+```
+Defaults:vuls !requiretty
+```
+
 
 ## -ask-key-password option 
 


### PR DESCRIPTION
- Fix no tty error while scanning with -external-ssh
- High speed scan in -ssh-external mode (see. #138 )