### PR TITLE
Output changelog in report, TUI and JSON for Ubuntu/Debian/CentOS

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1022,6 +1022,27 @@ Confidence      100 / YumUpdateSecurityMatch
   | CpeNameMatch           | 100                |                              All |Search for NVD information with CPE name specified in config.toml|
 
 
+### Changelog Part
+
+The scan results of Ubuntu, Debian, Raspbian or CentOS are also output Changelog in TUI or report with -format-full-text.
+(RHEL, Amazon or FreeBSD will be available in the near future)
+
+The output change log includes only the difference between the currently installed version and candidate version.
+
+```
+tar-1.28-2.1 -> tar-1.28-2.1ubuntu0.1
+-------------------------------------
+tar (1.28-2.1ubuntu0.1) xenial-security; urgency=medium
+
+  * SECURITY UPDATE: extract pathname bypass
+    - debian/patches/CVE-2016-6321.patch: skip members whose names contain
+      ".." in src/extract.c.
+    - CVE-2016-6321
+
+ -- Marc Deslauriers <marc.deslauriers@ubuntu.com>  Thu, 17 Nov 2016 11:06:07 -0500
+```
+
+
 ## Example: Send scan results to Slack
 ```
 $ vuls report \

--- a/README.md
+++ b/README.md
@@ -1028,6 +1028,27 @@ Confidence      100 / YumUpdateSecurityMatch
   | PkgAuditMatch          | 100                |                          FreeBSD |Detection using pkg audit|
   | CpeNameMatch           | 100                |                              All |Search for NVD information with CPE name specified in config.toml|
 
+
+### Changelog Part
+
+The scan results of Ubuntu, Debian, Raspbian or CentOS are also output Changelog in TUI or report with -format-full-text.
+(RHEL, Amazon or FreeBSD will be available in the near future)
+
+The output change log includes only the difference between the currently installed version and candidate version.
+
+```
+tar-1.28-2.1 -> tar-1.28-2.1ubuntu0.1
+-------------------------------------
+tar (1.28-2.1ubuntu0.1) xenial-security; urgency=medium
+
+  * SECURITY UPDATE: extract pathname bypass
+    - debian/patches/CVE-2016-6321.patch: skip members whose names contain
+      ".." in src/extract.c.
+    - CVE-2016-6321
+
+ -- Marc Deslauriers <marc.deslauriers@ubuntu.com>  Thu, 17 Nov 2016 11:06:07 -0500
+```
+
 ## Example: Send scan results to Slack
 ```
 $ vuls report \

--- a/models/models.go
+++ b/models/models.go
@@ -250,20 +250,43 @@ func (c Confidence) String() string {
 	return fmt.Sprintf("%d / %s", c.Score, c.DetectionMethod)
 }
 
+const (
+	// CpeNameMatchStr is a String representation of CpeNameMatch
+	CpeNameMatchStr = "CpeNameMatch"
+
+	// YumUpdateSecurityMatchStr is a String representation of YumUpdateSecurityMatch
+	YumUpdateSecurityMatchStr = "YumUpdateSecurityMatch"
+
+	// PkgAuditMatchStr is a String representation of PkgAuditMatch
+	PkgAuditMatchStr = "PkgAuditMatch"
+
+	// ChangelogExactMatchStr is a String representation of ChangelogExactMatch
+	ChangelogExactMatchStr = "ChangelogExactMatch"
+
+	// ChangelogLenientMatchStr is a String representation of ChangelogLenientMatch
+	ChangelogLenientMatchStr = "ChangelogLenientMatch"
+
+	// FailedToGetChangelog is a String representation of FailedToGetChangelog
+	FailedToGetChangelog = "FailedToGetChangelog"
+
+	// FailedToFindVersionInChangelog is a String representation of FailedToFindVersionInChangelog
+	FailedToFindVersionInChangelog = "FailedToFindVersionInChangelog"
+)
+
 // CpeNameMatch is a ranking how confident the CVE-ID was deteted correctly
-var CpeNameMatch = Confidence{100, "CpeNameMatch"}
+var CpeNameMatch = Confidence{100, CpeNameMatchStr}
 
 // YumUpdateSecurityMatch is a ranking how confident the CVE-ID was deteted correctly
-var YumUpdateSecurityMatch = Confidence{100, "YumUpdateSecurityMatch"}
+var YumUpdateSecurityMatch = Confidence{100, YumUpdateSecurityMatchStr}
 
 // PkgAuditMatch is a ranking how confident the CVE-ID was deteted correctly
-var PkgAuditMatch = Confidence{100, "PkgAuditMatch"}
+var PkgAuditMatch = Confidence{100, PkgAuditMatchStr}
 
 // ChangelogExactMatch is a ranking how confident the CVE-ID was deteted correctly
-var ChangelogExactMatch = Confidence{95, "ChangelogExactMatch"}
+var ChangelogExactMatch = Confidence{95, ChangelogExactMatchStr}
 
 // ChangelogLenientMatch is a ranking how confident the CVE-ID was deteted correctly
-var ChangelogLenientMatch = Confidence{50, "ChangelogLenientMatch"}
+var ChangelogLenientMatch = Confidence{50, ChangelogLenientMatchStr}
 
 // VulnInfos is VulnInfo list, getter/setter, sortable methods.
 type VulnInfos []VulnInfo
@@ -284,6 +307,9 @@ func (v *VulnInfo) NilSliceToEmpty() {
 	}
 	if v.DistroAdvisories == nil {
 		v.DistroAdvisories = []DistroAdvisory{}
+	}
+	if v.Packages == nil {
+		v.Packages = PackageInfoList{}
 	}
 }
 
@@ -466,6 +492,14 @@ type PackageInfo struct {
 	NewVersion string
 	NewRelease string
 	Repository string
+	Changelog  Changelog
+}
+
+// Changelog has contents of changelog and how to get it.
+// Method: modesl.detectionMethodStr
+type Changelog struct {
+	Contents string
+	Method   string
 }
 
 // ToStringCurrentVersion returns package name-version-release

--- a/report/azureblob.go
+++ b/report/azureblob.go
@@ -47,7 +47,7 @@ func (w AzureBlobWriter) Write(rs ...models.ScanResult) (err error) {
 	if c.Conf.FormatOneLineText {
 		timestr := rs[0].ScannedAt.Format(time.RFC3339)
 		k := fmt.Sprintf(timestr + "/summary.txt")
-		text := toOneLineSummary(rs...)
+		text := formatOneLineSummary(rs...)
 		b := []byte(text)
 		if err := createBlockBlob(cli, k, b); err != nil {
 			return err
@@ -69,7 +69,7 @@ func (w AzureBlobWriter) Write(rs ...models.ScanResult) (err error) {
 
 		if c.Conf.FormatShortText {
 			k := key + "_short.txt"
-			b := []byte(toShortPlainText(r))
+			b := []byte(formatShortPlainText(r))
 			if err := createBlockBlob(cli, k, b); err != nil {
 				return err
 			}
@@ -77,7 +77,7 @@ func (w AzureBlobWriter) Write(rs ...models.ScanResult) (err error) {
 
 		if c.Conf.FormatFullText {
 			k := key + "_full.txt"
-			b := []byte(toFullPlainText(r))
+			b := []byte(formatFullPlainText(r))
 			if err := createBlockBlob(cli, k, b); err != nil {
 				return err
 			}

--- a/report/email.go
+++ b/report/email.go
@@ -40,7 +40,7 @@ func (w EMailWriter) Write(rs ...models.ScanResult) (err error) {
 
 	for _, r := range rs {
 		if conf.FormatOneEMail {
-			message += toFullPlainText(r) + "\r\n\r\n"
+			message += formatFullPlainText(r) + "\r\n\r\n"
 			totalResult.KnownCves = append(totalResult.KnownCves, r.KnownCves...)
 			totalResult.UnknownCves = append(totalResult.UnknownCves, r.UnknownCves...)
 		} else {
@@ -52,7 +52,7 @@ func (w EMailWriter) Write(rs ...models.ScanResult) (err error) {
 				subject = fmt.Sprintf("%s%s %s",
 					conf.EMail.SubjectPrefix, r.ServerInfo(), r.CveSummary())
 			}
-			message = toFullPlainText(r)
+			message = formatFullPlainText(r)
 			if err := sender.Send(subject, message); err != nil {
 				return err
 			}
@@ -68,7 +68,7 @@ One Line Summary
 
 
 %s`,
-			toOneLineSummary(rs...), message)
+			formatOneLineSummary(rs...), message)
 
 		subject := fmt.Sprintf("%s %s",
 			conf.EMail.SubjectPrefix,

--- a/report/localfile.go
+++ b/report/localfile.go
@@ -38,7 +38,7 @@ type LocalFileWriter struct {
 func (w LocalFileWriter) Write(rs ...models.ScanResult) (err error) {
 	if c.Conf.FormatOneLineText {
 		path := filepath.Join(w.CurrentDir, "summary.txt")
-		text := toOneLineSummary(rs...)
+		text := formatOneLineSummary(rs...)
 		if err := writeFile(path, []byte(text), 0600); err != nil {
 			return fmt.Errorf(
 				"Failed to write to file. path: %s, err: %s",
@@ -63,7 +63,7 @@ func (w LocalFileWriter) Write(rs ...models.ScanResult) (err error) {
 		if c.Conf.FormatShortText {
 			p := path + "_short.txt"
 			if err := writeFile(
-				p, []byte(toShortPlainText(r)), 0600); err != nil {
+				p, []byte(formatShortPlainText(r)), 0600); err != nil {
 				return fmt.Errorf(
 					"Failed to write text files. path: %s, err: %s", p, err)
 			}
@@ -72,7 +72,7 @@ func (w LocalFileWriter) Write(rs ...models.ScanResult) (err error) {
 		if c.Conf.FormatFullText {
 			p := path + "_full.txt"
 			if err := writeFile(
-				p, []byte(toFullPlainText(r)), 0600); err != nil {
+				p, []byte(formatFullPlainText(r)), 0600); err != nil {
 				return fmt.Errorf(
 					"Failed to write text files. path: %s, err: %s", p, err)
 			}

--- a/report/s3.go
+++ b/report/s3.go
@@ -55,7 +55,7 @@ func (w S3Writer) Write(rs ...models.ScanResult) (err error) {
 	if c.Conf.FormatOneLineText {
 		timestr := rs[0].ScannedAt.Format(time.RFC3339)
 		k := fmt.Sprintf(timestr + "/summary.txt")
-		text := toOneLineSummary(rs...)
+		text := formatOneLineSummary(rs...)
 		if err := putObject(svc, k, []byte(text)); err != nil {
 			return err
 		}
@@ -76,7 +76,7 @@ func (w S3Writer) Write(rs ...models.ScanResult) (err error) {
 
 		if c.Conf.FormatShortText {
 			k := key + "_short.txt"
-			text := toShortPlainText(r)
+			text := formatShortPlainText(r)
 			if err := putObject(svc, k, []byte(text)); err != nil {
 				return err
 			}
@@ -84,7 +84,7 @@ func (w S3Writer) Write(rs ...models.ScanResult) (err error) {
 
 		if c.Conf.FormatFullText {
 			k := key + "_full.txt"
-			text := toFullPlainText(r)
+			text := formatFullPlainText(r)
 			if err := putObject(svc, k, []byte(text)); err != nil {
 				return err
 			}

--- a/report/stdout.go
+++ b/report/stdout.go
@@ -32,7 +32,7 @@ func (w StdoutWriter) WriteScanSummary(rs ...models.ScanResult) {
 	fmt.Printf("\n\n")
 	fmt.Println("One Line Summary")
 	fmt.Println("================")
-	fmt.Printf("%s\n", toScanSummary(rs...))
+	fmt.Printf("%s\n", formatScanSummary(rs...))
 }
 
 func (w StdoutWriter) Write(rs ...models.ScanResult) error {
@@ -40,19 +40,19 @@ func (w StdoutWriter) Write(rs ...models.ScanResult) error {
 		fmt.Print("\n\n")
 		fmt.Println("One Line Summary")
 		fmt.Println("================")
-		fmt.Println(toOneLineSummary(rs...))
+		fmt.Println(formatOneLineSummary(rs...))
 		fmt.Print("\n")
 	}
 
 	if c.Conf.FormatShortText {
 		for _, r := range rs {
-			fmt.Println(toShortPlainText(r))
+			fmt.Println(formatShortPlainText(r))
 		}
 	}
 
 	if c.Conf.FormatFullText {
 		for _, r := range rs {
-			fmt.Println(toFullPlainText(r))
+			fmt.Println(formatFullPlainText(r))
 		}
 	}
 	return nil

--- a/report/tui.go
+++ b/report/tui.go
@@ -133,6 +133,27 @@ func keybindings(g *gocui.Gui) (err error) {
 	errs = append(errs, g.SetKeybinding("detail", gocui.KeyCtrlP, gocui.ModNone, previousSummary))
 	errs = append(errs, g.SetKeybinding("detail", gocui.KeyEnter, gocui.ModNone, nextView))
 
+	// changelog
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyTab, gocui.ModNone, nextView))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyCtrlQ, gocui.ModNone, previousView))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyCtrlH, gocui.ModNone, nextView))
+	//  errs = append(errs, g.SetKeybinding("changelog", gocui.KeyCtrlL, gocui.ModNone, nextView))
+	//  errs = append(errs, g.SetKeybinding("changelog", gocui.KeyArrowUp, gocui.ModAlt, previousView))
+	//  errs = append(errs, g.SetKeybinding("changelog", gocui.KeyArrowLeft, gocui.ModAlt, nextView))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyArrowDown, gocui.ModNone, cursorDown))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyArrowUp, gocui.ModNone, cursorUp))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyCtrlJ, gocui.ModNone, cursorDown))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyCtrlK, gocui.ModNone, cursorUp))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyCtrlD, gocui.ModNone, cursorPageDown))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyCtrlU, gocui.ModNone, cursorPageUp))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeySpace, gocui.ModNone, cursorPageDown))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyBackspace, gocui.ModNone, cursorPageUp))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyBackspace2, gocui.ModNone, cursorPageUp))
+	//  errs = append(errs, g.SetKeybinding("changelog", gocui.KeyCtrlM, gocui.ModNone, cursorMoveMiddle))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyCtrlN, gocui.ModNone, nextSummary))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyCtrlP, gocui.ModNone, previousSummary))
+	errs = append(errs, g.SetKeybinding("changelog", gocui.KeyEnter, gocui.ModNone, nextView))
+
 	//  errs = append(errs, g.SetKeybinding("msg", gocui.KeyEnter, gocui.ModNone, delMsg))
 	//  errs = append(errs, g.SetKeybinding("detail", gocui.KeyEnter, gocui.ModNone, showMsg))
 
@@ -162,6 +183,8 @@ func nextView(g *gocui.Gui, v *gocui.View) error {
 	case "summary":
 		_, err = g.SetCurrentView("detail")
 	case "detail":
+		_, err = g.SetCurrentView("changelog")
+	case "changelog":
 		_, err = g.SetCurrentView("side")
 	default:
 		_, err = g.SetCurrentView("summary")
@@ -182,6 +205,8 @@ func previousView(g *gocui.Gui, v *gocui.View) error {
 		_, err = g.SetCurrentView("side")
 	case "detail":
 		_, err = g.SetCurrentView("summary")
+	case "changelog":
+		_, err = g.SetCurrentView("detail")
 	default:
 		_, err = g.SetCurrentView("side")
 	}
@@ -207,6 +232,11 @@ func movable(v *gocui.View, nextY int) (ok bool, yLimit int) {
 			return false, currentDetailLimitY
 		}
 		return true, currentDetailLimitY
+	case "changelog":
+		if currentDetailLimitY < nextY {
+			return false, currentDetailLimitY
+		}
+		return true, currentDetailLimitY
 	default:
 		return true, 0
 	}
@@ -217,7 +247,7 @@ func pageUpDownJumpCount(v *gocui.View) int {
 	switch v.Name() {
 	case "side", "summary":
 		jump = 8
-	case "detail":
+	case "detail", "changelog":
 		jump = 30
 	default:
 		jump = 8
@@ -230,6 +260,9 @@ func onMovingCursorRedrawView(g *gocui.Gui, v *gocui.View) error {
 	switch v.Name() {
 	case "summary":
 		if err := redrawDetail(g); err != nil {
+			return err
+		}
+		if err := redrawChangelog(g); err != nil {
 			return err
 		}
 	case "side":
@@ -395,6 +428,9 @@ func changeHost(g *gocui.Gui, v *gocui.View) error {
 	if err := g.DeleteView("detail"); err != nil {
 		return err
 	}
+	if err := g.DeleteView("changelog"); err != nil {
+		return err
+	}
 
 	_, cy := v.Cursor()
 	l, err := v.Line(cy)
@@ -416,6 +452,9 @@ func changeHost(g *gocui.Gui, v *gocui.View) error {
 	if err := setDetailLayout(g); err != nil {
 		return err
 	}
+	if err := setChangelogLayout(g); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -425,6 +464,17 @@ func redrawDetail(g *gocui.Gui) error {
 	}
 
 	if err := setDetailLayout(g); err != nil {
+		return err
+	}
+	return nil
+}
+
+func redrawChangelog(g *gocui.Gui) error {
+	if err := g.DeleteView("changelog"); err != nil {
+		return err
+	}
+
+	if err := setChangelogLayout(g); err != nil {
 		return err
 	}
 	return nil
@@ -498,12 +548,15 @@ func layout(g *gocui.Gui) error {
 	if err := setDetailLayout(g); err != nil {
 		return err
 	}
+	if err := setChangelogLayout(g); err != nil {
+		return err
+	}
 	return nil
 }
 
 func setSideLayout(g *gocui.Gui) error {
 	_, maxY := g.Size()
-	if v, err := g.SetView("side", -1, -1, 40, maxY); err != nil {
+	if v, err := g.SetView("side", -1, -1, 40, int(float64(maxY)*0.2)); err != nil {
 		if err != gocui.ErrUnknownView {
 			return err
 		}
@@ -614,18 +667,52 @@ func setDetailLayout(g *gocui.Gui) error {
 	_, oy := summaryView.Origin()
 	currentCveInfo = cy + oy
 
-	if v, err := g.SetView("detail", 40, int(float64(maxY)*0.2), maxX, maxY); err != nil {
+	if v, err := g.SetView("detail", -1, int(float64(maxY)*0.2), int(float64(maxX)*0.5), maxY); err != nil {
 		if err != gocui.ErrUnknownView {
 			return err
 		}
-		//  text := report.ToPlainTextDetailsLangEn(
-		//      currentScanResult.KnownCves[currentCveInfo],
-		//      currentScanResult.Family)
-
 		text, err := detailLines()
 		if err != nil {
 			return err
 		}
+		fmt.Fprint(v, text)
+		v.Editable = false
+		v.Wrap = true
+
+		currentDetailLimitY = len(strings.Split(text, "\n")) - 1
+	}
+	return nil
+}
+
+func setChangelogLayout(g *gocui.Gui) error {
+	maxX, maxY := g.Size()
+
+	summaryView, err := g.View("summary")
+	if err != nil {
+		return err
+	}
+	_, cy := summaryView.Cursor()
+	_, oy := summaryView.Origin()
+	currentCveInfo = cy + oy
+
+	if v, err := g.SetView("changelog", int(float64(maxX)*0.5), int(float64(maxY)*0.2), maxX, maxY); err != nil {
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+		if len(currentScanResult.Errors) != 0 || len(currentScanResult.AllCves()) == 0 {
+			return nil
+		}
+
+		lines := []string{}
+		cveInfo := currentScanResult.AllCves()[currentCveInfo]
+		for _, pack := range cveInfo.Packages {
+			for _, p := range currentScanResult.Packages {
+				if pack.Name == p.Name {
+					lines = append(lines, formatOneChangelog(p), "\n")
+				}
+			}
+		}
+		text := strings.Join(lines, "\n")
 		fmt.Fprint(v, text)
 		v.Editable = false
 		v.Wrap = true

--- a/scan/debian_test.go
+++ b/scan/debian_test.go
@@ -61,8 +61,9 @@ func TestParseScannedPackagesLineDebian(t *testing.T) {
 func TestGetCveIDParsingChangelog(t *testing.T) {
 
 	var tests = []struct {
-		in       []string
-		expected []DetectedCveID
+		in        []string
+		cveIDs    []DetectedCveID
+		changelog models.Changelog
 	}{
 		{
 			// verubuntu1
@@ -77,17 +78,24 @@ CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
 CVE-2015-3210: heap buffer overflow in pcre_compile2() /
 systemd (228-5) unstable; urgency=medium
 systemd (228-4) unstable; urgency=medium
-systemd (228-3) unstable; urgency=medium
-systemd (228-2) unstable; urgency=medium
-systemd (228-1) unstable; urgency=medium
-systemd (227-3) unstable; urgency=medium
-systemd (227-2) unstable; urgency=medium
-systemd (227-1) unstable; urgency=medium`,
+systemd (228-3) unstable; urgency=medium`,
 			},
 			[]DetectedCveID{
 				{"CVE-2015-2325", models.ChangelogExactMatch},
 				{"CVE-2015-2326", models.ChangelogExactMatch},
 				{"CVE-2015-3210", models.ChangelogExactMatch},
+			},
+			models.Changelog{
+				Contents: `systemd (229-2) unstable; urgency=medium
+systemd (229-1) unstable; urgency=medium
+systemd (228-6) unstable; urgency=medium
+CVE-2015-2325: heap buffer overflow in compile_branch(). (Closes: #781795)
+CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
+CVE-2015-3210: heap buffer overflow in pcre_compile2() /
+systemd (228-5) unstable; urgency=medium
+systemd (228-4) unstable; urgency=medium`,
+				//TODO
+				Method: models.ChangelogExactMatchStr,
 			},
 		},
 		{
@@ -96,21 +104,35 @@ systemd (227-1) unstable; urgency=medium`,
 				"libpcre3",
 				"2:8.35-7.1ubuntu1",
 				`pcre3 (2:8.38-2) unstable; urgency=low
-pcre3 (2:8.38-1) unstable; urgency=low
-pcre3 (2:8.35-8) unstable; urgency=low
-pcre3 (2:8.35-7.4) unstable; urgency=medium
-pcre3 (2:8.35-7.3) unstable; urgency=medium
-pcre3 (2:8.35-7.2) unstable; urgency=low
-CVE-2015-2325: heap buffer overflow in compile_branch(). (Closes: #781795)
-CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
-CVE-2015-3210: heap buffer overflow in pcre_compile2() /
-pcre3 (2:8.35-7.1) unstable; urgency=medium
-pcre3 (2:8.35-7) unstable; urgency=medium`,
+		 pcre3 (2:8.38-1) unstable; urgency=low
+		 pcre3 (2:8.35-8) unstable; urgency=low
+		 pcre3 (2:8.35-7.4) unstable; urgency=medium
+		 pcre3 (2:8.35-7.3) unstable; urgency=medium
+		 pcre3 (2:8.35-7.2) unstable; urgency=low
+		 CVE-2015-2325: heap buffer overflow in compile_branch(). (Closes: #781795)
+		 CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
+		 CVE-2015-3210: heap buffer overflow in pcre_compile2() /
+		 pcre3 (2:8.35-7.1) unstable; urgency=medium
+		 pcre3 (2:8.35-7) unstable; urgency=medium`,
 			},
 			[]DetectedCveID{
 				{"CVE-2015-2325", models.ChangelogExactMatch},
 				{"CVE-2015-2326", models.ChangelogExactMatch},
 				{"CVE-2015-3210", models.ChangelogExactMatch},
+			},
+			models.Changelog{
+				Contents: `pcre3 (2:8.38-2) unstable; urgency=low
+		 pcre3 (2:8.38-1) unstable; urgency=low
+		 pcre3 (2:8.35-8) unstable; urgency=low
+		 pcre3 (2:8.35-7.4) unstable; urgency=medium
+		 pcre3 (2:8.35-7.3) unstable; urgency=medium
+		 pcre3 (2:8.35-7.2) unstable; urgency=low
+		 CVE-2015-2325: heap buffer overflow in compile_branch(). (Closes: #781795)
+		 CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
+		 CVE-2015-3210: heap buffer overflow in pcre_compile2() /
+		 pcre3 (2:8.35-7.1) unstable; urgency=medium`,
+				//TODO
+				Method: models.ChangelogExactMatchStr,
 			},
 		},
 		{
@@ -119,29 +141,39 @@ pcre3 (2:8.35-7) unstable; urgency=medium`,
 				"sysvinit",
 				"2.88dsf-59.2ubuntu3",
 				`sysvinit (2.88dsf-59.3ubuntu1) xenial; urgency=low
-sysvinit (2.88dsf-59.3) unstable; urgency=medium
-CVE-2015-2325: heap buffer overflow in compile_branch(). (Closes: #781795)
-CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
-CVE-2015-3210: heap buffer overflow in pcre_compile2() /
-sysvinit (2.88dsf-59.2ubuntu3) xenial; urgency=medium
-sysvinit (2.88dsf-59.2ubuntu2) wily; urgency=medium
-sysvinit (2.88dsf-59.2ubuntu1) wily; urgency=medium
-CVE-2015-2321: heap buffer overflow in pcre_compile2(). (Closes: #783285)
-sysvinit (2.88dsf-59.2) unstable; urgency=medium
-sysvinit (2.88dsf-59.1ubuntu3) wily; urgency=medium
-CVE-2015-2322: heap buffer overflow in pcre_compile2(). (Closes: #783285)
-sysvinit (2.88dsf-59.1ubuntu2) wily; urgency=medium
-sysvinit (2.88dsf-59.1ubuntu1) wily; urgency=medium
-sysvinit (2.88dsf-59.1) unstable; urgency=medium
-CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
-sysvinit (2.88dsf-59) unstable; urgency=medium
-sysvinit (2.88dsf-58) unstable; urgency=low
-sysvinit (2.88dsf-57) unstable; urgency=low`,
+		 sysvinit (2.88dsf-59.3) unstable; urgency=medium
+		 CVE-2015-2325: heap buffer overflow in compile_branch(). (Closes: #781795)
+		 CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
+		 CVE-2015-3210: heap buffer overflow in pcre_compile2() /
+		 sysvinit (2.88dsf-59.2ubuntu3) xenial; urgency=medium
+		 sysvinit (2.88dsf-59.2ubuntu2) wily; urgency=medium
+		 sysvinit (2.88dsf-59.2ubuntu1) wily; urgency=medium
+		 CVE-2015-2321: heap buffer overflow in pcre_compile2(). (Closes: #783285)
+		 sysvinit (2.88dsf-59.2) unstable; urgency=medium
+		 sysvinit (2.88dsf-59.1ubuntu3) wily; urgency=medium
+		 CVE-2015-2322: heap buffer overflow in pcre_compile2(). (Closes: #783285)
+		 sysvinit (2.88dsf-59.1ubuntu2) wily; urgency=medium
+		 sysvinit (2.88dsf-59.1ubuntu1) wily; urgency=medium
+		 sysvinit (2.88dsf-59.1) unstable; urgency=medium
+		 CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
+		 sysvinit (2.88dsf-59) unstable; urgency=medium
+		 sysvinit (2.88dsf-58) unstable; urgency=low
+		 sysvinit (2.88dsf-57) unstable; urgency=low`,
 			},
 			[]DetectedCveID{
 				{"CVE-2015-2325", models.ChangelogExactMatch},
 				{"CVE-2015-2326", models.ChangelogExactMatch},
 				{"CVE-2015-3210", models.ChangelogExactMatch},
+			},
+			models.Changelog{
+				Contents: `sysvinit (2.88dsf-59.3ubuntu1) xenial; urgency=low
+		 sysvinit (2.88dsf-59.3) unstable; urgency=medium
+		 CVE-2015-2325: heap buffer overflow in compile_branch(). (Closes: #781795)
+		 CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
+		 CVE-2015-3210: heap buffer overflow in pcre_compile2() /
+		 sysvinit (2.88dsf-59.2ubuntu3) xenial; urgency=medium`,
+				//TODO
+				Method: models.ChangelogExactMatchStr,
 			},
 		},
 		{
@@ -149,38 +181,77 @@ sysvinit (2.88dsf-57) unstable; urgency=low`,
 			[]string{
 				"bsdutils",
 				"1:2.27.1-1ubuntu3",
-				` util-linux (2.27.1-3ubuntu1) xenial; urgency=medium
-util-linux (2.27.1-3) unstable; urgency=medium
-CVE-2015-2325: heap buffer overflow in compile_branch(). (Closes: #781795)
-CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
-CVE-2015-3210: CVE-2016-1000000heap buffer overflow in pcre_compile2() /
-util-linux (2.27.1-2) unstable; urgency=medium
-util-linux (2.27.1-1ubuntu4) xenial; urgency=medium
-util-linux (2.27.1-1ubuntu3) xenial; urgency=medium
-util-linux (2.27.1-1ubuntu2) xenial; urgency=medium
-util-linux (2.27.1-1ubuntu1) xenial; urgency=medium
-util-linux (2.27.1-1) unstable; urgency=medium
-util-linux (2.27-3ubuntu1) xenial; urgency=medium
-util-linux (2.27-3) unstable; urgency=medium
-util-linux (2.27-2) unstable; urgency=medium
-util-linux (2.27-1) unstable; urgency=medium
-util-linux (2.27~rc2-2) experimental; urgency=medium
-util-linux (2.27~rc2-1) experimental; urgency=medium
-util-linux (2.27~rc1-1) experimental; urgency=medium
-util-linux (2.26.2-9) unstable; urgency=medium
-util-linux (2.26.2-8) experimental; urgency=medium
-util-linux (2.26.2-7) experimental; urgency=medium
-util-linux (2.26.2-6ubuntu3) wily; urgency=medium
-CVE-2015-2329: heap buffer overflow in compile_branch(). (Closes: #781795)
-util-linux (2.26.2-6ubuntu2) wily; urgency=medium
-util-linux (2.26.2-6ubuntu1) wily; urgency=medium
-util-linux (2.26.2-6) unstable; urgency=medium`,
+				`util-linux (2.27.1-3ubuntu1) xenial; urgency=medium
+		 util-linux (2.27.1-3) unstable; urgency=medium
+		 CVE-2015-2325: heap buffer overflow in compile_branch(). (Closes: #781795)
+		 CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
+		 CVE-2015-3210: CVE-2016-1000000heap buffer overflow in pcre_compile2() /
+		 util-linux (2.27.1-2) unstable; urgency=medium
+		 util-linux (2.27.1-1ubuntu4) xenial; urgency=medium
+		 util-linux (2.27.1-1ubuntu3) xenial; urgency=medium
+		 util-linux (2.27.1-1ubuntu2) xenial; urgency=medium
+		 util-linux (2.27.1-1ubuntu1) xenial; urgency=medium
+		 util-linux (2.27.1-1) unstable; urgency=medium
+		 util-linux (2.27-3ubuntu1) xenial; urgency=medium`,
 			},
 			[]DetectedCveID{
 				{"CVE-2015-2325", models.ChangelogExactMatch},
 				{"CVE-2015-2326", models.ChangelogExactMatch},
 				{"CVE-2015-3210", models.ChangelogExactMatch},
 				{"CVE-2016-1000000", models.ChangelogExactMatch},
+			},
+			models.Changelog{
+				Contents: `util-linux (2.27.1-3ubuntu1) xenial; urgency=medium
+		 util-linux (2.27.1-3) unstable; urgency=medium
+		 CVE-2015-2325: heap buffer overflow in compile_branch(). (Closes: #781795)
+		 CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
+		 CVE-2015-3210: CVE-2016-1000000heap buffer overflow in pcre_compile2() /
+		 util-linux (2.27.1-2) unstable; urgency=medium
+		 util-linux (2.27.1-1ubuntu4) xenial; urgency=medium
+		 util-linux (2.27.1-1ubuntu3) xenial; urgency=medium`,
+				//TODO
+				Method: models.ChangelogExactMatchStr,
+			},
+		},
+		{
+			// 1:ver-ubuntu3
+			[]string{
+				"bsdutils",
+				"1:2.27-3ubuntu3",
+				`util-linux (2.27.1-3ubuntu1) xenial; urgency=medium
+		 util-linux (2.27.1-3) unstable; urgency=medium
+		 CVE-2015-2325: heap buffer overflow in compile_branch(). (Closes: #781795)
+		 CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
+		 CVE-2015-3210: CVE-2016-1000000heap buffer overflow in pcre_compile2() /
+		 util-linux (2.27.1-2) unstable; urgency=medium
+		 util-linux (2.27.1-1ubuntu4) xenial; urgency=medium
+		 util-linux (2.27.1-1ubuntu3) xenial; urgency=medium
+		 util-linux (2.27.1-1ubuntu2) xenial; urgency=medium
+		 util-linux (2.27.1-1ubuntu1) xenial; urgency=medium
+		 util-linux (2.27.1-1) unstable; urgency=medium
+		 util-linux (2.27-3) xenial; urgency=medium`,
+			},
+			[]DetectedCveID{
+				{"CVE-2015-2325", models.ChangelogExactMatch},
+				{"CVE-2015-2326", models.ChangelogExactMatch},
+				{"CVE-2015-3210", models.ChangelogExactMatch},
+				{"CVE-2016-1000000", models.ChangelogExactMatch},
+			},
+			models.Changelog{
+				Contents: `util-linux (2.27.1-3ubuntu1) xenial; urgency=medium
+		 util-linux (2.27.1-3) unstable; urgency=medium
+		 CVE-2015-2325: heap buffer overflow in compile_branch(). (Closes: #781795)
+		 CVE-2015-2326: heap buffer overflow in pcre_compile2(). (Closes: #783285)
+		 CVE-2015-3210: CVE-2016-1000000heap buffer overflow in pcre_compile2() /
+		 util-linux (2.27.1-2) unstable; urgency=medium
+		 util-linux (2.27.1-1ubuntu4) xenial; urgency=medium
+		 util-linux (2.27.1-1ubuntu3) xenial; urgency=medium
+		 util-linux (2.27.1-1ubuntu2) xenial; urgency=medium
+		 util-linux (2.27.1-1ubuntu1) xenial; urgency=medium
+		 util-linux (2.27.1-1) unstable; urgency=medium
+		 util-linux (2.27-3) xenial; urgency=medium`,
+				//TODO
+				Method: models.ChangelogExactMatchStr,
 			},
 		},
 		{
@@ -189,27 +260,41 @@ util-linux (2.26.2-6) unstable; urgency=medium`,
 				"tar",
 				"1.27.1-2+b1",
 				`tar (1.27.1-2+deb8u1) jessie-security; urgency=high
-  * CVE-2016-6321: Bypassing the extract path name.
-tar (1.27.1-2) unstable; urgency=low`,
+		   * CVE-2016-6321: Bypassing the extract path name.
+		 tar (1.27.1-2) unstable; urgency=low`,
 			},
 			[]DetectedCveID{
 				{"CVE-2016-6321", models.ChangelogLenientMatch},
+			},
+			models.Changelog{
+				Contents: `tar (1.27.1-2+deb8u1) jessie-security; urgency=high
+		   * CVE-2016-6321: Bypassing the extract path name.
+		 tar (1.27.1-2) unstable; urgency=low`,
+				Method: models.ChangelogLenientMatchStr,
 			},
 		},
 	}
 
 	d := newDebian(config.ServerInfo{})
 	for _, tt := range tests {
-		actual := d.getCveIDsFromChangelog(tt.in[2], tt.in[0], tt.in[1])
-		if len(actual) != len(tt.expected) {
-			t.Errorf("Len of return array are'nt same. expected %#v, actual %#v", tt.expected, actual)
+		aCveIDs, aClog := d.getCveIDsFromChangelog(tt.in[2], tt.in[0], tt.in[1])
+		if len(aCveIDs) != len(tt.cveIDs) {
+			t.Errorf("Len of return array are'nt same. expected %#v, actual %#v", tt.cveIDs, aCveIDs)
 			t.Errorf(pp.Sprintf("%s", tt.in))
 			continue
 		}
-		for i := range tt.expected {
-			if !reflect.DeepEqual(tt.expected[i], actual[i]) {
-				t.Errorf("expected %v, actual %v", tt.expected[i], actual[i])
+		for i := range tt.cveIDs {
+			if !reflect.DeepEqual(tt.cveIDs[i], aCveIDs[i]) {
+				t.Errorf("expected %v, actual %v", tt.cveIDs[i], aCveIDs[i])
 			}
+		}
+
+		if aClog.Contents != tt.changelog.Contents {
+			t.Errorf(pp.Sprintf("expected: %s, actual: %s", tt.changelog.Contents, aClog.Contents))
+		}
+
+		if aClog.Method != tt.changelog.Method {
+			t.Errorf(pp.Sprintf("expected: %s, actual: %s", tt.changelog.Method, aClog.Method))
 		}
 	}
 }

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -332,11 +332,14 @@ func decorateCmd(c conf.ServerInfo, cmd string, sudo bool) string {
 		cmd = strings.Replace(cmd, "sudo -S echo", "echo", -1)
 	}
 
-	if c.Distro.Family != "FreeBSD" {
-		// set pipefail option. Bash only
-		// http://unix.stackexchange.com/questions/14270/get-exit-status-of-process-thats-piped-to-another
-		cmd = fmt.Sprintf("set -o pipefail; %s", cmd)
-	}
+	// If you are using pipe and you want to detect preprocessing errors, remove comment out
+	//  switch c.Distro.Family {
+	//  case "FreeBSD", "ubuntu", "debian", "raspbian":
+	//  default:
+	//      // set pipefail option. Bash only
+	//      // http://unix.stackexchange.com/questions/14270/get-exit-status-of-process-thats-piped-to-another
+	//      cmd = fmt.Sprintf("set -o pipefail; %s", cmd)
+	//  }
 
 	if c.IsContainer() {
 		switch c.Container.Type {

--- a/scan/redhat_test.go
+++ b/scan/redhat_test.go
@@ -1071,7 +1071,7 @@ func TestGetChangelogCVELines(t *testing.T) {
 		Release: "6.7",
 	}
 	for _, tt := range testsCentos6 {
-		rpm2changelog, err := r.parseAllChangelog(stdoutCentos6)
+		rpm2changelog, err := r.divideChangelogByPackage(stdoutCentos6)
 		if err != nil {
 			t.Errorf("err: %s", err)
 		}
@@ -1157,7 +1157,7 @@ func TestGetChangelogCVELines(t *testing.T) {
 		Release: "5.6",
 	}
 	for _, tt := range testsCentos5 {
-		rpm2changelog, err := r.parseAllChangelog(stdoutCentos5)
+		rpm2changelog, err := r.divideChangelogByPackage(stdoutCentos5)
 		if err != nil {
 			t.Errorf("err: %s", err)
 		}


### PR DESCRIPTION
## What did you implement:

In case of updating vulnerable package, it is helpful to see a changelog information.
The output change log includes only the difference between the currently installed version and candidate version.

Closes #341 

**NOTE**
**Amazon/RHEL/FreeBSD will be implemented after abolition of prepare subcommand. #365**

## TODO
- [x] CentOS
- [x] Ubuntu/Raspbian
- [x] Debian
- [x] TUI
- [x] Email
- [x] Stdout
- [x] LocalFile
- [x] gzip
- [x] Output a detailed information to a TUI / Reporting / JSON package that does not have Changelog or failed version match in Changelog
- [x] README


## How did you implement it:


## How can we verify it:


## Todos:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** YES
remove cache.db
