### PR TITLE
aptitude changelog defaults to using more, which is not interactive a…

### DIFF
--- a/scan/debian.go
+++ b/scan/debian.go
@@ -537,7 +537,7 @@ func (o *debian) scanPackageCveIDs(pack models.PackageInfo) ([]string, error) {
 	case "ubuntu":
 		cmd = fmt.Sprintf(`apt-get changelog %s | grep '\(urgency\|CVE\)'`, pack.Name)
 	case "debian":
-		cmd = fmt.Sprintf(`aptitude changelog %s | grep '\(urgency\|CVE\)'`, pack.Name)
+		cmd = fmt.Sprintf(`env PAGER=cat aptitude changelog %s | grep '\(urgency\|CVE\)'`, pack.Name)
 	}
 	cmd = util.PrependProxyEnv(cmd)
 


### PR DESCRIPTION
…nd breaks docker scans. Set PAGER=cat before running to default to cat.

Resolves #323 

Relates to initial container support and debian scan code: #67 and f4fb0b5