### PR TITLE
Feature/enable.log.levels

### DIFF
--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -39,7 +39,7 @@ type ConfigtestCmd struct {
 	askKeyPassword bool
 	sshExternal    bool
 
-	debug bool
+	loglevel       string
 }
 
 // Name return subcommand name
@@ -55,7 +55,7 @@ func (*ConfigtestCmd) Usage() string {
 		        [-config=/path/to/config.toml]
 	        	[-ask-key-password]
 	        	[-ssh-external]
-		        [-debug]
+				[-loglevel=debug|info|warning|error|fatal|panic]
 
 		        [SERVER]...
 `
@@ -67,7 +67,7 @@ func (p *ConfigtestCmd) SetFlags(f *flag.FlagSet) {
 	defaultConfPath := filepath.Join(wd, "config.toml")
 	f.StringVar(&p.configPath, "config", defaultConfPath, "/path/to/toml")
 
-	f.BoolVar(&p.debug, "debug", false, "debug mode")
+	f.StringVar(&p.loglevel, "loglevel", "info", "[debug|info|warning|error|fatal|panic]")
 
 	f.BoolVar(
 		&p.askKeyPassword,
@@ -96,7 +96,7 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 		}
 	}
 
-	c.Conf.Debug = p.debug
+	c.Conf.LogLevel = p.loglevel
 	c.Conf.SSHExternal = p.sshExternal
 
 	err = c.Load(p.configPath, keyPass)

--- a/commands/prepare.go
+++ b/commands/prepare.go
@@ -32,7 +32,7 @@ import (
 
 // PrepareCmd is Subcommand of host discovery mode
 type PrepareCmd struct {
-	debug      bool
+	loglevel string
 	configPath string
 
 	askSudoPassword bool
@@ -59,7 +59,7 @@ func (*PrepareCmd) Usage() string {
 	prepare
 			[-config=/path/to/config.toml]
 			[-ask-key-password]
-			[-debug]
+			[-loglevel=debug|info|warning|error|fatal|panic]
 
 		    [SERVER]...
 `
@@ -68,7 +68,7 @@ func (*PrepareCmd) Usage() string {
 // SetFlags set flag
 func (p *PrepareCmd) SetFlags(f *flag.FlagSet) {
 
-	f.BoolVar(&p.debug, "debug", false, "debug mode")
+	f.StringVar(&p.loglevel, "loglevel", "info", "[debug|info|warning|error|fatal|panic]")
 
 	wd, _ := os.Getwd()
 
@@ -132,7 +132,7 @@ func (p *PrepareCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 		c.Conf.Servers = target
 	}
 
-	c.Conf.Debug = p.debug
+	c.Conf.LogLevel = p.loglevel
 
 	// Set up custom logger
 	logger := util.NewCustomLogger(c.ServerInfo{})

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -39,7 +39,7 @@ import (
 // ScanCmd is Subcommand of host discovery mode
 type ScanCmd struct {
 	lang     string
-	debug    bool
+	loglevel string
 	debugSQL bool
 
 	configPath string
@@ -88,6 +88,7 @@ func (*ScanCmd) Synopsis() string { return "Scan vulnerabilities" }
 func (*ScanCmd) Usage() string {
 	return `scan:
 	scan
+	    [-loglevel=debug|info|warning|error|fatal|panic]
 		[-lang=en|ja]
 		[-config=/path/to/config.toml]
 		[-results-dir=/path/to/results]
@@ -123,7 +124,7 @@ func (*ScanCmd) Usage() string {
 // SetFlags set flag
 func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&p.lang, "lang", "en", "[en|ja]")
-	f.BoolVar(&p.debug, "debug", false, "debug mode")
+	f.StringVar(&p.loglevel, "loglevel", "info", "[debug|info|warning|error|fatal|panic]")
 	f.BoolVar(&p.debugSQL, "debug-sql", false, "SQL debug mode")
 
 	wd, _ := os.Getwd()
@@ -307,7 +308,7 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	}
 
 	c.Conf.Lang = p.lang
-	c.Conf.Debug = p.debug
+	c.Conf.LogLevel = p.loglevel
 	c.Conf.DebugSQL = p.debugSQL
 
 	// logger

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -45,6 +45,7 @@ type ScanCmd struct {
 	configPath string
 
 	resultsDir       string
+	cvedbtype        string
 	cvedbpath        string
 	cveDictionaryURL string
 	cacheDBPath      string
@@ -90,7 +91,8 @@ func (*ScanCmd) Usage() string {
 		[-lang=en|ja]
 		[-config=/path/to/config.toml]
 		[-results-dir=/path/to/results]
-		[-cve-dictionary-dbpath=/path/to/cve.sqlite3]
+		[-cve-dictionary-dbtype=sqlite3|mysql]
+		[-cve-dictionary-dbpath=/path/to/cve.sqlite3 or mysql connection string]
 		[-cve-dictionary-url=http://127.0.0.1:1323]
 		[-cache-dbpath=/path/to/cache.db]
 		[-cvss-over=7]
@@ -131,6 +133,12 @@ func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 
 	defaultResultsDir := filepath.Join(wd, "results")
 	f.StringVar(&p.resultsDir, "results-dir", defaultResultsDir, "/path/to/results")
+
+	f.StringVar(
+		&p.cvedbtype,
+		"cve-dictionary-dbtype",
+		"sqlite3",
+		"DB type for fetching CVE dictionary (sqlite3 or mysql)")
 
 	f.StringVar(
 		&p.cvedbpath,
@@ -254,7 +262,9 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	logrus.Info("Start scanning")
 	logrus.Infof("config: %s", p.configPath)
 	if p.cvedbpath != "" {
-		logrus.Infof("cve-dictionary: %s", p.cvedbpath)
+		if p.cvedbtype == "sqlite3" {
+			logrus.Infof("cve-dictionary: %s", p.cvedbpath)
+		}
 	} else {
 		logrus.Infof("cve-dictionary: %s", p.cveDictionaryURL)
 	}
@@ -357,6 +367,7 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	}
 
 	c.Conf.ResultsDir = p.resultsDir
+	c.Conf.CveDBType = p.cvedbtype
 	c.Conf.CveDBPath = p.cvedbpath
 	c.Conf.CveDictionaryURL = p.cveDictionaryURL
 	c.Conf.CacheDBPath = p.cacheDBPath

--- a/config/config.go
+++ b/config/config.go
@@ -30,12 +30,13 @@ var Conf Config
 
 //Config is struct of Configuration
 type Config struct {
-	Debug    bool
+	LogLevel string
 	DebugSQL bool
 	Lang     string
 
 	Mail    smtpConf
 	Slack   SlackConf
+
 	Default ServerInfo
 	Servers map[string]ServerInfo
 
@@ -69,6 +70,11 @@ type Config struct {
 func (c Config) Validate() bool {
 	errs := []error{}
 
+	_, err := log.ParseLevel(c.LogLevel)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("Invalid log level %s", c.LogLevel))
+	}
+
 	if len(c.ResultsDir) != 0 {
 		if ok, _ := valid.IsFilePath(c.ResultsDir); !ok {
 			errs = append(errs, fmt.Errorf(
@@ -97,7 +103,7 @@ func (c Config) Validate() bool {
 		}
 	}
 
-	_, err := valid.ValidateStruct(c)
+	_, err = valid.ValidateStruct(c)
 	if err != nil {
 		errs = append(errs, err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ type Config struct {
 
 	HTTPProxy   string `valid:"url"`
 	ResultsDir  string
+	CveDBType   string
 	CveDBPath   string
 	CacheDBPath string
 
@@ -75,10 +76,17 @@ func (c Config) Validate() bool {
 		}
 	}
 
-	if len(c.CveDBPath) != 0 {
-		if ok, _ := valid.IsFilePath(c.CveDBPath); !ok {
-			errs = append(errs, fmt.Errorf(
-				"SQLite3 DB(Cve Dictionary) path must be a *Absolute* file path. -cve-dictionary-dbpath: %s", c.CveDBPath))
+	if c.CveDBType != "sqlite3" && c.CveDBType != "mysql" {
+		errs = append(errs, fmt.Errorf(
+			"CVE DB type must be either 'sqlite3' or 'mysql'.  -cve-dictionary-dbtype: %s", c.CveDBType))
+	}
+
+	if c.CveDBType == "sqlite3" {
+		if len(c.CveDBPath) != 0 {
+			if ok, _ := valid.IsFilePath(c.CveDBPath); !ok {
+				errs = append(errs, fmt.Errorf(
+					"SQLite3 DB(Cve Dictionary) path must be a *Absolute* file path. -cve-dictionary-dbpath: %s", c.CveDBPath))
+			}
 		}
 	}
 

--- a/cveapi/cve_client.go
+++ b/cveapi/cve_client.go
@@ -49,7 +49,7 @@ func (api *cvedictClient) initialize() {
 
 func (api cvedictClient) CheckHealth() (ok bool, err error) {
 	if config.Conf.CveDBPath != "" {
-		log.Debugf("get cve-dictionary from sqlite3")
+		log.Debugf("get cve-dictionary from %s", config.Conf.CveDBType)
 		return true, nil
 	}
 
@@ -135,8 +135,10 @@ func (api cvedictClient) FetchCveDetails(cveIDs []string) (cveDetails cve.CveDet
 }
 
 func (api cvedictClient) FetchCveDetailsFromCveDB(cveIDs []string) (cveDetails cve.CveDetails, err error) {
-	log.Debugf("open cve-dictionary db")
+	log.Debugf("open cve-dictionary db (%s)", config.Conf.CveDBType)
+	cveconfig.Conf.DBType = config.Conf.CveDBType
 	cveconfig.Conf.DBPath = config.Conf.CveDBPath
+	cveconfig.Conf.DebugSQL = config.Conf.DebugSQL
 	if err := cvedb.OpenDB(); err != nil {
 		return []cve.CveDetail{},
 			fmt.Errorf("Failed to open DB. err: %s", err)
@@ -239,8 +241,11 @@ func (api cvedictClient) httpPost(key, url string, query map[string]string) ([]c
 }
 
 func (api cvedictClient) FetchCveDetailsByCpeNameFromDB(cpeName string) ([]cve.CveDetail, error) {
-	log.Debugf("open cve-dictionary db")
+	log.Debugf("open cve-dictionary db (%s)", config.Conf.CveDBType)
+	cveconfig.Conf.DBType = config.Conf.CveDBType
 	cveconfig.Conf.DBPath = config.Conf.CveDBPath
+	cveconfig.Conf.DebugSQL = config.Conf.DebugSQL
+
 	if err := cvedb.OpenDB(); err != nil {
 		return []cve.CveDetail{},
 			fmt.Errorf("Failed to open DB. err: %s", err)

--- a/cveapi/cve_client.go
+++ b/cveapi/cve_client.go
@@ -57,7 +57,8 @@ func (api cvedictClient) CheckHealth() (ok bool, err error) {
 	url := fmt.Sprintf("%s/health", api.baseURL)
 	var errs []error
 	var resp *http.Response
-	resp, _, errs = gorequest.New().SetDebug(config.Conf.Debug).Get(url).End()
+
+	resp, _, errs = gorequest.New().SetDebug(util.IsDebugEnabled()).Get(url).End()
 	//  resp, _, errs = gorequest.New().Proxy(api.httpProxy).Get(url).End()
 	if 0 < len(errs) || resp == nil || resp.StatusCode != 200 {
 		return false, fmt.Errorf("Failed to request to CVE server. url: %s, errs: %v", url, errs)
@@ -214,7 +215,7 @@ func (api cvedictClient) httpPost(key, url string, query map[string]string) ([]c
 	var errs []error
 	var resp *http.Response
 	f := func() (err error) {
-		req := gorequest.New().SetDebug(config.Conf.Debug).Post(url)
+		req := gorequest.New().SetDebug(util.IsDebugEnabled()).Post(url)
 		for key := range query {
 			req = req.Send(fmt.Sprintf("%s=%s", key, query[key])).Type("json")
 		}

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -313,7 +313,7 @@ func (o *debian) ensureChangelogCache(current cache.Meta) error {
 		}
 	}
 
-	if config.Conf.Debug {
+	if util.IsDebugEnabled() {
 		cache.DB.PrettyPrint(current)
 	}
 	return nil

--- a/util/logutil.go
+++ b/util/logutil.go
@@ -34,10 +34,9 @@ func NewCustomLogger(c config.ServerInfo) *logrus.Entry {
 	log := logrus.New()
 	log.Formatter = &formatter.TextFormatter{MsgAnsiColor: c.LogMsgAnsiColor}
 	log.Out = os.Stderr
-	log.Level = logrus.InfoLevel
-	if config.Conf.Debug {
-		log.Level = logrus.DebugLevel
-	}
+
+	level, _ := logrus.ParseLevel(config.Conf.LogLevel)
+	log.Level = level
 
 	// File output
 	logDir := "/var/log/vuls"
@@ -69,4 +68,10 @@ func NewCustomLogger(c config.ServerInfo) *logrus.Entry {
 
 	fields := logrus.Fields{"prefix": whereami}
 	return log.WithFields(fields)
+}
+
+// IsDebugEnabled returns true if a log level of DEBUG has been set.
+func IsDebugEnabled() (bool) {
+	level, _ := logrus.ParseLevel(config.Conf.LogLevel)
+	return level == logrus.DebugLevel
 }


### PR DESCRIPTION
Added support for a `-loglevel=debug|info|warning|error|fatal|panic` flag.

I wanted to control the level of output, as opposed to be default "info" with debug as an option.  This allows me to display only errors if desired without all of the additional console logging.  I had considered adding a -silent flag so that there would be three levels of logging, but decided this gave more flexibility.

I removed the `-debug` flag as well as it's redundant with being able to specify log levels.
