### PR TITLE
Bug fix: not send e-mail to cc address

### DIFF
--- a/report/email.go
+++ b/report/email.go
@@ -122,7 +122,7 @@ func (e *emailSender) Send(subject, body string) (err error) {
 			emailConf.SMTPAddr,
 		),
 		emailConf.From,
-		emailConf.To,
+		mailAddresses,
 		[]byte(message),
 	)
 	if err != nil {

--- a/report/email_test.go
+++ b/report/email_test.go
@@ -47,12 +47,13 @@ var mailTests = []mailTest{
 
 			From: "from@address.com",
 			To:   []string{"to@address.com"},
+			Cc:   []string{"cc@address.com"},
 		},
 		emailRecorder{
 			addr: "127.0.0.1:25",
 			auth: smtp.PlainAuth("", "", "", "127.0.0.1"),
 			from: "from@address.com",
-			to:   []string{"to@address.com"},
+			to:   []string{"to@address.com", "cc@address.com"},
 			body: "body",
 		},
 	},
@@ -66,6 +67,7 @@ var mailTests = []mailTest{
 
 			From: "from@address.com",
 			To:   []string{"to1@address.com", "to2@address.com"},
+			Cc:   []string{"cc1@address.com", "cc2@address.com"},
 		},
 		emailRecorder{
 			addr: "127.0.0.1:25",
@@ -76,7 +78,8 @@ var mailTests = []mailTest{
 				"127.0.0.1",
 			),
 			from: "from@address.com",
-			to:   []string{"to1@address.com", "to2@address.com"},
+			to: []string{"to1@address.com", "to2@address.com",
+				"cc1@address.com", "cc2@address.com"},
 			body: "body",
 		},
 	},


### PR DESCRIPTION
I think, with this code, `cc` address will not receive e-mail.
This is because `emailConf.To` is specified to `to` field.
https://github.com/future-architect/vuls/blob/master/report/email.go#L125

Please check if vuls send to `cc` address.