### PR TITLE
Fix locale env var LANG to LANGUAGE

### DIFF
--- a/scan/debian.go
+++ b/scan/debian.go
@@ -301,7 +301,7 @@ func (o *debian) fillCandidateVersion(before models.PackageInfoList) (filled []m
 	for _, p := range before {
 		names = append(names, p.Name)
 	}
-	cmd := fmt.Sprintf("LANG=en_US.UTF-8 apt-cache policy %s", strings.Join(names, " "))
+	cmd := fmt.Sprintf("LANGUAGE=en_US.UTF-8 apt-cache policy %s", strings.Join(names, " "))
 	r := o.ssh(cmd, sudo)
 	if !r.isSuccess() {
 		return nil, fmt.Errorf("Failed to SSH: %s.", r)
@@ -323,7 +323,7 @@ func (o *debian) fillCandidateVersion(before models.PackageInfoList) (filled []m
 }
 
 func (o *debian) GetUpgradablePackNames() (packNames []string, err error) {
-	cmd := util.PrependProxyEnv("LANG=en_US.UTF-8 apt-get upgrade --dry-run")
+	cmd := util.PrependProxyEnv("LANGUAGE=en_US.UTF-8 apt-get upgrade --dry-run")
 	r := o.ssh(cmd, sudo)
 	if r.isSuccess(0, 1) {
 		return o.parseAptGetUpgrade(r.Stdout)

--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -251,7 +251,7 @@ func (o *redhat) scanUnsecurePackages() ([]CvePacksInfo, error) {
 
 // For CentOS
 func (o *redhat) scanUnsecurePackagesUsingYumCheckUpdate() (CvePacksList, error) {
-	cmd := "LANG=en_US.UTF-8 yum --color=never check-update"
+	cmd := "LANGUAGE=en_US.UTF-8 yum --color=never check-update"
 	r := o.ssh(util.PrependProxyEnv(cmd), sudo)
 	if !r.isSuccess(0, 100) {
 		//returns an exit code of 100 if there are available updates.
@@ -547,7 +547,7 @@ func (o *redhat) getAllChangelog(packInfoList models.PackageInfoList) (stdout st
 	}
 
 	// yum update --changelog doesn't have --color option.
-	command += fmt.Sprintf(" LANG=en_US.UTF-8 yum update --changelog %s", packageNames)
+	command += fmt.Sprintf(" LANGUAGE=en_US.UTF-8 yum update --changelog %s", packageNames)
 
 	r := o.ssh(command, sudo)
 	if !r.isSuccess(0, 1) {
@@ -589,7 +589,7 @@ func (o *redhat) scanUnsecurePackagesUsingYumPluginSecurity() (CvePacksList, err
 
 	// get package name, version, rel to be upgrade.
 	//  cmd = "yum check-update --security"
-	cmd = "LANG=en_US.UTF-8 yum --color=never check-update"
+	cmd = "LANGUAGE=en_US.UTF-8 yum --color=never check-update"
 	r = o.ssh(util.PrependProxyEnv(cmd), o.sudo())
 	if !r.isSuccess(0, 100) {
 		//returns an exit code of 100 if there are available updates.


### PR DESCRIPTION
LANGUAGE is more priority than LANG.

http://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html
```
2.3.2 Locale Environment Variables

A locale is composed of several locale categories, see Aspects. When a program looks up locale dependent values, it does this according to the following environment variables, in priority order:

 LANGUAGE
 LC_ALL
 LC_xxx, according to selected locale category: LC_CTYPE, LC_NUMERIC, LC_TIME, LC_COLLATE, LC_MONETARY, LC_MESSAGES, ...
 LANG
```