### PR TITLE
Fix version having assumeno option

### DIFF
--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -550,9 +550,9 @@ func (o *redhat) getAllChangelog(packInfoList models.PackageInfoList) (stdout st
 		yumopts += " --skip-broken"
 	}
 
-	// CentOS 5 does not have --assumeno option.
+	// CentOS 5 and 6 does not have --assumeno option.
 	majorVersion, _ := o.Distro.MajorVersion()
-	if majorVersion < 6 {
+	if majorVersion < 7 {
 		command = "echo N | " + command
 	} else {
 		yumopts += " --assumeno"


### PR DESCRIPTION
In CentOS6, yum version is `3.2.29`.
This version does not have `--assumeno` option.
Fix the condition to CentOS 7 only.