### PR TITLE
Output confidence score of detection accuracy and detection method to JSON or Reporting

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -255,20 +255,19 @@ One Line Summary
 View short summary.
 
 ```
-$ vuls report -format-short-text -cvedb-path=$PWD/cve.sqlite3
+$ vuls report -format-short-text -cvedb-path=$PWD/cve.sqlite3 --lang=ja
 
 172-31-4-8 (amazon 2015.09)
 ===========================
 Total: 94 (High:19 Medium:54 Low:7 ?:14)        103 updatable packages
 
-CVE-2016-0705   10.0 (High)     Double free vulnerability in the dsa_priv_decode function in
-                                crypto/dsa/dsa_ameth.c in OpenSSL 1.0.1 before 1.0.1s and 1.0.2 before 1.0.2g
-                                allows remote attackers to cause a denial of service (memory corruption) or
-                                possibly have unspecified other impact via a malformed DSA private key.
-                                http://www.cvedetails.com/cve/CVE-2016-0705
-                                http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-0705
-                                libssl1.0.0-1.0.2f-2ubuntu1 -> libssl1.0.0-1.0.2g-1ubuntu4.5
-                                openssl-1.0.2f-2ubuntu1 -> openssl-1.0.2g-1ubuntu4.5
+CVE-2016-5636           10.0 (High)     CPython の zipimport.c の get_data 関数における整数オーバーフローの脆弱性
+                                        http://jvndb.jvn.jp/ja/contents/2016/JVNDB-2016-004528.html
+                                        https://access.redhat.com/security/cve/CVE-2016-5636
+                                        python27-2.7.10-4.119.amzn1 -> python27-2.7.12-2.120.amzn1
+                                        python27-devel-2.7.10-4.119.amzn1 -> python27-devel-2.7.12-2.120.amzn1
+                                        python27-libs-2.7.10-4.119.amzn1 -> python27-libs-2.7.12-2.120.amzn1
+                                        Candidate: 100 / YumUpdateSecurityMatch
 
 ... snip ...
 ````
@@ -276,30 +275,36 @@ CVE-2016-0705   10.0 (High)     Double free vulnerability in the dsa_priv_decode
 View full report.
 
 ```
-$ vuls report -format-full-text -cvedb-path=$PWD/cve.sqlite3
+$ vuls report -format-full-text -cvedb-path=$PWD/cve.sqlite3 --lang=ja
 
 172-31-4-82 (amazon 2015.09)
 ============================
 Total: 94 (High:19 Medium:54 Low:7 ?:14)        103 updatable packages
 
-
-CVE-2016-0705
+CVE-2016-5636
 -------------
 Score           10.0 (High)
 Vector          (AV:N/AC:L/Au:N/C:C/I:C/A:C)
-Summary         Double free vulnerability in the dsa_priv_decode function in
-                crypto/dsa/dsa_ameth.c in OpenSSL 1.0.1 before 1.0.1s and 1.0.2 before 1.0.2g
-                allows remote attackers to cause a denial of service (memory corruption) or
-                possibly have unspecified other impact via a malformed DSA private key.
-CWE             https://cwe.mitre.org/data/definitions/.html
-NVD             https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-0705
-MITRE           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0705
-CVE Details     http://www.cvedetails.com/cve/CVE-2016-0705
-CVSS Claculator https://nvd.nist.gov/cvss/v2-calculator?name=CVE-2016-0705&vector=(AV:N/AC:L/...
-Ubuntu-CVE      http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-0705
-Package         libssl1.0.0-1.0.2f-2ubuntu1 -> libssl1.0.0-1.0.2g-1ubuntu4.5
-                openssl-1.0.2f-2ubuntu1 -> openssl-1.0.2g-1ubuntu4.5
+Title           CPython の zipimport.c の get_data 関数における整数オーバーフローの脆弱性
+Description     CPython (別名 Python) の zipimport.c の get_data
+                関数には、整数オーバーフローの脆弱性が存在します。
 
+                補足情報 : CWE による脆弱性タイプは、CWE-190: Integer Overflow or Wraparound
+                (整数オーバーフローまたはラップアラウンド) と識別されています。
+                http://cwe.mitre.org/data/definitions/190.html
+CWE-190         https://cwe.mitre.org/data/definitions/190.html
+CWE-190(JVN)    http://jvndb.jvn.jp/ja/cwe/CWE-190.html
+JVN             http://jvndb.jvn.jp/ja/contents/2016/JVNDB-2016-004528.html
+NVD             https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-5636
+MITRE           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5636
+CVE Details     http://www.cvedetails.com/cve/CVE-2016-5636
+CVSS Claculator https://nvd.nist.gov/cvss/v2-calculator?name=CVE-2016-5636&vector=(AV:N/AC:L/...
+RHEL-CVE        https://access.redhat.com/security/cve/CVE-2016-5636
+ALAS-2016-724   https://alas.aws.amazon.com/ALAS-2016-724.html
+Package         python27-2.7.10-4.119.amzn1 -> python27-2.7.12-2.120.amzn1
+                python27-devel-2.7.10-4.119.amzn1 -> python27-devel-2.7.12-2.120.amzn1
+                python27-libs-2.7.10-4.119.amzn1 -> python27-libs-2.7.12-2.120.amzn1
+Confidence      100 / YumUpdateSecurityMatch
 ... snip ...
 ```
 
@@ -924,6 +929,97 @@ report:
   -to-slack
         Send report via Slack
 ```
+
+## How to read a report
+
+### Example
+
+```
+$ vuls report -format-full-text
+
+172-31-4-82 (amazon 2015.09)
+============================
+Total: 94 (High:19 Medium:54 Low:7 ?:14)        103 updatable packages
+
+CVE-2016-5636
+-------------
+Score           10.0 (High)
+Vector          (AV:N/AC:L/Au:N/C:C/I:C/A:C)
+Summary         Integer overflow in the get_data function in zipimport.c in CPython (aka Python)
+                before 2.7.12, 3.x before 3.4.5, and 3.5.x before 3.5.2 allows remote attackers
+                to have unspecified impact via a negative data size value, which triggers a
+                heap-based buffer overflow.
+CWE             https://cwe.mitre.org/data/definitions/190.html
+NVD             https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-5636
+MITRE           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5636
+CVE Details     http://www.cvedetails.com/cve/CVE-2016-5636
+CVSS Claculator https://nvd.nist.gov/cvss/v2-calculator?name=CVE-2016-5636&vector=(AV:N/AC:L/...
+RHEL-CVE        https://access.redhat.com/security/cve/CVE-2016-5636
+ALAS-2016-724   https://alas.aws.amazon.com/ALAS-2016-724.html
+Package         python27-2.7.10-4.119.amzn1 -> python27-2.7.12-2.120.amzn1
+                python27-devel-2.7.10-4.119.amzn1 -> python27-devel-2.7.12-2.120.amzn1
+                python27-libs-2.7.10-4.119.amzn1 -> python27-libs-2.7.12-2.120.amzn1
+Confidence      100 / YumUpdateSecurityMatch
+
+... snip ...
+```
+
+### Summary part
+
+```
+172-31-4-82 (amazon 2015.09)
+============================
+Total: 94 (High:19 Medium:54 Low:7 ?:14)        103 updatable packages
+```
+
+- `172-31-4-82` means that it is a scan report of `servers.172-31-4-82` defined in cocnfig.toml.
+- `(amazon 2015.09)` means that the version of the OS is Amazon Linux 2015.09.
+- `Total: 94 (High:19 Medium:54 Low:7 ?:14)` means that a total of 94 vulnerabilities exist, and the distribution of CVSS Severity is displayed.
+- `103 updatable packages` means that there are 103 updateable packages on the target server.
+
+### Detailed Part
+
+```
+CVE-2016-5636
+-------------
+Score           10.0 (High)
+Vector          (AV:N/AC:L/Au:N/C:C/I:C/A:C)
+Summary         Integer overflow in the get_data function in zipimport.c in CPython (aka Python)
+                before 2.7.12, 3.x before 3.4.5, and 3.5.x before 3.5.2 allows remote attackers
+                to have unspecified impact via a negative data size value, which triggers a
+                heap-based buffer overflow.
+CWE             https://cwe.mitre.org/data/definitions/190.html
+NVD             https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-5636
+MITRE           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5636
+CVE Details     http://www.cvedetails.com/cve/CVE-2016-5636
+CVSS Claculator https://nvd.nist.gov/cvss/v2-calculator?name=CVE-2016-5636&vector=(AV:N/AC:L/...
+RHEL-CVE        https://access.redhat.com/security/cve/CVE-2016-5636
+ALAS-2016-724   https://alas.aws.amazon.com/ALAS-2016-724.html
+Package         python27-2.7.10-4.119.amzn1 -> python27-2.7.12-2.120.amzn1
+                python27-devel-2.7.10-4.119.amzn1 -> python27-devel-2.7.12-2.120.amzn1
+                python27-libs-2.7.10-4.119.amzn1 -> python27-libs-2.7.12-2.120.amzn1
+Confidence      100 / YumUpdateSecurityMatch
+```
+
+- `Score` means CVSS Score.
+- `Vector` means [CVSS Vector](https://nvd.nist.gov/CVSS/Vector-v2.aspx)
+- `Summary` means Summary of the CVE.
+- `CWE` means [CWE - Common Weakness Enumeration](https://nvd.nist.gov/cwe.cfm) of the CVE.
+- `NVD` `MITRE` `CVE Details` `CVSS Caluculator`
+- `RHEL-CVE` means the URL of OS distributor support.
+- `Package` shows the package version information including this vulnerability.
+- `Confidence` means the reliability of detection.
+  - `100` is highly reliable
+  - `YumUpdateSecurityMatch` is the method of detecting this vulnerability.
+- Item list of `Confidence`
+  | Detection Method       | Confidence         |  OS                              |Description|
+  |:-----------------------|-------------------:|:---------------------------------|:--|
+  | YumUpdateSecurityMatch | 100                |               RHEL, Amazon Linux |Detection using yum-plugin-security|
+  | ChangelogExactMatch    | 95                 | CentOS, Ubuntu, Debian, Raspbian |Exact version match between changelog and package version|
+  | ChangelogLenientMatch  | 50                 |         Ubuntu, Debian, Raspbian |Lenient version match between changelog and package version| 
+  | PkgAuditMatch          | 100                |                          FreeBSD |Detection using pkg audit|
+  | CpeNameMatch           | 100                |                              All |Search for NVD information with CPE name specified in config.toml|
+
 
 ## Example: Send scan results to Slack
 ```

--- a/README.md
+++ b/README.md
@@ -254,15 +254,16 @@ $ vuls report -format-short-text
 ===========================
 Total: 94 (High:19 Medium:54 Low:7 ?:14)        103 updatable packages
 
-CVE-2016-0705   10.0 (High)     Double free vulnerability in the dsa_priv_decode function in
-                                crypto/dsa/dsa_ameth.c in OpenSSL 1.0.1 before 1.0.1s and 1.0.2 before 1.0.2g
-                                allows remote attackers to cause a denial of service (memory corruption) or
-                                possibly have unspecified other impact via a malformed DSA private key.
-                                http://www.cvedetails.com/cve/CVE-2016-0705
-                                http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-0705
-                                libssl1.0.0-1.0.2f-2ubuntu1 -> libssl1.0.0-1.0.2g-1ubuntu4.5
-                                openssl-1.0.2f-2ubuntu1 -> openssl-1.0.2g-1ubuntu4.5
-
+CVE-2016-5636           10.0 (High)     Integer overflow in the get_data function in zipimport.c in CPython (aka Python)
+                                        before 2.7.12, 3.x before 3.4.5, and 3.5.x before 3.5.2 allows remote attackers
+                                        to have unspecified impact via a negative data size value, which triggers a
+                                        heap-based buffer overflow.
+                                        http://www.cvedetails.com/cve/CVE-2016-5636
+                                        https://access.redhat.com/security/cve/CVE-2016-5636
+                                        python27-2.7.10-4.119.amzn1 -> python27-2.7.12-2.120.amzn1
+                                        python27-devel-2.7.10-4.119.amzn1 -> python27-devel-2.7.12-2.120.amzn1
+                                        python27-libs-2.7.10-4.119.amzn1 -> python27-libs-2.7.12-2.120.amzn1
+                                        Candidate: 100 / YumUpdateSecurityMatch
 ... snip ...
 ````
 
@@ -275,23 +276,25 @@ $ vuls report -format-full-text
 ============================
 Total: 94 (High:19 Medium:54 Low:7 ?:14)        103 updatable packages
 
-
-CVE-2016-0705
+CVE-2016-5636
 -------------
 Score           10.0 (High)
 Vector          (AV:N/AC:L/Au:N/C:C/I:C/A:C)
-Summary         Double free vulnerability in the dsa_priv_decode function in
-                crypto/dsa/dsa_ameth.c in OpenSSL 1.0.1 before 1.0.1s and 1.0.2 before 1.0.2g
-                allows remote attackers to cause a denial of service (memory corruption) or
-                possibly have unspecified other impact via a malformed DSA private key.
-CWE             https://cwe.mitre.org/data/definitions/.html
-NVD             https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-0705
-MITRE           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0705
-CVE Details     http://www.cvedetails.com/cve/CVE-2016-0705
-CVSS Claculator https://nvd.nist.gov/cvss/v2-calculator?name=CVE-2016-0705&vector=(AV:N/AC:L/...
-Ubuntu-CVE      http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-0705
-Package         libssl1.0.0-1.0.2f-2ubuntu1 -> libssl1.0.0-1.0.2g-1ubuntu4.5
-                openssl-1.0.2f-2ubuntu1 -> openssl-1.0.2g-1ubuntu4.5
+Summary         Integer overflow in the get_data function in zipimport.c in CPython (aka Python)
+                before 2.7.12, 3.x before 3.4.5, and 3.5.x before 3.5.2 allows remote attackers
+                to have unspecified impact via a negative data size value, which triggers a
+                heap-based buffer overflow.
+CWE             https://cwe.mitre.org/data/definitions/190.html
+NVD             https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-5636
+MITRE           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5636
+CVE Details     http://www.cvedetails.com/cve/CVE-2016-5636
+CVSS Claculator https://nvd.nist.gov/cvss/v2-calculator?name=CVE-2016-5636&vector=(AV:N/AC:L/...
+RHEL-CVE        https://access.redhat.com/security/cve/CVE-2016-5636
+ALAS-2016-724   https://alas.aws.amazon.com/ALAS-2016-724.html
+Package         python27-2.7.10-4.119.amzn1 -> python27-2.7.12-2.120.amzn1
+                python27-devel-2.7.10-4.119.amzn1 -> python27-devel-2.7.12-2.120.amzn1
+                python27-libs-2.7.10-4.119.amzn1 -> python27-libs-2.7.12-2.120.amzn1
+Confidence      100 / YumUpdateSecurityMatch
 
 ... snip ...
 ```
@@ -932,6 +935,96 @@ report:
   -to-slack
         Send report via Slack
 ```
+
+## How to read a report
+
+### Example
+
+```
+$ vuls report -format-full-text
+
+172-31-4-82 (amazon 2015.09)
+============================
+Total: 94 (High:19 Medium:54 Low:7 ?:14)        103 updatable packages
+
+CVE-2016-5636
+-------------
+Score           10.0 (High)
+Vector          (AV:N/AC:L/Au:N/C:C/I:C/A:C)
+Summary         Integer overflow in the get_data function in zipimport.c in CPython (aka Python)
+                before 2.7.12, 3.x before 3.4.5, and 3.5.x before 3.5.2 allows remote attackers
+                to have unspecified impact via a negative data size value, which triggers a
+                heap-based buffer overflow.
+CWE             https://cwe.mitre.org/data/definitions/190.html
+NVD             https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-5636
+MITRE           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5636
+CVE Details     http://www.cvedetails.com/cve/CVE-2016-5636
+CVSS Claculator https://nvd.nist.gov/cvss/v2-calculator?name=CVE-2016-5636&vector=(AV:N/AC:L/...
+RHEL-CVE        https://access.redhat.com/security/cve/CVE-2016-5636
+ALAS-2016-724   https://alas.aws.amazon.com/ALAS-2016-724.html
+Package         python27-2.7.10-4.119.amzn1 -> python27-2.7.12-2.120.amzn1
+                python27-devel-2.7.10-4.119.amzn1 -> python27-devel-2.7.12-2.120.amzn1
+                python27-libs-2.7.10-4.119.amzn1 -> python27-libs-2.7.12-2.120.amzn1
+Confidence      100 / YumUpdateSecurityMatch
+
+... snip ...
+```
+
+### Summary part
+
+```
+172-31-4-82 (amazon 2015.09)
+============================
+Total: 94 (High:19 Medium:54 Low:7 ?:14)        103 updatable packages
+```
+
+- `172-31-4-82` means that it is a scan report of `servers.172-31-4-82` defined in cocnfig.toml.
+- `(amazon 2015.09)` means that the version of the OS is Amazon Linux 2015.09.
+- `Total: 94 (High:19 Medium:54 Low:7 ?:14)` means that a total of 94 vulnerabilities exist, and the distribution of CVSS Severity is displayed.
+- `103 updatable packages` means that there are 103 updateable packages on the target server.
+
+### Detailed Part
+
+```
+CVE-2016-5636
+-------------
+Score           10.0 (High)
+Vector          (AV:N/AC:L/Au:N/C:C/I:C/A:C)
+Summary         Integer overflow in the get_data function in zipimport.c in CPython (aka Python)
+                before 2.7.12, 3.x before 3.4.5, and 3.5.x before 3.5.2 allows remote attackers
+                to have unspecified impact via a negative data size value, which triggers a
+                heap-based buffer overflow.
+CWE             https://cwe.mitre.org/data/definitions/190.html
+NVD             https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-5636
+MITRE           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5636
+CVE Details     http://www.cvedetails.com/cve/CVE-2016-5636
+CVSS Claculator https://nvd.nist.gov/cvss/v2-calculator?name=CVE-2016-5636&vector=(AV:N/AC:L/...
+RHEL-CVE        https://access.redhat.com/security/cve/CVE-2016-5636
+ALAS-2016-724   https://alas.aws.amazon.com/ALAS-2016-724.html
+Package         python27-2.7.10-4.119.amzn1 -> python27-2.7.12-2.120.amzn1
+                python27-devel-2.7.10-4.119.amzn1 -> python27-devel-2.7.12-2.120.amzn1
+                python27-libs-2.7.10-4.119.amzn1 -> python27-libs-2.7.12-2.120.amzn1
+Confidence      100 / YumUpdateSecurityMatch
+```
+
+- `Score` means CVSS Score.
+- `Vector` means [CVSS Vector](https://nvd.nist.gov/CVSS/Vector-v2.aspx)
+- `Summary` means Summary of the CVE.
+- `CWE` means [CWE - Common Weakness Enumeration](https://nvd.nist.gov/cwe.cfm) of the CVE.
+- `NVD` `MITRE` `CVE Details` `CVSS Caluculator`
+- `RHEL-CVE` means the URL of OS distributor support.
+- `Package` shows the package version information including this vulnerability.
+- `Confidence` means the reliability of detection.
+  - `100` is highly reliable
+  - `YumUpdateSecurityMatch` is the method of detecting this vulnerability.
+- Item list of `Confidence`
+  | Detection Method       | Confidence         |  OS                              |Description|
+  |:-----------------------|-------------------:|:---------------------------------|:--|
+  | YumUpdateSecurityMatch | 100                |               RHEL, Amazon Linux |Detection using yum-plugin-security|
+  | ChangelogExactMatch    | 95                 | CentOS, Ubuntu, Debian, Raspbian |Exact version match between changelog and package version|
+  | ChangelogLenientMatch  | 50                 |         Ubuntu, Debian, Raspbian |Lenient version match between changelog and package version| 
+  | PkgAuditMatch          | 100                |                          FreeBSD |Detection using pkg audit|
+  | CpeNameMatch           | 100                |                              All |Search for NVD information with CPE name specified in config.toml|
 
 ## Example: Send scan results to Slack
 ```

--- a/commands/report.go
+++ b/commands/report.go
@@ -368,6 +368,7 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 		util.Log.Error(err)
 		return subcommands.ExitFailure
 	}
+	util.Log.Infof("Loaded: %s", jsonDir)
 
 	var results []models.ScanResult
 	for _, r := range history.ScanResults {

--- a/commands/util.go
+++ b/commands/util.go
@@ -200,11 +200,13 @@ func scanVulnByCpeNames(cpeNames []string, scannedVulns []models.VulnInfo) ([]mo
 				names := val.CpeNames
 				names = util.AppendIfMissing(names, name)
 				val.CpeNames = names
+				val.Confidence = models.CpeNameMatch
 				set[detail.CveID] = val
 			} else {
 				v := models.VulnInfo{
-					CveID:    detail.CveID,
-					CpeNames: []string{name},
+					CveID:      detail.CveID,
+					CpeNames:   []string{name},
+					Confidence: models.CpeNameMatch,
 				}
 				v.NilSliceToEmpty()
 				set[detail.CveID] = v

--- a/models/models.go
+++ b/models/models.go
@@ -239,12 +239,39 @@ type NWLink struct {
 	LinkState string
 }
 
+// Confidence is a ranking how confident the CVE-ID was deteted correctly
+// Score: 0 - 100
+type Confidence struct {
+	Score           int
+	DetectionMethod string
+}
+
+func (c Confidence) String() string {
+	return fmt.Sprintf("%d / %s", c.Score, c.DetectionMethod)
+}
+
+// CpeNameMatch is a ranking how confident the CVE-ID was deteted correctly
+var CpeNameMatch = Confidence{100, "CpeNameMatch"}
+
+// YumUpdateSecurityMatch is a ranking how confident the CVE-ID was deteted correctly
+var YumUpdateSecurityMatch = Confidence{100, "YumUpdateSecurityMatch"}
+
+// PkgAuditMatch is a ranking how confident the CVE-ID was deteted correctly
+var PkgAuditMatch = Confidence{100, "PkgAuditMatch"}
+
+// ChangelogExactMatch is a ranking how confident the CVE-ID was deteted correctly
+var ChangelogExactMatch = Confidence{95, "ChangelogExactMatch"}
+
+// ChangelogLenientMatch is a ranking how confident the CVE-ID was deteted correctly
+var ChangelogLenientMatch = Confidence{50, "ChangelogLenientMatch"}
+
 // VulnInfos is VulnInfo list, getter/setter, sortable methods.
 type VulnInfos []VulnInfo
 
 // VulnInfo holds a vulnerability information and unsecure packages
 type VulnInfo struct {
 	CveID            string
+	Confidence       Confidence
 	Packages         PackageInfoList
 	DistroAdvisories []DistroAdvisory // for Aamazon, RHEL, FreeBSD
 	CpeNames         []string

--- a/report/slack.go
+++ b/report/slack.go
@@ -221,36 +221,38 @@ func color(cvssScore float64) string {
 }
 
 func attachmentText(cveInfo models.CveInfo, osFamily string) string {
-
 	linkText := links(cveInfo, osFamily)
-
 	switch {
 	case config.Conf.Lang == "ja" &&
 		0 < cveInfo.CveDetail.Jvn.CvssScore():
 
 		jvn := cveInfo.CveDetail.Jvn
-		return fmt.Sprintf("*%4.1f (%s)* <%s|%s>\n%s\n%s",
+		return fmt.Sprintf("*%4.1f (%s)* <%s|%s>\n%s\n%s\n*Confidence:* %v",
 			cveInfo.CveDetail.CvssScore(config.Conf.Lang),
 			jvn.CvssSeverity(),
-			fmt.Sprintf(cvssV2CalcURLTemplate, cveInfo.CveDetail.CveID, jvn.CvssVector()),
+			fmt.Sprintf(cvssV2CalcURLTemplate,
+				cveInfo.CveDetail.CveID, jvn.CvssVector()),
 			jvn.CvssVector(),
 			jvn.CveTitle(),
 			linkText,
+			cveInfo.VulnInfo.Confidence,
 		)
-
 	case 0 < cveInfo.CveDetail.CvssScore("en"):
 		nvd := cveInfo.CveDetail.Nvd
-		return fmt.Sprintf("*%4.1f (%s)* <%s|%s>\n%s\n%s",
+		return fmt.Sprintf("*%4.1f (%s)* <%s|%s>\n%s\n%s\n*Confidence:* %v",
 			cveInfo.CveDetail.CvssScore(config.Conf.Lang),
 			nvd.CvssSeverity(),
-			fmt.Sprintf(cvssV2CalcURLTemplate, cveInfo.CveDetail.CveID, nvd.CvssVector()),
+			fmt.Sprintf(cvssV2CalcURLTemplate,
+				cveInfo.CveDetail.CveID, nvd.CvssVector()),
 			nvd.CvssVector(),
 			nvd.CveSummary(),
 			linkText,
+			cveInfo.VulnInfo.Confidence,
 		)
 	default:
 		nvd := cveInfo.CveDetail.Nvd
-		return fmt.Sprintf("?\n%s\n%s", nvd.CveSummary(), linkText)
+		return fmt.Sprintf("?\n%s\n%s\n*Confidence:* %v",
+			nvd.CveSummary(), linkText, cveInfo.VulnInfo.Confidence)
 	}
 }
 

--- a/report/tui.go
+++ b/report/tui.go
@@ -569,11 +569,9 @@ func summaryLines() string {
 			cols = []string{
 				fmt.Sprintf(indexFormat, i+1),
 				d.CveDetail.CveID,
-				fmt.Sprintf("|  %-4.1f(%s)",
-					d.CveDetail.CvssScore(config.Conf.Lang),
-					d.CveDetail.Jvn.CvssSeverity(),
-				),
-				//  strings.Join(packs, ","),
+				fmt.Sprintf("| %4.1f",
+					d.CveDetail.CvssScore(config.Conf.Lang)),
+				fmt.Sprintf("| %3d |", d.VulnInfo.Confidence.Score),
 				summary,
 			}
 		} else {
@@ -581,18 +579,17 @@ func summaryLines() string {
 
 			var cvssScore string
 			if d.CveDetail.CvssScore("en") <= 0 {
-				cvssScore = "| ?"
+				cvssScore = "|   ?"
 			} else {
-				cvssScore = fmt.Sprintf("| %-4.1f(%s)",
-					d.CveDetail.CvssScore(config.Conf.Lang),
-					d.CveDetail.Nvd.CvssSeverity(),
-				)
+				cvssScore = fmt.Sprintf("| %4.1f",
+					d.CveDetail.CvssScore(config.Conf.Lang))
 			}
 
 			cols = []string{
 				fmt.Sprintf(indexFormat, i+1),
 				d.CveDetail.CveID,
 				cvssScore,
+				fmt.Sprintf("| %3d |", d.VulnInfo.Confidence.Score),
 				summary,
 			}
 		}
@@ -644,6 +641,7 @@ type dataForTmpl struct {
 	CvssVector       string
 	CvssSeverity     string
 	Summary          string
+	Confidence       models.Confidence
 	CweURL           string
 	VulnSiteLinks    []string
 	References       []cve.Reference
@@ -723,6 +721,7 @@ func detailLines() (string, error) {
 		CvssSeverity:  cvssSeverity,
 		CvssVector:    cvssVector,
 		Summary:       summary,
+		Confidence:    cveInfo.VulnInfo.Confidence,
 		CweURL:        cweURL,
 		VulnSiteLinks: links,
 		References:    refs,
@@ -752,6 +751,11 @@ Summary
 --------------
 
  {{.Summary }}
+
+Confidence
+--------------
+
+ {{.Confidence }}
 
 CWE
 --------------

--- a/report/util.go
+++ b/report/util.go
@@ -128,11 +128,12 @@ No CVE-IDs are found in updatable packages.
 		switch {
 		case config.Conf.Lang == "ja" &&
 			0 < d.CveDetail.Jvn.CvssScore():
-			summary := fmt.Sprintf("%s\n%s\n%s\n%s",
+			summary := fmt.Sprintf("%s\n%s\n%s\n%sCandidate: %v",
 				d.CveDetail.Jvn.CveTitle(),
 				d.CveDetail.Jvn.Link(),
 				distroLinks(d, r.Family)[0].url,
 				packsVer,
+				d.VulnInfo.Confidence,
 			)
 			scols = []string{
 				d.CveDetail.CveID,
@@ -144,12 +145,13 @@ No CVE-IDs are found in updatable packages.
 			}
 
 		case 0 < d.CveDetail.CvssScore("en"):
-			summary := fmt.Sprintf("%s\n%s/%s\n%s\n%s",
+			summary := fmt.Sprintf("%s\n%s/%s\n%s\n%sCandidate: %v",
 				d.CveDetail.Nvd.CveSummary(),
 				cveDetailsBaseURL,
 				d.CveDetail.CveID,
 				distroLinks(d, r.Family)[0].url,
 				packsVer,
+				d.VulnInfo.Confidence,
 			)
 			scols = []string{
 				d.CveDetail.CveID,
@@ -160,8 +162,8 @@ No CVE-IDs are found in updatable packages.
 				summary,
 			}
 		default:
-			summary := fmt.Sprintf("%s\n%s",
-				distroLinks(d, r.Family)[0].url, packsVer)
+			summary := fmt.Sprintf("%s\n%sCandidate: %v",
+				distroLinks(d, r.Family)[0].url, packsVer, d.VulnInfo.Confidence)
 			scols = []string{
 				d.CveDetail.CveID,
 				"?",
@@ -277,6 +279,7 @@ func toPlainTextUnknownCve(cveInfo models.CveInfo, osFamily string) string {
 	}
 	dtable = addPackageInfos(dtable, cveInfo.Packages)
 	dtable = addCpeNames(dtable, cveInfo.CpeNames)
+	dtable.AddRow("Confidence", cveInfo.VulnInfo.Confidence)
 
 	return fmt.Sprintf("%s", dtable)
 }
@@ -319,6 +322,7 @@ func toPlainTextDetailsLangJa(cveInfo models.CveInfo, osFamily string) string {
 
 	dtable = addPackageInfos(dtable, cveInfo.Packages)
 	dtable = addCpeNames(dtable, cveInfo.CpeNames)
+	dtable.AddRow("Confidence", cveInfo.VulnInfo.Confidence)
 
 	return fmt.Sprintf("%s", dtable)
 }
@@ -359,6 +363,7 @@ func toPlainTextDetailsLangEn(d models.CveInfo, osFamily string) string {
 	}
 	dtable = addPackageInfos(dtable, d.Packages)
 	dtable = addCpeNames(dtable, d.CpeNames)
+	dtable.AddRow("Confidence", d.VulnInfo.Confidence)
 
 	return fmt.Sprintf("%s\n", dtable)
 }

--- a/scan/freebsd.go
+++ b/scan/freebsd.go
@@ -167,6 +167,7 @@ func (o *bsd) scanUnsecurePackages() (vulnInfos []models.VulnInfo, err error) {
 			CveID:            k,
 			Packages:         packs,
 			DistroAdvisories: disAdvs,
+			Confidence:       models.PkgAuditMatch,
 		})
 	}
 	return

--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -352,8 +352,9 @@ func (o *redhat) scanUnsecurePackagesUsingYumCheckUpdate() (models.VulnInfos, er
 	for k, v := range cveIDPackInfoMap {
 		// Amazon, RHEL do not use this method, so VendorAdvisory do not set.
 		vinfos = append(vinfos, models.VulnInfo{
-			CveID:    k,
-			Packages: v,
+			CveID:      k,
+			Packages:   v,
+			Confidence: models.ChangelogExactMatch,
 		})
 	}
 	return vinfos, nil
@@ -670,6 +671,7 @@ func (o *redhat) scanUnsecurePackagesUsingYumPluginSecurity() (models.VulnInfos,
 					CveID:            cveID,
 					DistroAdvisories: []models.DistroAdvisory{advIDCveIDs.DistroAdvisory},
 					Packages:         dict[advIDCveIDs.DistroAdvisory.AdvisoryID],
+					Confidence:       models.YumUpdateSecurityMatch,
 				}
 				vinfos = append(vinfos, cpinfo)
 			}


### PR DESCRIPTION
Added an item called Confidence to the report. 
Describe the description in README.md.

### Detailed Part

```
CVE-2016-5636
-------------
Score           10.0 (High)
Vector          (AV:N/AC:L/Au:N/C:C/I:C/A:C)
Summary         Integer overflow in the get_data function in zipimport.c in CPython (aka Python)
                before 2.7.12, 3.x before 3.4.5, and 3.5.x before 3.5.2 allows remote attackers
                to have unspecified impact via a negative data size value, which triggers a
                heap-based buffer overflow.
CWE             https://cwe.mitre.org/data/definitions/190.html
NVD             https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-5636
MITRE           https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5636
CVE Details     http://www.cvedetails.com/cve/CVE-2016-5636
CVSS Claculator https://nvd.nist.gov/cvss/v2-calculator?name=CVE-2016-5636&vector=(AV:N/AC:L/...
RHEL-CVE        https://access.redhat.com/security/cve/CVE-2016-5636
ALAS-2016-724   https://alas.aws.amazon.com/ALAS-2016-724.html
Package         python27-2.7.10-4.119.amzn1 -> python27-2.7.12-2.120.amzn1
                python27-devel-2.7.10-4.119.amzn1 -> python27-devel-2.7.12-2.120.amzn1
                python27-libs-2.7.10-4.119.amzn1 -> python27-libs-2.7.12-2.120.amzn1
Confidence      100 / YumUpdateSecurityMatch
```

- `Score` means CVSS Score.
- `Vector` means [CVSS Vector](https://nvd.nist.gov/CVSS/Vector-v2.aspx)
- `Summary` means Summary of the CVE.
- `CWE` means [CWE - Common Weakness Enumeration](https://nvd.nist.gov/cwe.cfm) of the CVE.
- `NVD` `MITRE` `CVE Details` `CVSS Caluculator`
- `RHEL-CVE` means the URL of OS distributor support.
- `Package` shows the package version information including this vulnerability.
- `Confidence` means the reliability of detection.
  - `100` is highly reliable
  - `YumUpdateSecurityMatch` is the method of detecting this vulnerability.
- Item list of `Confidence`

  | Detection Method       | Confidence         |  OS                              |Description|
  |:-----------------------|-------------------:|:---------------------------------|:--|
  | YumUpdateSecurityMatch | 100                |               RHEL, Amazon Linux |Detection using yum-plugin-security|
  | ChangelogExactMatch    | 95                 | CentOS, Ubuntu, Debian, Raspbian |Exact version match between changelog and package version|
  | ChangelogLenientMatch  | 50                 |         Ubuntu, Debian, Raspbian |Lenient version match between changelog and package version| 
  | PkgAuditMatch          | 100                |                          FreeBSD |Detection using pkg audit|
  | CpeNameMatch           | 100                |                              All |Search for NVD information with CPE name specified in config.toml|


# TODO 
- [x] debain/ubuntu/Raspbian
- [x] CpeNames
- [x] CentOS
- [x] Amazon/RHEL
- [x] TUI
- [x] Email
- [x] Text
- [x] Slack
- [x] Testcase
- [x] README

## What did you implement:

#327

## Todos:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below
