### PR TITLE
Increase the width of RequestPty

### DIFF
--- a/scan/executil.go
+++ b/scan/executil.go
@@ -222,7 +222,7 @@ func sshExecNative(c conf.ServerInfo, cmd string, sudo bool) (result execResult)
 		ssh.TTY_OP_ISPEED: 14400, // input speed = 14.4kbaud
 		ssh.TTY_OP_OSPEED: 14400, // output speed = 14.4kbaud
 	}
-	if err = session.RequestPty("xterm", 400, 256, modes); err != nil {
+	if err = session.RequestPty("xterm", 400, 1000, modes); err != nil {
 		result.Error = fmt.Errorf(
 			"Failed to request for pseudo terminal. servername: %s, err: %s",
 			c.ServerName, err)


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/future-architect/vuls/issues/360

## How did you implement it:

Increase the width (256→1000)

## How can we verify it:

You need the multi-line changelog.
If the output of one line exceeds the specified width (256), it will start new line in the middle.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
