### PR TITLE
Fix the changelog cache logic for ubuntu/debian

### DIFF
--- a/cache/bolt_test.go
+++ b/cache/bolt_test.go
@@ -90,8 +90,11 @@ func TestEnsureBuckets(t *testing.T) {
 	if !found {
 		t.Errorf("Not Found in meta")
 	}
-	if !reflect.DeepEqual(meta, m) {
+	if meta.Name != m.Name || meta.Distro != m.Distro {
 		t.Errorf("expected %v, actual %v", meta, m)
+	}
+	if !reflect.DeepEqual(meta.Packs, m.Packs) {
+		t.Errorf("expected %v, actual %v", meta.Packs, m.Packs)
 	}
 	if err := DB.Close(); err != nil {
 		t.Errorf("Failed to close bolt: %s", err)

--- a/cache/db.go
+++ b/cache/db.go
@@ -18,6 +18,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package cache
 
 import (
+	"time"
+
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/models"
 )
@@ -31,6 +33,7 @@ const metabucket = "changelog-meta"
 type Cache interface {
 	Close() error
 	GetMeta(string) (Meta, bool, error)
+	RefreshMeta(Meta) error
 	EnsureBuckets(Meta) error
 	PrettyPrint(Meta) error
 	GetChangelog(string, string) (string, error)
@@ -40,9 +43,10 @@ type Cache interface {
 // Meta holds a server name, distro information of the scanned server and
 // package information that was collected at the last scan.
 type Meta struct {
-	Name   string
-	Distro config.Distro
-	Packs  []models.PackageInfo
+	Name      string
+	Distro    config.Distro
+	Packs     []models.PackageInfo
+	CreatedAt time.Time
 }
 
 // FindPack search a PackageInfo

--- a/scan/debian_test.go
+++ b/scan/debian_test.go
@@ -545,7 +545,7 @@ func TestGetChangelogCache(t *testing.T) {
 	}
 
 	d := newDebian(config.ServerInfo{})
-	actual := d.getChangelogCache(meta, pack)
+	actual := d.getChangelogCache(&meta, pack)
 	if actual != "" {
 		t.Errorf("Failed to get empty stirng from cache:")
 	}
@@ -555,21 +555,21 @@ func TestGetChangelogCache(t *testing.T) {
 		t.Errorf("Failed to put changelog: %s", err)
 	}
 
-	actual = d.getChangelogCache(meta, pack)
+	actual = d.getChangelogCache(&meta, pack)
 	if actual != clog {
 		t.Errorf("Failed to get changelog from cache: %s", actual)
 	}
 
 	// increment a version of the pack
 	pack.NewVersion = "1.0.2"
-	actual = d.getChangelogCache(meta, pack)
+	actual = d.getChangelogCache(&meta, pack)
 	if actual != "" {
 		t.Errorf("The changelog is not invalidated: %s", actual)
 	}
 
 	// change a name of the pack
 	pack.Name = "bash"
-	actual = d.getChangelogCache(meta, pack)
+	actual = d.getChangelogCache(&meta, pack)
 	if actual != "" {
 		t.Errorf("The changelog is not invalidated: %s", actual)
 	}


### PR DESCRIPTION
In the past implementations, there was a bug in the Cache of Ubuntu / Debian's Changelog, which lacked detection of vulnerability.

This bug was fixed.
If you are using Vuls to detect Ubuntu / Debian vulnerabilities please update to the latest version.
see https://github.com/future-architect/vuls#update-vuls-with-glide

Note that this bug has no effect on other than Ubuntu / Debian scanning.