### PR TITLE
Fixed bug with parsing update line on CentOS/RHEL

### DIFF
--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -407,7 +407,7 @@ func (o *redhat) parseYumCheckUpdateLines(stdout string) (results models.Package
 
 func (o *redhat) parseYumCheckUpdateLine(line string) (models.PackageInfo, error) {
 	fields := strings.Fields(line)
-	if len(fields) != 3 {
+	if len(fields) < 3 {
 		return models.PackageInfo{}, fmt.Errorf("Unknown format: %s", line)
 	}
 	splitted := strings.Split(fields[0], ".")

--- a/scan/redhat_test.go
+++ b/scan/redhat_test.go
@@ -616,6 +616,7 @@ Obsoleting Packages
 python-libs.i686    2.6.6-64.el6   rhui-REGION-rhel-server-releases
     python-ordereddict.noarch     1.1-3.el6ev    installed
 bind-utils.x86_64                       30:9.3.6-25.P1.el5_11.8          updates
+pytalloc.x86_64                 2.0.7-2.el6                      @CentOS 6.5/6.5
 `
 
 	r.Packages = []models.PackageInfo{
@@ -643,6 +644,11 @@ bind-utils.x86_64                       30:9.3.6-25.P1.el5_11.8          updates
 			Name:    "bind-utils",
 			Version: "1.0",
 			Release: "1",
+		},
+		{
+			Name:    "pytalloc",
+			Version: "2.0.1",
+			Release: "0",
 		},
 	}
 	var tests = []struct {
@@ -686,6 +692,13 @@ bind-utils.x86_64                       30:9.3.6-25.P1.el5_11.8          updates
 					Release:    "1",
 					NewVersion: "9.3.6",
 					NewRelease: "25.P1.el5_11.8",
+				},
+				{
+					Name:       "pytalloc",
+					Version:    "2.0.1",
+					Release:    "0",
+					NewVersion: "2.0.7",
+					NewRelease: "2.el6",
 				},
 			},
 		},


### PR DESCRIPTION
When package was installed from ISO or CD/DVD it can contain repository name with whitespaces. Example from one of our servers:
```bash
$ LANG=en_US.UTF-8 yum --color=never check-update -q | tr -s " " | grep pytalloc

pytalloc.x86_64 2.1.5-1.el6_7 base 
pytalloc.x86_64 2.1.5-1.el6_7 base 
 pytalloc.x86_64 2.0.7-2.el6 @CentOS 6.5/6.5
```

In this case vuls can't parse last line from example because in `parseYumCheckUpdateLine` number of fields is limited by 3.