### PR TITLE
Fix changelog cache bug on Ubuntu and Debian #235

### DIFF
--- a/scan/debian.go
+++ b/scan/debian.go
@@ -513,7 +513,7 @@ func (o *debian) getChangelogCache(meta cache.Meta, pack models.PackageInfo) str
 	}
 	changelog, err := cache.DB.GetChangelog(meta.Name, pack.Name)
 	if err != nil {
-		o.log.Warnf("Failed to get chnagelog. bucket: %s, key:%s, err: %s",
+		o.log.Warnf("Failed to get changelog. bucket: %s, key:%s, err: %s",
 			meta.Name, pack.Name, err)
 		return ""
 	}
@@ -541,11 +541,13 @@ func (o *debian) scanPackageCveIDs(pack models.PackageInfo) ([]string, error) {
 		o.log.Warnf("Failed to SSH: %s", r)
 		// Ignore this Error.
 		return nil, nil
-
 	}
-	err := cache.DB.PutChangelog(o.getServerInfo().GetServerName(), pack.Name, r.Stdout)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to put changelog into cache")
+
+	if 0 < len(strings.TrimSpace(r.Stdout)) {
+		err := cache.DB.PutChangelog(o.getServerInfo().GetServerName(), pack.Name, r.Stdout)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to put changelog into cache")
+		}
 	}
 	// No error will be returned. Only logging.
 	return o.getCveIDFromChangelog(r.Stdout, pack.Name, pack.Version), nil


### PR DESCRIPTION
For details, see #235 

It's better to scan after removing cache.db.