### PR TITLE
Disable -ask-sudo-password for security reasons

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -112,6 +112,9 @@ $ cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
 $ chmod 600 ~/.ssh/authorized_keys
 ```
 
+VulsはSSHパスワード認証をサポートしていない。SSH公開鍵鍵認証を使う必要がある。
+また、パスワードありのSUDOもセキュリティ上の理由によりサポートしていないため、スキャン対象サーバに/etc/sudoersにNOPASSWDを設定して、パスワードなしでSUDO可能にする必要がある。
+
 ## Step3. Install requirements
 
 Vulsセットアップに必要な以下のソフトウェアをインストールする。
@@ -506,13 +509,13 @@ host         = "172.31.4.82"
     また、以下のSSH認証をサポートしている。
     - SSH agent
     - SSH public key authentication (with password, empty password)
-    - Password authentication
+    SSH Password認証はサポートしていない
 
 ----
 
 # Usage: Configtest 
 
-configtestサブコマンドは、config.tomlで定義されたサーバ/コンテナに対してSSH可能かどうかをチェックする。
+configtestサブコマンドは、config.tomlで定義されたサーバ/コンテナに対してSSH可能かどうかをチェックする。  
 
 ```
 $ vuls configtest --help
@@ -533,6 +536,18 @@ configtest:
   -ssh-external
         Use external ssh command. Default: Use the Go native implementation
 ```
+
+また、スキャン対象サーバに対してパスワードなしでSUDO可能な状態かもチェックする。  
+スキャン対象サーバ上の`/etc/sudoers`のサンプル
+- CentOS, Amazon Linux, RedHat Enterprise Linux
+```
+vuls ALL=(root) NOPASSWD: /usr/bin/yum
+```
+- Ubuntu, Debian
+```
+vuls ALL=(root) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt-cache
+```
+
 
 ----
 
@@ -555,14 +570,11 @@ Prepareサブコマンドは、Vuls内部で利用する以下のパッケージ
 $ vuls prepare -help
 prepare
                         [-config=/path/to/config.toml] [-debug]
-                        [-ask-sudo-password]
                         [-ask-key-password]
                         [SERVER]...
 
   -ask-key-password
         Ask ssh privatekey password before scanning
-  -ask-sudo-password
-        Ask sudo password of target servers before scanning
   -config string
         /path/to/toml (default "$PWD/config.toml")
   -debug
@@ -595,7 +607,6 @@ scan:
                 [-report-slack]
                 [-report-text]
                 [-http-proxy=http://192.168.0.1:8080]
-                [-ask-sudo-password]
                 [-ask-key-password]
                 [-debug]
                 [-debug-sql]
@@ -611,8 +622,6 @@ scan:
 
   -ask-key-password
         Ask ssh privatekey password before scanning
-  -ask-sudo-password
-        Ask sudo password of target servers before scanning
   -aws-profile string
         AWS Profile to use (default "default")
   -aws-region string
@@ -685,14 +694,6 @@ Defaults:vuls !requiretty
 | empty password   |                 -  | |
 | with password    |           required | or use ssh-agent |
 
-## -ask-sudo-password option
-
-| sudo password on target servers | -ask-sudo-password | |
-|:-----------------|:-------|:------|
-| NOPASSWORD       | - | defined as NOPASSWORD in /etc/sudoers on target servers |
-| with password    | required |  |
-
-
 ## -report-json , -report-text option
 
 結果をファイルに出力したい場合に指定する。出力先は、`$PWD/result/current/`    
@@ -705,12 +706,10 @@ $ vuls scan \
       -report-slack \ 
       -report-mail \
       -cvss-over=7 \
-      -ask-sudo-password \ 
       -ask-key-password \
       -cve-dictionary-dbpath=$PWD/cve.sqlite3
 ```
 この例では、
-- スキャン対象サーバのsudoパスワードを指定
 - SSH公開鍵認証（秘密鍵パスフレーズ）を指定
 - configに定義された全サーバをスキャン
 - レポートをslack, emailに送信
@@ -745,7 +744,6 @@ $ vuls scan \
 ```
 この例では、
 - SSH公開鍵認証（秘密鍵パスフレーズなし）
-- ノーパスワードでsudoが実行可能
 - configに定義された全サーバをスキャン
 - 結果をJSON形式でS3に格納する。
   - バケット名 ... vuls
@@ -767,7 +765,6 @@ $ vuls scan \
 ```
 この例では、
 - SSH公開鍵認証（秘密鍵パスフレーズなし）
-- ノーパスワードでsudoが実行可能
 - configに定義された全サーバをスキャン
 - 結果をJSON形式でAzure Blobに格納する。
   - コンテナ名 ... vuls

--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -98,7 +98,7 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 
 	c.Conf.Debug = p.debug
 
-	err = c.Load(p.configPath, keyPass, "")
+	err = c.Load(p.configPath, keyPass)
 	if err != nil {
 		logrus.Errorf("Error loading %s, %s", p.configPath, err)
 		return subcommands.ExitUsageError
@@ -152,5 +152,11 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 	Log.Info("Detecting Server/Contianer OS... ")
 	scan.InitServers(Log)
 
+	Log.Info("Checking sudo configuration... ")
+	if err := scan.CheckIfSudoNoPasswd(Log); err != nil {
+		Log.Errorf("Failed to sudo with nopassword via SSH. Define NOPASSWD in /etc/sudoers on target servers. err: %s", err)
+		return subcommands.ExitFailure
+	}
+	scan.PrintSSHableServerNames()
 	return subcommands.ExitSuccess
 }

--- a/commands/prepare.go
+++ b/commands/prepare.go
@@ -61,7 +61,6 @@ func (*PrepareCmd) Usage() string {
 	return `prepare:
 	prepare
 			[-config=/path/to/config.toml]
-			[-ask-sudo-password]
 			[-ask-key-password]
 			[-debug]
 
@@ -90,7 +89,7 @@ func (p *PrepareCmd) SetFlags(f *flag.FlagSet) {
 		&p.askSudoPassword,
 		"ask-sudo-password",
 		false,
-		"Ask sudo password of target servers before scanning",
+		"[Deprecated] THIS OPTION WAS REMOVED FOR SECURITY REASON. Define NOPASSWD in /etc/sudoers on tareget servers and use SSH key-based authentication",
 	)
 
 	f.BoolVar(
@@ -103,7 +102,7 @@ func (p *PrepareCmd) SetFlags(f *flag.FlagSet) {
 
 // Execute execute
 func (p *PrepareCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	var keyPass, sudoPass string
+	var keyPass string
 	var err error
 	if p.askKeyPassword {
 		prompt := "SSH key password: "
@@ -113,14 +112,11 @@ func (p *PrepareCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 		}
 	}
 	if p.askSudoPassword {
-		prompt := "sudo password: "
-		if sudoPass, err = getPasswd(prompt); err != nil {
-			logrus.Error(err)
-			return subcommands.ExitFailure
-		}
+		logrus.Errorf("[Deprecated] -ask-sudo-password WAS REMOVED FOR SECURITY REASONS. Define NOPASSWD in /etc/sudoers on tareget servers and use SSH key-based authentication")
+		return subcommands.ExitFailure
 	}
 
-	err = c.Load(p.configPath, keyPass, sudoPass)
+	err = c.Load(p.configPath, keyPass)
 	if err != nil {
 		logrus.Errorf("Error loading %s, %s", p.configPath, err)
 		return subcommands.ExitUsageError

--- a/config/config.go
+++ b/config/config.go
@@ -216,7 +216,6 @@ func (c *SlackConf) Validate() (errs []error) {
 type ServerInfo struct {
 	ServerName  string
 	User        string
-	Password    string
 	Host        string
 	Port        string
 	KeyPath     string
@@ -232,7 +231,6 @@ type ServerInfo struct {
 
 	// used internal
 	LogMsgAnsiColor string // DebugLog Color
-	SudoOpt         SudoOption
 	Container       Container
 	Family          string
 }
@@ -252,14 +250,4 @@ type Container struct {
 	ContainerID string
 	Name        string
 	Type        string
-}
-
-// SudoOption is flag of sudo option.
-type SudoOption struct {
-
-	// echo pass | sudo -S ls
-	ExecBySudo bool
-
-	// echo pass | sudo sh -C 'ls'
-	ExecBySudoSh bool
 }

--- a/config/loader.go
+++ b/config/loader.go
@@ -18,14 +18,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package config
 
 // Load loads configuration
-func Load(path, keyPass, sudoPass string) error {
+func Load(path, keyPass string) error {
 	var loader Loader
 	loader = TOMLLoader{}
-
-	return loader.Load(path, keyPass, sudoPass)
+	return loader.Load(path, keyPass)
 }
 
 // Loader is interface of concrete loader
 type Loader interface {
-	Load(string, string, string) error
+	Load(string, string) error
 }

--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -31,7 +31,7 @@ type TOMLLoader struct {
 }
 
 // Load load the configuraiton TOML file specified by path arg.
-func (c TOMLLoader) Load(pathToToml, keyPass, sudoPass string) (err error) {
+func (c TOMLLoader) Load(pathToToml, keyPass string) (err error) {
 	var conf Config
 	if _, err := toml.DecodeFile(pathToToml, &conf); err != nil {
 		log.Error("Load config failed", err)
@@ -49,15 +49,11 @@ func (c TOMLLoader) Load(pathToToml, keyPass, sudoPass string) (err error) {
 		d.KeyPassword = keyPass
 	}
 
-	if sudoPass != "" {
-		d.Password = sudoPass
-	}
-
 	i := 0
 	for name, v := range conf.Servers {
 
-		if 0 < len(v.KeyPassword) || 0 < len(v.Password) {
-			log.Warn("[Deprecated] password and keypassword in config file are unsecure. Remove them immediately for a security reason. They will be removed in a future release.")
+		if 0 < len(v.KeyPassword) {
+			log.Warn("[Deprecated] KEYPASSWORD IN CONFIG FILE ARE UNSECURE. REMOVE THEM IMMEDIATELY FOR A SECURITY REASONS. THEY WILL BE REMOVED IN A FUTURE RELEASE.")
 		}
 
 		s := ServerInfo{ServerName: name}
@@ -69,12 +65,6 @@ func (c TOMLLoader) Load(pathToToml, keyPass, sudoPass string) (err error) {
 			s.User = d.User
 		default:
 			return fmt.Errorf("%s is invalid. User is empty", name)
-		}
-
-		//  s.Password = sudoPass
-		s.Password = v.Password
-		if s.Password == "" {
-			s.Password = d.Password
 		}
 
 		s.Host = v.Host

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -45,11 +45,7 @@ func newDebian(c config.ServerInfo) *debian {
 // Ubuntu, Debian
 // https://github.com/serverspec/specinfra/blob/master/lib/specinfra/helper/detect_os/debian.rb
 func detectDebian(c config.ServerInfo) (itsMe bool, deb osTypeInterface, err error) {
-
 	deb = newDebian(c)
-
-	// set sudo option flag
-	c.SudoOpt = config.SudoOption{ExecBySudo: true}
 	deb.setServerInfo(c)
 
 	if r := sshExec(c, "ls /etc/debian_version", noSudo); !r.isSuccess() {
@@ -117,6 +113,16 @@ func detectDebian(c config.ServerInfo) (itsMe bool, deb osTypeInterface, err err
 
 func trim(str string) string {
 	return strings.TrimSpace(str)
+}
+
+func (o *debian) checkIfSudoNoPasswd() error {
+	r := o.ssh("apt-get -v", sudo)
+	if !r.isSuccess() {
+		o.log.Errorf("sudo error on %s", r)
+		return fmt.Errorf("Failed to sudo: %s", r)
+	}
+	o.log.Infof("sudo ... OK")
+	return nil
 }
 
 func (o *debian) install() error {

--- a/scan/freebsd.go
+++ b/scan/freebsd.go
@@ -39,6 +39,12 @@ func detectFreebsd(c config.ServerInfo) (itsMe bool, bsd osTypeInterface) {
 	return false, bsd
 }
 
+func (o *bsd) checkIfSudoNoPasswd() error {
+	// FreeBSD doesn't need root privilege
+	o.log.Infof("sudo ... OK")
+	return nil
+}
+
 func (o *bsd) install() error {
 	return nil
 }

--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -47,11 +47,7 @@ func newRedhat(c config.ServerInfo) *redhat {
 
 // https://github.com/serverspec/specinfra/blob/master/lib/specinfra/helper/detect_os/redhat.rb
 func detectRedhat(c config.ServerInfo) (itsMe bool, red osTypeInterface) {
-
 	red = newRedhat(c)
-
-	// set sudo option flag
-	c.SudoOpt = config.SudoOption{ExecBySudo: true}
 	red.setServerInfo(c)
 
 	if r := sshExec(c, "ls /etc/fedora-release", noSudo); r.isSuccess() {
@@ -100,6 +96,16 @@ func detectRedhat(c config.ServerInfo) (itsMe bool, red osTypeInterface) {
 
 	Log.Debugf("Not RedHat like Linux. servername: %s", c.ServerName)
 	return false, red
+}
+
+func (o *redhat) checkIfSudoNoPasswd() error {
+	r := o.ssh("yum --version", sudo)
+	if !r.isSuccess() {
+		o.log.Errorf("sudo error on %s", r)
+		return fmt.Errorf("Failed to sudo: %s", r)
+	}
+	o.log.Infof("sudo ... OK")
+	return nil
 }
 
 // CentOS 5 ... yum-plugin-security, yum-changelog


### PR DESCRIPTION
Disable -ask-sudo-password option for security reasons.
Vuls user have to be able to execute below commands via SSH without sudo password.
- CentOS, RHEL, Amazon Linux ... `/usr/bin/yum`
- Debian, Ubuntu ... `/usr/bin/apt-get, /usr/bin/apt-cache`

Example of /etc/sudoers on target servers
- CentOS, Amazon Linux, RedHat Enterprise Linux
```
vuls ALL=(root) NOPASSWD: /usr/bin/yum
```
- Ubuntu, Debian
```
vuls ALL=(root) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt-cache
```
