### PR TITLE
Fix for #205 ubuntu scan fails

### DIFF
--- a/scan/debian.go
+++ b/scan/debian.go
@@ -344,7 +344,6 @@ func (o *debian) parseAptGetUpgrade(stdout string) (upgradableNames []string, er
 			if matche := startRe.MatchString(line); matche {
 				startLineFound = true
 			}
-
 			continue
 		}
 		result := stopRe.FindStringSubmatch(line)

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -340,7 +340,6 @@ func (o *debian) parseAptGetUpgrade(stdout string) (upgradableNames []string, er
 
 	lines := strings.Split(stdout, "\n")
 	for _, line := range lines {
-		o.log.Debugf("line == %s", line)
 		if !startLineFound {
 			if matche := startRe.MatchString(line); matche {
 				startLineFound = true


### PR DESCRIPTION
Fix for #205 

Just runs another regex that matches the older apt versions output. It works, but its not pretty might want to put something more elegant in. 

Cheers
Will
