### PR TITLE
Fix updatalbe packages count #373

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -445,16 +445,18 @@ func (ps PackageInfoList) MergeNewVersion(as PackageInfoList) {
 
 func (ps PackageInfoList) countUpdatablePacks() int {
 	count := 0
+	set := make(map[string]bool)
 	for _, p := range ps {
-		if len(p.NewVersion) != 0 {
+		if len(p.NewVersion) != 0 && !set[p.Name] {
 			count++
+			set[p.Name] = true
 		}
 	}
 	return count
 }
 
-// ToUpdatablePacksSummary returns a summary of updatable packages
-func (ps PackageInfoList) ToUpdatablePacksSummary() string {
+// FormatUpdatablePacksSummary returns a summary of updatable packages
+func (ps PackageInfoList) FormatUpdatablePacksSummary() string {
 	return fmt.Sprintf("%d updatable packages",
 		ps.countUpdatablePacks())
 }

--- a/report/util.go
+++ b/report/util.go
@@ -40,7 +40,7 @@ func formatScanSummary(rs ...models.ScanResult) string {
 				r.FormatServerName(),
 				fmt.Sprintf("%s%s", r.Family, r.Release),
 				fmt.Sprintf("%d CVEs", len(r.ScannedCves)),
-				r.Packages.ToUpdatablePacksSummary(),
+				r.Packages.FormatUpdatablePacksSummary(),
 			}
 		} else {
 			cols = []interface{}{
@@ -65,7 +65,7 @@ func formatOneLineSummary(rs ...models.ScanResult) string {
 			cols = []interface{}{
 				r.FormatServerName(),
 				r.CveSummary(),
-				r.Packages.ToUpdatablePacksSummary(),
+				r.Packages.FormatUpdatablePacksSummary(),
 			}
 		} else {
 			cols = []interface{}{
@@ -97,7 +97,7 @@ func formatShortPlainText(r models.ScanResult) string {
 		r.ServerInfo(),
 		buf.String(),
 		r.CveSummary(),
-		r.Packages.ToUpdatablePacksSummary(),
+		r.Packages.FormatUpdatablePacksSummary(),
 	)
 
 	if len(r.Errors) != 0 {
@@ -111,7 +111,7 @@ func formatShortPlainText(r models.ScanResult) string {
 %s
 No CVE-IDs are found in updatable packages.
 %s
-`, header, r.Packages.ToUpdatablePacksSummary())
+`, header, r.Packages.FormatUpdatablePacksSummary())
 	}
 
 	for _, d := range cves {
@@ -192,7 +192,7 @@ func formatFullPlainText(r models.ScanResult) string {
 		r.ServerInfo(),
 		buf.String(),
 		r.CveSummary(),
-		r.Packages.ToUpdatablePacksSummary(),
+		r.Packages.FormatUpdatablePacksSummary(),
 	)
 
 	if len(r.Errors) != 0 {
@@ -206,7 +206,7 @@ func formatFullPlainText(r models.ScanResult) string {
 %s
 No CVE-IDs are found in updatable packages.
 %s
-`, header, r.Packages.ToUpdatablePacksSummary())
+`, header, r.Packages.FormatUpdatablePacksSummary())
 	}
 
 	scoredReport, unscoredReport := []string{}, []string{}


### PR DESCRIPTION
## What did you implement:

Closes #373

## How did you implement it:

Don't count duplicate package names.

## How can we verify it:

Make sure that the number of updatable packages of vuls scan result and yum check-update are the same

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
