### PR TITLE
Handle the refactored gocui SetCurrentView method.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -61,7 +61,7 @@ imports:
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/jroimartin/gocui
-  version: 4e9ce9a8e26f2ef33dfe297dbdfca148733b6b9b
+  version: 550f04e523205530542d0c4fe63c4c0ab5d046bd
 - name: github.com/k0kubun/pp
   version: f5dce6ed0ccf6c350f1679964ff6b61f3d6d2033
 - name: github.com/kotakanbe/go-cve-dictionary

--- a/report/tui.go
+++ b/report/tui.go
@@ -176,35 +176,41 @@ func keybindings(g *gocui.Gui) (err error) {
 }
 
 func nextView(g *gocui.Gui, v *gocui.View) error {
+	var err error
+
 	if v == nil {
-		return g.SetCurrentView("side")
+		_, err = g.SetCurrentView("side")
 	}
 	switch v.Name() {
 	case "side":
-		return g.SetCurrentView("summary")
+		_, err = g.SetCurrentView("summary")
 	case "summary":
-		return g.SetCurrentView("detail")
+		_, err = g.SetCurrentView("detail")
 	case "detail":
-		return g.SetCurrentView("side")
+		_, err = g.SetCurrentView("side")
 	default:
-		return g.SetCurrentView("summary")
+		_, err = g.SetCurrentView("summary")
 	}
+	return err
 }
 
 func previousView(g *gocui.Gui, v *gocui.View) error {
+	var err error
+
 	if v == nil {
-		return g.SetCurrentView("side")
+		_, err = g.SetCurrentView("side")
 	}
 	switch v.Name() {
 	case "side":
-		return g.SetCurrentView("side")
+		_, err = g.SetCurrentView("side")
 	case "summary":
-		return g.SetCurrentView("side")
+		_, err = g.SetCurrentView("side")
 	case "detail":
-		return g.SetCurrentView("summary")
+		_, err = g.SetCurrentView("summary")
 	default:
-		return g.SetCurrentView("side")
+		_, err = g.SetCurrentView("side")
 	}
+	return err
 }
 
 func movable(v *gocui.View, nextY int) (ok bool, yLimit int) {
@@ -373,7 +379,7 @@ func cursorPageUp(g *gocui.Gui, v *gocui.View) error {
 func previousSummary(g *gocui.Gui, v *gocui.View) error {
 	if v != nil {
 		// cursor to summary
-		if err := g.SetCurrentView("summary"); err != nil {
+		if _, err := g.SetCurrentView("summary"); err != nil {
 			return err
 		}
 		// move next line
@@ -381,7 +387,7 @@ func previousSummary(g *gocui.Gui, v *gocui.View) error {
 			return err
 		}
 		// cursor to detail
-		if err := g.SetCurrentView("detail"); err != nil {
+		if _, err := g.SetCurrentView("detail"); err != nil {
 			return err
 		}
 	}
@@ -391,7 +397,7 @@ func previousSummary(g *gocui.Gui, v *gocui.View) error {
 func nextSummary(g *gocui.Gui, v *gocui.View) error {
 	if v != nil {
 		// cursor to summary
-		if err := g.SetCurrentView("summary"); err != nil {
+		if _, err := g.SetCurrentView("summary"); err != nil {
 			return err
 		}
 		// move next line
@@ -399,7 +405,7 @@ func nextSummary(g *gocui.Gui, v *gocui.View) error {
 			return err
 		}
 		// cursor to detail
-		if err := g.SetCurrentView("detail"); err != nil {
+		if _, err := g.SetCurrentView("detail"); err != nil {
 			return err
 		}
 	}
@@ -464,7 +470,7 @@ func getLine(g *gocui.Gui, v *gocui.View) error {
 			return err
 		}
 		fmt.Fprintln(v, l)
-		if err := g.SetCurrentView("msg"); err != nil {
+		if _, err := g.SetCurrentView("msg"); err != nil {
 			return err
 		}
 	}
@@ -486,7 +492,7 @@ func showMsg(g *gocui.Gui, v *gocui.View) error {
 			return err
 		}
 		fmt.Fprintln(v, l)
-		if err := g.SetCurrentView("msg"); err != nil {
+		if _, err := g.SetCurrentView("msg"); err != nil {
 			return err
 		}
 	}
@@ -497,7 +503,7 @@ func delMsg(g *gocui.Gui, v *gocui.View) error {
 	if err := g.DeleteView("msg"); err != nil {
 		return err
 	}
-	if err := g.SetCurrentView("summary"); err != nil {
+	if _, err := g.SetCurrentView("summary"); err != nil {
 		return err
 	}
 	return nil
@@ -532,7 +538,7 @@ func setSideLayout(g *gocui.Gui) error {
 			fmt.Fprintln(v, result.ServerInfoTui())
 		}
 		currentScanResult = scanHistory.ScanResults[0]
-		if err := g.SetCurrentView("side"); err != nil {
+		if _, err := g.SetCurrentView("side"); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Previously, the method just returned an error if an error occurred (or nil if no error).
The new method now returns the view as well as well as the error object.  Updated to ignore the
view and handle the error object as usual.

Fix for issue #228.
https://github.com/future-architect/vuls/issues/228