### PR TITLE
Update glide.lock to fix import error

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -70,7 +70,7 @@ imports:
 - name: github.com/k0kubun/pp
   version: f5dce6ed0ccf6c350f1679964ff6b61f3d6d2033
 - name: github.com/kotakanbe/go-cve-dictionary
-  version: 1551cb550c2ece4b16c25daba211878dbbcf73fd
+  version: c6894c632b69f1879fa49aa2f7b6a6c553061cfb
   subpackages:
   - config
   - db


### PR DESCRIPTION
see https://github.com/kotakanbe/go-cve-dictionary/pull/41