### PR TITLE
Use RFC3339 timestamps in the results

### DIFF
--- a/report/azureblob.go
+++ b/report/azureblob.go
@@ -113,7 +113,7 @@ func (w AzureBlobWriter) upload(res models.ScanResult) (err error) {
 	if err != nil {
 		return err
 	}
-	timestr := time.Now().Format("20060102_1504")
+	timestr := time.Now().Format(time.RFC3339)
 	name := ""
 	if len(res.Container.ContainerID) == 0 {
 		name = fmt.Sprintf("%s/%s.json", timestr, res.ServerName)

--- a/report/json.go
+++ b/report/json.go
@@ -134,8 +134,7 @@ func LoadOneScanHistory(jsonDir string) (scanHistory models.ScanHistory, err err
 	if scanResults[0].ScannedAt.IsZero() {
 		splitPath := strings.Split(jsonDir, string(os.PathSeparator))
 		timeStr := splitPath[len(splitPath)-1]
-		timeformat := "20060102_1504"
-		if scannedAt, err = time.Parse(timeformat, timeStr); err != nil {
+		if scannedAt, err = time.Parse(time.RFC3339, timeStr); err != nil {
 			err = fmt.Errorf("Failed to parse %s: %s", timeStr, err)
 			return
 		}

--- a/report/s3.go
+++ b/report/s3.go
@@ -77,7 +77,7 @@ func (w S3Writer) Write(scanResults []models.ScanResult) (err error) {
 
 	// http://docs.aws.amazon.com/sdk-for-go/latest/v1/developerguide/common-examples.title.html
 	svc := getS3()
-	timestr := time.Now().Format("20060102_1504")
+	timestr := time.Now().Format(time.RFC3339)
 	for _, r := range scanResults {
 		key := ""
 		if len(r.Container.ContainerID) == 0 {

--- a/report/util.go
+++ b/report/util.go
@@ -31,8 +31,7 @@ import (
 )
 
 func ensureResultDir(scannedAt time.Time) (path string, err error) {
-	const timeLayout = "20060102_1504"
-	jsonDirName := scannedAt.Format(timeLayout)
+	jsonDirName := scannedAt.Format(time.RFC3339)
 
 	resultsDir := config.Conf.ResultsDir
 	if len(resultsDir) == 0 {


### PR DESCRIPTION
This is a standard format that still preserves natural ordering in the results, is arguably easier to read, and also provides both seconds and time zone information, e.g. `2006-01-02T15:04:05Z07:00`.