### PR TITLE
Moved golang.org/x/net/context to context

### DIFF
--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package commands
 
 import (
+	"context"
 	"flag"
 	"io/ioutil"
 	"os"
@@ -26,7 +27,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/google/subcommands"
-	"golang.org/x/net/context"
 
 	c "github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/scan"

--- a/commands/discover.go
+++ b/commands/discover.go
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package commands
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -25,7 +26,6 @@ import (
 	"text/template"
 
 	"github.com/google/subcommands"
-	"golang.org/x/net/context"
 
 	"github.com/Sirupsen/logrus"
 	ps "github.com/kotakanbe/go-pingscanner"

--- a/commands/history.go
+++ b/commands/history.go
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package commands
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -28,7 +29,6 @@ import (
 	c "github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/report"
 	"github.com/google/subcommands"
-	"golang.org/x/net/context"
 )
 
 // HistoryCmd is Subcommand of list scanned results

--- a/commands/prepare.go
+++ b/commands/prepare.go
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package commands
 
 import (
+	"context"
 	"flag"
 	"os"
 	"path/filepath"
@@ -27,7 +28,6 @@ import (
 	"github.com/future-architect/vuls/scan"
 	"github.com/future-architect/vuls/util"
 	"github.com/google/subcommands"
-	"golang.org/x/net/context"
 )
 
 // PrepareCmd is Subcommand of host discovery mode

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package commands
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -34,7 +35,6 @@ import (
 	"github.com/future-architect/vuls/util"
 	"github.com/google/subcommands"
 	"github.com/k0kubun/pp"
-	"golang.org/x/net/context"
 )
 
 // ScanCmd is Subcommand of host discovery mode

--- a/commands/tui.go
+++ b/commands/tui.go
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package commands
 
 import (
+	"context"
 	"flag"
 	"io/ioutil"
 	"os"
@@ -28,7 +29,6 @@ import (
 	c "github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/report"
 	"github.com/google/subcommands"
-	"golang.org/x/net/context"
 )
 
 // TuiCmd is Subcommand of host discovery mode

--- a/glide.lock
+++ b/glide.lock
@@ -48,7 +48,7 @@ imports:
 - name: github.com/go-sql-driver/mysql
   version: 2a6c6079c7eff49a7e9d641e109d922f124a3e4c
 - name: github.com/google/subcommands
-  version: 1c7173745a6001f67d8d96ab4e178284c77f7759
+  version: a71b91e238406bd68766ee52db63bebedce0e9f6
 - name: github.com/gosuri/uitable
   version: 36ee7e946282a3fb1cfecd476ddc9b35d8847e42
   subpackages:

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"os"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/future-architect/vuls/commands"
 	"github.com/google/subcommands"


### PR DESCRIPTION
Corresponding to https://github.com/google/subcommands/pull/5.

- See also https://github.com/kotakanbe/go-cve-dictionary/pull/32 