### PR TITLE
remove unused import line.

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,8 +26,6 @@ import (
 
 	"github.com/future-architect/vuls/commands"
 	"github.com/google/subcommands"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 // Version of Vuls


### PR DESCRIPTION
## How did you implement it:

remove unused import line.
It was no longer necessary because access to gorm was limited to go-cve-dictionary library.

## How can we verify it:

compile & run vuls.
