### PR TITLE
Fix not working changelog cache on Container

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -241,6 +241,15 @@ type ServerInfo struct {
 	Distro          Distro
 }
 
+// GetServerName returns ServerName if this serverInfo is about host.
+// If this serverInfo is abount a container, returns containerID@ServerName
+func (s ServerInfo) GetServerName() string {
+	if len(s.Container.ContainerID) == 0 {
+		return s.ServerName
+	}
+	return fmt.Sprintf("%s@%s", s.Container.ContainerID, s.ServerName)
+}
+
 // Distro has distribution info
 type Distro struct {
 	Family  string

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -247,7 +247,7 @@ func (o *debian) scanUnsecurePackages(packs []models.PackageInfo) ([]CvePacksInf
 	}
 
 	current := cache.Meta{
-		Name:   o.getServerInfo().ServerName,
+		Name:   o.getServerInfo().GetServerName(),
 		Distro: o.getServerInfo().Distro,
 		Packs:  unsecurePacks,
 	}
@@ -377,7 +377,7 @@ func (o *debian) parseAptGetUpgrade(stdout string) (upgradableNames []string, er
 
 func (o *debian) scanPackageCveInfos(unsecurePacks []models.PackageInfo) (cvePacksList CvePacksList, err error) {
 	meta := cache.Meta{
-		Name:   o.getServerInfo().ServerName,
+		Name:   o.getServerInfo().GetServerName(),
 		Distro: o.getServerInfo().Distro,
 		Packs:  unsecurePacks,
 	}
@@ -520,7 +520,7 @@ func (o *debian) scanPackageCveIDs(pack models.PackageInfo) ([]string, error) {
 		return nil, nil
 
 	}
-	err := cache.DB.PutChangelog(o.getServerInfo().ServerName, pack.Name, r.Stdout)
+	err := cache.DB.PutChangelog(o.getServerInfo().GetServerName(), pack.Name, r.Stdout)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to put changelog into cache")
 	}

--- a/scan/serverapi.go
+++ b/scan/serverapi.go
@@ -251,7 +251,7 @@ func detectContainerOSes() (actives []osTypeInterface) {
 			defer func() {
 				if p := recover(); p != nil {
 					Log.Debugf("Panic: %s on %s",
-						p, s.getServerInfo().ServerName)
+						p, s.getServerInfo().GetServerName())
 				}
 			}()
 			osTypesChan <- detectContainerOSesOnServer(s)

--- a/scan/sshutil.go
+++ b/scan/sshutil.go
@@ -89,7 +89,7 @@ func parallelSSHExec(fn func(osTypeInterface) error, timeoutSec ...int) (errs []
 			defer func() {
 				if p := recover(); p != nil {
 					logrus.Debugf("Panic: %s on %s",
-						p, s.getServerInfo().ServerName)
+						p, s.getServerInfo().GetServerName())
 				}
 			}()
 			if err := fn(s); err != nil {
@@ -100,7 +100,7 @@ func parallelSSHExec(fn func(osTypeInterface) error, timeoutSec ...int) (errs []
 					err,
 				)
 			} else {
-				resChan <- s.getServerInfo().ServerName
+				resChan <- s.getServerInfo().GetServerName()
 			}
 		}(s)
 	}
@@ -129,7 +129,7 @@ func parallelSSHExec(fn func(osTypeInterface) error, timeoutSec ...int) (errs []
 	var timedoutSnames []string
 	if isTimedout {
 		for _, s := range servers {
-			name := s.getServerInfo().ServerName
+			name := s.getServerInfo().GetServerName()
 			found := false
 			for _, t := range snames {
 				if name == t {

--- a/util/logutil.go
+++ b/util/logutil.go
@@ -18,7 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package util
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -53,12 +52,7 @@ func NewCustomLogger(c config.ServerInfo) *logrus.Entry {
 
 	whereami := "localhost"
 	if 0 < len(c.ServerName) {
-		if 0 < len(c.Container.ContainerID) {
-			whereami = fmt.Sprintf(
-				"%s_%s", c.ServerName, c.Container.Name)
-		} else {
-			whereami = fmt.Sprintf("%s", c.ServerName)
-		}
+		whereami = c.GetServerName()
 	}
 
 	if _, err := os.Stat(logDir); err == nil {


### PR DESCRIPTION
Changelog cache was not working on Docker enviroment because the key was servername.
I fix the problem.
I changed the key of changelog cache from servername to containerID@servername.