### PR TITLE
Fix non-interactive `apt-get install` #251

### DIFF
--- a/scan/debian.go
+++ b/scan/debian.go
@@ -159,7 +159,7 @@ func (o *debian) install() error {
 	}
 
 	for _, name := range o.lackDependencies {
-		cmd = util.PrependProxyEnv("apt-get install " + name)
+		cmd = util.PrependProxyEnv("apt-get install -y " + name)
 		if r := o.ssh(cmd, sudo); !r.isSuccess() {
 			msg := fmt.Sprintf("Failed to SSH: %s", r)
 			o.log.Errorf(msg)


### PR DESCRIPTION
Setting `DEBIAN_FRONTEND=noninteractive` may be more robust if doing more with `apt-get`.