### PR TITLE
Change ssh option from -t to -tt

### DIFF
--- a/scan/executil.go
+++ b/scan/executil.go
@@ -258,7 +258,7 @@ func sshExecExternal(c conf.ServerInfo, cmd string, sudo bool) (result execResul
 	}
 
 	defaultSSHArgs := []string{
-		"-t",
+		"-tt",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "LogLevel=quiet",
@@ -285,7 +285,7 @@ func sshExecExternal(c conf.ServerInfo, cmd string, sudo bool) (result execResul
 	}
 
 	cmd = decorateCmd(c, cmd, sudo)
-	//  cmd = fmt.Sprintf("stty cols 256; set -o pipefail; %s", cmd)
+	cmd = fmt.Sprintf("stty cols 1000; %s", cmd)
 
 	args = append(args, cmd)
 	execCmd := ex.Command(sshBinaryPath, args...)


### PR DESCRIPTION
## What did you implement:

Closes https://github.com/future-architect/vuls/issues/359

## How did you implement it:

Change ssh option from `-t` to `-tt`.
If ssh has no local tty, `-tt` option should be used to force pseudo-terminal allocation.
```
$ man ssh
 -t      Force pseudo-terminal allocation.  This can be used to execute arbitrary screen-based programs on a remote machine, which can be very useful, e.g. when implementing menu services.Multiple -t options force tty allocation, even if ssh has no local tty.
```

## How can we verify it:

```
$ ./vuls scan -ssh-external
```

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
