### PR TITLE
Fix apt command to scan correctly when system locale is not english

### DIFF
--- a/scan/debian.go
+++ b/scan/debian.go
@@ -313,7 +313,7 @@ func (o *debian) fillCandidateVersion(packs []models.PackageInfo) ([]models.Pack
 			select {
 			case pack := <-reqChan:
 				func(p models.PackageInfo) {
-					cmd := fmt.Sprintf("apt-cache policy %s", p.Name)
+					cmd := fmt.Sprintf("LANG=en_US.UTF-8 apt-cache policy %s", p.Name)
 					r := o.ssh(cmd, sudo)
 					if !r.isSuccess() {
 						errChan <- fmt.Errorf("Failed to SSH: %s.", r)
@@ -387,7 +387,7 @@ func (o *debian) GetUnsecurePackNamesUsingUnattendedUpgrades() (packNames []stri
 }
 
 func (o *debian) GetUpgradablePackNames() (packNames []string, err error) {
-	cmd := util.PrependProxyEnv("apt-get upgrade --dry-run")
+	cmd := util.PrependProxyEnv("LANG=en_US.UTF-8 apt-get upgrade --dry-run")
 	r := o.ssh(cmd, sudo)
 	if r.isSuccess(0, 1) {
 		return o.parseAptGetUpgrade(r.Stdout)


### PR DESCRIPTION
Add LANG=en_US.UTF-8 at the beginning of apt command.
Currently, on Ubuntu, no vulnerabilities are found when system locale is not English.