### PR TITLE
Add leniancy to the version matching for debian to account for versio…

### DIFF
--- a/scan/debian.go
+++ b/scan/debian.go
@@ -592,11 +592,20 @@ func (o *debian) parseChangelog(changelog string,
 	cveRe := regexp.MustCompile(`(CVE-\d{4}-\d{4,})`)
 	stopRe := regexp.MustCompile(fmt.Sprintf(`\(%s\)`, regexp.QuoteMeta(versionOrLater)))
 	stopLineFound := false
+	leniantStopLineFound := false
+	versionOrLaterLeniant := versionOrLater
+	if i := strings.IndexRune(versionOrLaterLeniant, '+'); i >= 0 {
+		versionOrLaterLeniant = versionOrLaterLeniant[:i]
+	}
+	leniantRe := regexp.MustCompile(fmt.Sprintf(`\(%s\)`, regexp.QuoteMeta(versionOrLaterLeniant)))
 	lines := strings.Split(changelog, "\n")
 	for _, line := range lines {
 		if matche := stopRe.MatchString(line); matche {
 			//  o.log.Debugf("Found the stop line: %s", line)
 			stopLineFound = true
+			break
+		} else if matchel := leniantRe.MatchString(line); matchel {
+			leniantStopLineFound = true
 			break
 		} else if matches := cveRe.FindAllString(line, -1); 0 < len(matches) {
 			for _, m := range matches {
@@ -604,7 +613,7 @@ func (o *debian) parseChangelog(changelog string,
 			}
 		}
 	}
-	if !stopLineFound {
+	if !stopLineFound && !leniantStopLineFound {
 		return []string{}, fmt.Errorf(
 			"Failed to scan CVE IDs. The version is not in changelog. name: %s, version: %s",
 			packName,


### PR DESCRIPTION
…ns without the "+" when package maintainers aren't using them.

#327 