### PR TITLE
Fix bug: Vuls on Docker

### DIFF
--- a/setup/docker/dockerfile/Dockerfile
+++ b/setup/docker/dockerfile/Dockerfile
@@ -79,7 +79,7 @@ RUN chmod 755 ${VULS_ROOT}/scripts/*
 #Vulrepo Install
 RUN git clone https://github.com/usiusi360/vulsrepo /tmp/vulsrepo
 RUN mkdir /usr/share/nginx/html/vulsrepo/
-RUN cp -rp /tmp/vulsrepo/src/* /usr/share/nginx/html/vulsrepo
+RUN cp -rp /tmp/vulsrepo/dist/* /usr/share/nginx/html/vulsrepo
 RUN rm -rf /tmp/vulsrepo
 
 #Home


### PR DESCRIPTION
When I tried `docker-compose up -d`, but encoutered bug.

```
Step 25 : RUN cp -rp /tmp/vulsrepo/src/* /usr/share/nginx/html/vulsrepo
 ---> Running in 5e3c7fbc4e6b
cp: cannot stat '/tmp/vulsrepo/src/*': No such file or directory
ERROR: Service 'vuls' failed to 
```

This affected below PR https://github.com/usiusi360/vulsrepo/pull/20