### PR TITLE
Add Content-Type header to report/mail.go .

### DIFF
--- a/report/mail.go
+++ b/report/mail.go
@@ -52,6 +52,7 @@ func (w MailWriter) Write(scanResults []models.ScanResult) (err error) {
 		headers["To"] = to
 		headers["Cc"] = cc
 		headers["Subject"] = subject
+		headers["Content-Type"] = "text/plain; charset=utf-8"
 
 		var message string
 		for k, v := range headers {


### PR DESCRIPTION
Vuls report mail has NO charset header.
This pull request contain 'Content-Type: text/plain; charset=utf8' header.