### PR TITLE
Use --assumeno option

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -603,9 +603,9 @@ configtest:
 
 スキャン対象サーバ上の`/etc/sudoers`のサンプル
 
-- CentOS, RHEL, Amazon Linux
+- CentOS, RHEL, Amazon Linux (CentOS 5の場合は`/bin/echo`も必要)
 ```
-vuls ALL=(root) NOPASSWD: /usr/bin/yum, /bin/echo
+vuls ALL=(root) NOPASSWD: /usr/bin/yum (, /bin/echo)
 ```
 - Ubuntu, Debian
 ```

--- a/README.md
+++ b/README.md
@@ -606,9 +606,9 @@ configtest:
 And also, configtest subcommand checks sudo settings on target servers whether Vuls is able to SUDO with nopassword via SSH.  
 
 Example of /etc/sudoers on target servers
-- CentOS, RHEL
+- CentOS, RHEL (CentOS 5 needs also `/bin/echo`)
 ```
-vuls ALL=(root) NOPASSWD: /usr/bin/yum, /bin/echo
+vuls ALL=(root) NOPASSWD: /usr/bin/yum (, /bin/echo)
 ```
 - Ubuntu, Debian
 ```

--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -97,8 +97,13 @@ func detectRedhat(c config.ServerInfo) (itsMe bool, red osTypeInterface) {
 }
 
 func (o *redhat) checkIfSudoNoPasswd() error {
+	majorVersion, err := o.Distro.MajorVersion()
+	if err != nil {
+		return fmt.Errorf("Not implemented yet: %s, err: %s", o.Distro, err)
+	}
+
 	cmd := "yum --version"
-	if o.Distro.Family == "centos" {
+	if o.Distro.Family == "centos" && majorVersion < 6 {
 		cmd = "echo N | " + cmd
 	}
 	r := o.exec(cmd, o.sudo())
@@ -532,7 +537,7 @@ func (o *redhat) getAllChangelog(packInfoList models.PackageInfoList) (stdout st
 		packageNames += fmt.Sprintf("%s ", packInfo.Name)
 	}
 
-	command := "echo N | "
+	command := ""
 	if 0 < len(config.Conf.HTTPProxy) {
 		command += util.ProxyEnv()
 	}
@@ -544,6 +549,15 @@ func (o *redhat) getAllChangelog(packInfoList models.PackageInfoList) (stdout st
 	if config.Conf.SkipBroken {
 		yumopts += " --skip-broken"
 	}
+
+	// CentOS 5 does not have --assumeno option.
+	majorVersion, _ := o.Distro.MajorVersion()
+	if majorVersion < 6 {
+		command = "echo N | " + command
+	} else {
+		yumopts += " --assumeno"
+	}
+
 	// yum update --changelog doesn't have --color option.
 	command += fmt.Sprintf(" LANGUAGE=en_US.UTF-8 yum %s --changelog update ", yumopts) + packageNames
 


### PR DESCRIPTION
In the case of CentOS,  we need to write `/bin/echo` to sudoers.
```
vuls ALL=(root) NOPASSWD: /usr/bin/yum, /bin/echo
```

However, with CentOS 6,7 , `yum --assumeno` option makes `/bin/echo` unnecessary.