### PR TITLE
Check whether echo is executable with nopasswd

### DIFF
--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -97,7 +97,11 @@ func detectRedhat(c config.ServerInfo) (itsMe bool, red osTypeInterface) {
 }
 
 func (o *redhat) checkIfSudoNoPasswd() error {
-	r := o.exec("yum --version", o.sudo())
+        cmd := "yum --version"
+        if o.Distro.Family == "centos" {
+                cmd = "echo N | " + cmd
+        }
+        r := o.exec(cmd, o.sudo())
 	if !r.isSuccess() {
 		o.log.Errorf("sudo error on %s", r)
 		return fmt.Errorf("Failed to sudo: %s", r)


### PR DESCRIPTION
OS : CentOS 6.8
Even if I forget to write `/bin/echo` in sudoers file, `vuls configtest` will succeed.
However, `vuls scan` will fail because `echo N` is used in `getAllChangelog`.

```
$ sudo cat /etc/sudoers | grep vuls
vuls ALL=(root) NOPASSWD: /usr/bin/yum
$ vuls configtest
[Jan 22 23:18:05]  INFO [localhost] Validating Config...
[Jan 22 23:18:05]  INFO [localhost] Detecting Server/Contianer OS...
[Jan 22 23:18:05]  INFO [localhost] Detecting OS of servers...
[Jan 22 23:18:06]  INFO [localhost] (1/1) Detected: vagrant: centos 6.8
[Jan 22 23:18:06]  INFO [localhost] Detecting OS of containers...
[Jan 22 23:18:06]  INFO [localhost] Checking sudo configuration...
[Jan 22 23:18:06]  INFO [vagrant] sudo ... OK
[Jan 22 23:18:06]  INFO [localhost] SSH-able servers are below...
vagrant
$ vuls scan
INFO[0000] Start scanning
INFO[0000] config: /vuls/config.toml
[Jan 21 23:21:46]  INFO [localhost] Validating Config...
[Jan 21 23:21:46]  INFO [localhost] Detecting Server/Contianer OS...
[Jan 21 23:21:46]  INFO [localhost] Detecting OS of servers...
[Jan 21 23:21:48]  INFO [localhost] (1/1) Detected: vagrant: centos 6.8
[Jan 21 23:21:48]  INFO [localhost] Detecting OS of containers...
[Jan 21 23:21:48]  INFO [localhost] Checking sudo configuration...
[Jan 21 23:21:48]  INFO [vagrant] sudo ... OK
[Jan 21 23:21:48]  INFO [localhost] Detecting Platforms...
[Jan 21 23:22:00]  INFO [localhost] (1/1) vagrant is running on other
[Jan 21 23:22:00]  INFO [localhost] Scanning vulnerabilities...
[Jan 21 23:22:00]  INFO [localhost] Check required packages for scanning...
[Jan 21 23:22:01]  INFO [localhost] Scanning vulnerable OS packages...
[Jan 22 01:02:01] ERROR [localhost] Failed to scan. err: Timed out: [vagrant]
```

To prevent this problem, I check whether `echo` is executable with nopasswd in `checkIfSudoNoPasswd()`.
If I forget to write `/bin/echo` in sudoers file, `vuls configtest` will fail.

```
$ vuls configtest
[Jan 22 23:32:59]  INFO [localhost] Validating Config...
[Jan 22 23:32:59]  INFO [localhost] Detecting Server/Contianer OS...
[Jan 22 23:32:59]  INFO [localhost] Detecting OS of servers...
[Jan 22 23:33:00]  INFO [localhost] (1/1) Detected: vagrant: centos 6.8
[Jan 22 23:33:00]  INFO [localhost] Detecting OS of containers...
[Jan 22 23:33:00]  INFO [localhost] Checking sudo configuration...
[Jan 22 23:33:15] ERROR [localhost] Failed to sudo with nopassword via SSH. Define NOPASSWD in /etc/sudoers on target servers. err: [Timed out: [vagrant]]
```

Thanks!