### PR TITLE
Stop quietly ignoring `--ssh-external` on Windows

### DIFF
--- a/commands/prepare.go
+++ b/commands/prepare.go
@@ -145,6 +145,10 @@ func (p *PrepareCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{
 	c.Conf.Debug = p.debug
 	c.Conf.SSHExternal = p.sshExternal
 
+	logrus.Info("Validating Config...")
+	if !c.Conf.Validate() {
+		return subcommands.ExitUsageError
+	}
 	// Set up custom logger
 	logger := util.NewCustomLogger(c.ServerInfo{})
 

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ package config
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -69,6 +70,10 @@ type Config struct {
 // Validate configuration
 func (c Config) Validate() bool {
 	errs := []error{}
+
+	if runtime.GOOS == "windows" && c.SSHExternal {
+		errs = append(errs, fmt.Errorf("-ssh-external cannot be used on windows"))
+	}
 
 	if len(c.ResultsDir) != 0 {
 		if ok, _ := valid.IsFilePath(c.ResultsDir); !ok {

--- a/scan/sshutil.go
+++ b/scan/sshutil.go
@@ -26,7 +26,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -150,19 +149,15 @@ func parallelSSHExec(fn func(osTypeInterface) error, timeoutSec ...int) (errs []
 }
 
 func sshExec(c conf.ServerInfo, cmd string, sudo bool, log ...*logrus.Entry) (result sshResult) {
-	if isSSHExecNative() {
-		result = sshExecNative(c, cmd, sudo)
-	} else {
+	if conf.Conf.SSHExternal {
 		result = sshExecExternal(c, cmd, sudo)
+	} else {
+		result = sshExecNative(c, cmd, sudo)
 	}
 
 	logger := getSSHLogger(log...)
 	logger.Debug(result)
 	return
-}
-
-func isSSHExecNative() bool {
-	return runtime.GOOS == "windows" || !conf.Conf.SSHExternal
 }
 
 func sshExecNative(c conf.ServerInfo, cmd string, sudo bool) (result sshResult) {


### PR DESCRIPTION
This minor refactor checks the SSHExternal flag during validations, rather that setting it and then quietly ignoring it on Windows machines.