### PR TITLE
Supports yum --enablerepo option (supports only base,updates for now)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -252,6 +252,9 @@ type ServerInfo struct {
 	// Optional key-value set that will be outputted to JSON
 	Optional [][]interface{}
 
+	// For CentOS, RHEL, Amazon
+	Enablerepo string
+
 	// used internal
 	LogMsgAnsiColor string // DebugLog Color
 	Container       Container

--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -20,6 +20,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	log "github.com/Sirupsen/logrus"
@@ -153,6 +154,23 @@ func (c TOMLLoader) Load(pathToToml, keyPass string) error {
 			}
 			if !found {
 				s.Optional = append(s.Optional, dkv)
+			}
+		}
+
+		s.Enablerepo = v.Enablerepo
+		if len(s.Enablerepo) == 0 {
+			s.Enablerepo = d.Enablerepo
+		}
+		if len(s.Enablerepo) != 0 {
+			for _, repo := range strings.Split(s.Enablerepo, ",") {
+				switch repo {
+				case "base", "updates":
+					// nop
+				default:
+					return fmt.Errorf(
+						"For now, enablerepo have to be base or updates: %s, servername: %s",
+						s.Enablerepo, name)
+				}
 			}
 		}
 

--- a/models/models.go
+++ b/models/models.go
@@ -282,12 +282,12 @@ type PackageInfo struct {
 	gorm.Model `json:"-" xml:"-"`
 	CveInfoID  uint `json:"-" xml:"-"`
 
-	Name    string
-	Version string
-	Release string
-
+	Name       string
+	Version    string
+	Release    string
 	NewVersion string
 	NewRelease string
+	Repository string
 }
 
 // ToStringCurrentVersion returns package name-version-release

--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -165,11 +165,9 @@ func (o *redhat) checkRequiredPackagesInstalled() error {
 			return fmt.Errorf(msg)
 		}
 
-		var packName = ""
+		var packName = "yum-plugin-changelog"
 		if majorVersion < 6 {
 			packName = "yum-changelog"
-		} else {
-			packName = "yum-plugin-changelog"
 		}
 
 		cmd := "rpm -q " + packName
@@ -250,7 +248,13 @@ func (o *redhat) scanUnsecurePackages() ([]CvePacksInfo, error) {
 
 // For CentOS
 func (o *redhat) scanUnsecurePackagesUsingYumCheckUpdate() (CvePacksList, error) {
-	cmd := "LANGUAGE=en_US.UTF-8 yum --color=never check-update"
+	cmd := "LANGUAGE=en_US.UTF-8 yum --color=never %s check-update"
+	if o.getServerInfo().Enablerepo != "" {
+		cmd = fmt.Sprintf(cmd, "--enablerepo="+o.getServerInfo().Enablerepo)
+	} else {
+		cmd = fmt.Sprintf(cmd, "")
+	}
+
 	r := o.ssh(util.PrependProxyEnv(cmd), sudo)
 	if !r.isSuccess(0, 100) {
 		//returns an exit code of 100 if there are available updates.
@@ -398,6 +402,7 @@ func (o *redhat) parseYumCheckUpdateLines(stdout string) (results models.Package
 			}
 			installed.NewVersion = candidate.NewVersion
 			installed.NewRelease = candidate.NewRelease
+			installed.Repository = candidate.Repository
 			results = append(results, installed)
 		}
 	}
@@ -417,16 +422,19 @@ func (o *redhat) parseYumCheckUpdateLine(line string) (models.PackageInfo, error
 		packName = strings.Join(strings.Split(fields[0], ".")[0:(len(splitted)-1)], ".")
 	}
 
-	fields = strings.Split(fields[1], "-")
-	if len(fields) != 2 {
+	verfields := strings.Split(fields[1], "-")
+	if len(verfields) != 2 {
 		return models.PackageInfo{}, fmt.Errorf("Unknown format: %s", line)
 	}
-	version := o.regexpReplace(fields[0], `^[0-9]+:`, "")
-	release := fields[1]
+	version := o.regexpReplace(verfields[0], `^[0-9]+:`, "")
+	release := verfields[1]
+	repos := strings.Join(fields[2:len(fields)], " ")
+
 	return models.PackageInfo{
 		Name:       packName,
 		NewVersion: version,
 		NewRelease: release,
+		Repository: repos,
 	}, nil
 }
 
@@ -545,14 +553,15 @@ func (o *redhat) getAllChangelog(packInfoList models.PackageInfoList) (stdout st
 		command += util.ProxyEnv()
 	}
 
-	// yum update --changelog doesn't have --color option.
-	if config.Conf.SkipBroken {
-		command += fmt.Sprintf(
-			" LANGUAGE=en_US.UTF-8 yum --skip-broken update --changelog %s", packageNames)
-	} else {
-		command += fmt.Sprintf(
-			" LANGUAGE=en_US.UTF-8 yum update --changelog %s", packageNames)
+	yumopts := ""
+	if o.getServerInfo().Enablerepo != "" {
+		yumopts = " --enablerepo=" + o.getServerInfo().Enablerepo
 	}
+	if config.Conf.SkipBroken {
+		yumopts += " --skip-broken"
+	}
+	// yum update --changelog doesn't have --color option.
+	command += fmt.Sprintf(" LANGUAGE=en_US.UTF-8 yum %s --changelog update ", yumopts) + packageNames
 
 	r := o.ssh(command, sudo)
 	if !r.isSuccess(0, 1) {

--- a/scan/redhat_test.go
+++ b/scan/redhat_test.go
@@ -664,6 +664,7 @@ pytalloc.x86_64                 2.0.7-2.el6                      @CentOS 6.5/6.5
 					Release:    "4.el6",
 					NewVersion: "2.3.7",
 					NewRelease: "5.el6",
+					Repository: "base",
 				},
 				{
 					Name:       "bash",
@@ -671,6 +672,7 @@ pytalloc.x86_64                 2.0.7-2.el6                      @CentOS 6.5/6.5
 					Release:    "33",
 					NewVersion: "4.1.2",
 					NewRelease: "33.el6_7.1",
+					Repository: "updates",
 				},
 				{
 					Name:       "python-libs",
@@ -678,6 +680,7 @@ pytalloc.x86_64                 2.0.7-2.el6                      @CentOS 6.5/6.5
 					Release:    "1.1-0",
 					NewVersion: "2.6.6",
 					NewRelease: "64.el6",
+					Repository: "rhui-REGION-rhel-server-releases",
 				},
 				{
 					Name:       "python-ordereddict",
@@ -685,6 +688,7 @@ pytalloc.x86_64                 2.0.7-2.el6                      @CentOS 6.5/6.5
 					Release:    "1",
 					NewVersion: "1.1",
 					NewRelease: "3.el6ev",
+					Repository: "installed",
 				},
 				{
 					Name:       "bind-utils",
@@ -692,6 +696,7 @@ pytalloc.x86_64                 2.0.7-2.el6                      @CentOS 6.5/6.5
 					Release:    "1",
 					NewVersion: "9.3.6",
 					NewRelease: "25.P1.el5_11.8",
+					Repository: "updates",
 				},
 				{
 					Name:       "pytalloc",
@@ -699,6 +704,7 @@ pytalloc.x86_64                 2.0.7-2.el6                      @CentOS 6.5/6.5
 					Release:    "0",
 					NewVersion: "2.0.7",
 					NewRelease: "2.el6",
+					Repository: "@CentOS 6.5/6.5",
 				},
 			},
 		},
@@ -760,6 +766,7 @@ if-not-architecture        100-200                         amzn-main
 					Release:    "0.33.rc1.45.amzn1",
 					NewVersion: "9.8.2",
 					NewRelease: "0.37.rc1.45.amzn1",
+					Repository: "amzn-main",
 				},
 				{
 					Name:       "java-1.7.0-openjdk",
@@ -767,6 +774,7 @@ if-not-architecture        100-200                         amzn-main
 					Release:    "2.6.4.0.0.amzn1",
 					NewVersion: "1.7.0.95",
 					NewRelease: "2.6.4.0.65.amzn1",
+					Repository: "amzn-main",
 				},
 				{
 					Name:       "if-not-architecture",
@@ -774,6 +782,7 @@ if-not-architecture        100-200                         amzn-main
 					Release:    "20",
 					NewVersion: "100",
 					NewRelease: "200",
+					Repository: "amzn-main",
 				},
 			},
 		},


### PR DESCRIPTION
If you define as below in config.toml.
```
[servers.cent6]
host     = "127.0.0.1"
port     = "20062"
user     = "vuls"
keyPath  = "/path/to/id_rsa"
enablerepo = "updates,base"
```

Vuls issues yum with --enablerepo option
- yum check-update
```
yum --color=never --enablerepo=updates,base check-update
```

- yum --changelog update
```
yum  --enablerepo=updates,base --changelog update wget
```
See #246

For now, base and updates repository are supported.
Because a change-log format of additional yum repository is different  for each repos...