### PR TITLE
scan: 'CloudLinux' should be detected as centos

### DIFF
--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -70,7 +70,6 @@ func detectRedhat(c config.ServerInfo) (itsMe bool, red osTypeInterface) {
 			}
 
 			release := result[2]
-			fmt.Println(release)
 			switch strings.ToLower(result[1]) {
 			case "centos", "centos linux", "cloudlinux", "cloudlinux server":
 				red.setDistro("centos", release)

--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -70,8 +70,9 @@ func detectRedhat(c config.ServerInfo) (itsMe bool, red osTypeInterface) {
 			}
 
 			release := result[2]
+			fmt.Println(release)
 			switch strings.ToLower(result[1]) {
-			case "centos", "centos linux":
+			case "centos", "centos linux", "cloudlinux", "cloudlinux server":
 				red.setDistro("centos", release)
 			default:
 				red.setDistro("rhel", release)


### PR DESCRIPTION
https://en.wikipedia.org/wiki/CloudLinux_OS

Currently it is being mis-detected as `rhel` and therefore vuls will fail when preparing the node.

There are many EL off-shoots (each who modify `redhat-release`), but I am not sure how popular they are. CloudLinux is definitely widely used by web hosts. Might it be easier to have the default case as `centos` rather than `rhel`?

On EL6:

```
# cat /etc/redhat-release 
CloudLinux Server release 6.8 (Oleg Makarov)
```

On EL7:

```
# cat /etc/redhat-release 
CloudLinux release 7.2 (Valeri Kubasov) 
```
