### PR TITLE
Fixed error for the latest version of gocui

### DIFF
--- a/report/tui.go
+++ b/report/tui.go
@@ -48,8 +48,8 @@ func RunTui(jsonDirName string) subcommands.ExitStatus {
 		return subcommands.ExitFailure
 	}
 
-	g := gocui.NewGui()
-	if err := g.Init(); err != nil {
+	g, err := gocui.NewGui()
+	if err != nil {
 		log.Errorf("%s", err)
 		return subcommands.ExitFailure
 	}


### PR DESCRIPTION
The following is the error:
go/src/github.com/future-architect/vuls/report/tui.go:52: multiple-value gocui.NewGui() in single-value context