### PR TITLE
Change container scan format in config.toml

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -446,7 +446,6 @@ subjectPrefix = "[vuls]"
 #cpeNames = [
 #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
 #]
-#containers = ["${running}"]
 #optional = [
 #    ["key", "value"],
 #]
@@ -461,10 +460,13 @@ host         = "172.31.4.82"
 #cpeNames = [
 #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
 #]
-#containers = ["${running}"]
 #optional = [
 #    ["key", "value"],
 #]
+#[servers.172-31-4-82.containers]
+#type = "lxd" # or "docker"
+#indludes = ["${running}"]
+#excludes = ["container_name", "container_id"]
 ```
 
 このテンプレート使ってVulsの設定ファイルを作ってもよい。
@@ -530,11 +532,14 @@ host         = "172.31.4.82"
     #cpeNames = [
     #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
     #]
-    #containers = ["${running}"]
     #ignoreCves = ["CVE-2016-6313"]
     #optional = [
     #    ["key", "value"],
     #]
+    #[servers.172-31-4-82.containers]
+    #type = "lxd" # or "docker"
+    #indludes = ["${running}"]
+    #excludes = ["container_name", "container_id"]
     ```
     下記serversセクションで値が指定されなかった場合のデフォルト値
 
@@ -555,7 +560,7 @@ host         = "172.31.4.82"
     #    ["key", "value"],
     #]
     #containers = ["${running}"]
-    #[servers.172-31-4-82.container]
+    #[servers.172-31-4-82.containers]
     #type = "lxd"
     ```
 
@@ -792,7 +797,9 @@ Vulsは、DockerホストにSSHで接続し、`docker exec`でDockerコンテナ
     host         = "172.31.4.82"
     user        = "ec2-user"
     keyPath     = "/home/username/.ssh/id_rsa"
-    containers = ["${running}"]
+
+    [servers.172-31-4-82.containers]
+    indludes = ["${running}"]
     ```
 
 - あるコンテナのみスキャン  
@@ -806,7 +813,23 @@ Vulsは、DockerホストにSSHで接続し、`docker exec`でDockerコンテナ
     host         = "172.31.4.82"
     user        = "ec2-user"
     keyPath     = "/home/username/.ssh/id_rsa"
-    containers = ["container_name_a", "4aa37a8b63b9"]
+
+    [servers.172-31-4-82.containers]
+    includes = ["container_name_a", "4aa37a8b63b9"]
+    ```
+
+- あるコンテナ以外をスキャン  
+    ```
+    [servers]
+
+    [servers.172-31-4-82]
+    host         = "172.31.4.82"
+    user        = "ec2-user"
+    keyPath     = "/home/username/.ssh/id_rsa"
+
+    [servers.172-31-4-82.containers]
+    indludes = ["${running}"]
+    excludes = ["container_name_a", "4aa37a8b63b9"]
     ```
 
 - コンテナのみをスキャンする場合（ホストはスキャンしない）  
@@ -822,9 +845,10 @@ Vulsは、ホストにSSHで接続し、`lxc exec`でLXDコンテナにコマン
 host         = "172.31.4.82"
 user        = "ec2-user"
 keyPath     = "/home/username/.ssh/id_rsa"
-containers = ["${running}"]
-[servers.172-31-4-82.container]
+
+[servers.172-31-4-82.containers]
 type = "lxd"
+includes = ["${running}"]
 ```
 
 # Usage: Report

--- a/README.md
+++ b/README.md
@@ -447,7 +447,6 @@ subjectPrefix = "[vuls]"
 #cpeNames = [
 #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
 #]
-#containers = ["${running}"]
 #ignoreCves = ["CVE-2016-6313"]
 #optional = [
 #    ["key", "value"],
@@ -467,9 +466,10 @@ host         = "172.31.4.82"
 #optional = [
 #    ["key", "value"],
 #]
-#containers = ["${running}"]
-#[servers.172-31-4-82.container]
-#type = "lxd"
+#[servers.172-31-4-82.containers]
+#type = "lxd" # or "docker"
+#indludes = ["${running}"]
+#excludes = ["container_name", "container_id"]
 ```
 
 You can customize your configuration using this template.
@@ -538,7 +538,6 @@ You can customize your configuration using this template.
     #cpeNames = [
     #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
     #]
-    #containers = ["${running}"]
     #ignoreCves = ["CVE-2016-6313"]
     #optional = [
     #    ["key", "value"],
@@ -562,9 +561,10 @@ You can customize your configuration using this template.
     #optional = [
     #    ["key", "value"],
     #]
-    #containers = ["${running}"]
-    #[servers.172-31-4-82.container]
-    #type = "lxd"
+    #[servers.172-31-4-82.containers]
+    #type = "lxd" # or "docker"
+    #indludes = ["${running}"]
+    #excludes = ["container_name", "container_id"]
     ```
 
     You can overwrite the default value specified in default section.  
@@ -794,7 +794,9 @@ For more details, see [Architecture section](https://github.com/future-architect
     host         = "172.31.4.82"
     user        = "ec2-user"
     keyPath     = "/home/username/.ssh/id_rsa"
-    containers = ["${running}"]
+
+    [servers.172-31-4-82.containers]
+    indludes = ["${running}"]
     ```
 
 - To scan specific containers  
@@ -809,8 +811,25 @@ For more details, see [Architecture section](https://github.com/future-architect
     host         = "172.31.4.82"
     user        = "ec2-user"
     keyPath     = "/home/username/.ssh/id_rsa"
-    containers = ["container_name_a", "4aa37a8b63b9"]
+
+    [servers.172-31-4-82.containers]
+    includes = ["container_name_a", "4aa37a8b63b9"]
     ```
+
+- To scan except specific containers  
+    ```
+    [servers]
+
+    [servers.172-31-4-82]
+    host         = "172.31.4.82"
+    user        = "ec2-user"
+    keyPath     = "/home/username/.ssh/id_rsa"
+
+    [servers.172-31-4-82.containers]
+    indludes = ["${running}"]
+    excludes = ["container_name_a", "4aa37a8b63b9"]
+    ```
+
 - To scan containers only
   - --containers-only option is available.
 
@@ -824,9 +843,10 @@ Vuls scans lxd via `lxc exec` instead of SSH.
 host         = "172.31.4.82"
 user        = "ec2-user"
 keyPath     = "/home/username/.ssh/id_rsa"
-containers = ["${running}"]
-[servers.172-31-4-82.container]
+
+[servers.172-31-4-82.containers]
 type = "lxd"
+includes = ["${running}"]
 ```
 
 ----

--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -114,6 +114,8 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 	err = c.Load(p.configPath, keyPass)
 	if err != nil {
 		util.Log.Errorf("Error loading %s, %s", p.configPath, err)
+		util.Log.Errorf("If you update Vuls and get this error, there may be incompatible changes in config.toml")
+		util.Log.Errorf("Please check README: https://github.com/future-architect/vuls#configuration")
 		return subcommands.ExitUsageError
 	}
 	c.Conf.SSHExternal = p.sshExternal

--- a/commands/discover.go
+++ b/commands/discover.go
@@ -139,9 +139,10 @@ host         = "{{$ip}}"
 #optional = [
 #    ["key", "value"],
 #]
-#containers = ["${running}"]
-#[servers.{{index $names $i}}.container]
+#[servers.{{index $names $i}}.containers]
 #type = "docker" #or "lxd" defualt: docker
+#includes = ["${running}"]
+#excludes = ["container_name_a", "4aa37a8b63b9"]
 
 
 {{end}}

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -156,6 +156,8 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	err = c.Load(p.configPath, keyPass)
 	if err != nil {
 		util.Log.Errorf("Error loading %s, %s", p.configPath, err)
+		util.Log.Errorf("If you update Vuls and get this error, there may be incompatible changes in config.toml")
+		util.Log.Errorf("Please check README: https://github.com/future-architect/vuls#configuration")
 		return subcommands.ExitUsageError
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -339,7 +339,7 @@ type ServerInfo struct {
 	DependencyCheckXMLPath string
 
 	// Container Names or IDs
-	Containers []string
+	Containers Containers
 
 	IgnoreCves []string
 
@@ -394,10 +394,16 @@ func (s *ServerInfo) SetContainer(d Container) {
 	s.Container = d
 }
 
+// Containers has Containers information.
+type Containers struct {
+	Type     string
+	Includes []string
+	Excludes []string
+}
+
 // Container has Container information.
 type Container struct {
 	ContainerID string
 	Name        string
-	Type        string
 	Image       string
 }

--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -127,11 +127,9 @@ func (c TOMLLoader) Load(pathToToml, keyPass string) error {
 		}
 
 		s.Containers = v.Containers
-		if len(s.Containers) == 0 {
+		if len(s.Containers.Includes) == 0 {
 			s.Containers = d.Containers
 		}
-
-		s.Container.Type = v.Container.Type
 
 		s.IgnoreCves = v.IgnoreCves
 		for _, cve := range d.IgnoreCves {

--- a/models/models.go
+++ b/models/models.go
@@ -541,6 +541,7 @@ type Container struct {
 	ContainerID string
 	Name        string
 	Image       string
+	Type        string
 }
 
 // Platform has platform information

--- a/scan/base.go
+++ b/scan/base.go
@@ -77,7 +77,7 @@ func (l base) getPlatform() models.Platform {
 }
 
 func (l base) allContainers() (containers []config.Container, err error) {
-	switch l.ServerInfo.Container.Type {
+	switch l.ServerInfo.Containers.Type {
 	case "", "docker":
 		stdout, err := l.dockerPs("-a --format '{{.ID}} {{.Names}} {{.Image}}'")
 		if err != nil {
@@ -92,12 +92,12 @@ func (l base) allContainers() (containers []config.Container, err error) {
 		return l.parseLxdPs(stdout)
 	default:
 		return containers, fmt.Errorf(
-			"Not supported yet: %s", l.ServerInfo.Container.Type)
+			"Not supported yet: %s", l.ServerInfo.Containers.Type)
 	}
 }
 
 func (l *base) runningContainers() (containers []config.Container, err error) {
-	switch l.ServerInfo.Container.Type {
+	switch l.ServerInfo.Containers.Type {
 	case "", "docker":
 		stdout, err := l.dockerPs("--format '{{.ID}} {{.Names}} {{.Image}}'")
 		if err != nil {
@@ -112,12 +112,12 @@ func (l *base) runningContainers() (containers []config.Container, err error) {
 		return l.parseLxdPs(stdout)
 	default:
 		return containers, fmt.Errorf(
-			"Not supported yet: %s", l.ServerInfo.Container.Type)
+			"Not supported yet: %s", l.ServerInfo.Containers.Type)
 	}
 }
 
 func (l *base) exitedContainers() (containers []config.Container, err error) {
-	switch l.ServerInfo.Container.Type {
+	switch l.ServerInfo.Containers.Type {
 	case "", "docker":
 		stdout, err := l.dockerPs("--filter 'status=exited' --format '{{.ID}} {{.Names}} {{.Image}}'")
 		if err != nil {
@@ -132,7 +132,7 @@ func (l *base) exitedContainers() (containers []config.Container, err error) {
 		return l.parseLxdPs(stdout)
 	default:
 		return containers, fmt.Errorf(
-			"Not supported yet: %s", l.ServerInfo.Container.Type)
+			"Not supported yet: %s", l.ServerInfo.Containers.Type)
 	}
 }
 
@@ -271,10 +271,15 @@ func (l *base) convertToModel() models.ScanResult {
 	}
 	sort.Sort(l.VulnInfos)
 
+	ctype := l.ServerInfo.Containers.Type
+	if l.ServerInfo.Container.ContainerID != "" && ctype == "" {
+		ctype = "docker"
+	}
 	container := models.Container{
 		ContainerID: l.ServerInfo.Container.ContainerID,
 		Name:        l.ServerInfo.Container.Name,
 		Image:       l.ServerInfo.Container.Image,
+		Type:        ctype,
 	}
 
 	errs := []string{}

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -339,7 +339,7 @@ func decorateCmd(c conf.ServerInfo, cmd string, sudo bool) string {
 	//  }
 
 	if c.IsContainer() {
-		switch c.Container.Type {
+		switch c.Containers.Type {
 		case "", "docker":
 			cmd = fmt.Sprintf(`docker exec %s /bin/bash -c "%s"`, c.Container.ContainerID, cmd)
 		case "lxd":


### PR DESCRIPTION
## config.toml's format has been changed.

- before
```
[servers]

[servers.172-31-4-82]
host         = "172.31.4.82"
user        = "ec2-user"
keyPath     = "/home/username/.ssh/id_rsa"
containers = ["${running}"]

[servers.172-31-4-82.container]
type = "lxd" # or "docker"
```

- after
```
[servers]

[servers.172-31-4-82]
host         = "172.31.4.82"
user        = "ec2-user"
keyPath     = "/home/username/.ssh/id_rsa"

[servers.172-31-4-82.containers]
type = "lxd" # or "docker"
included  = ["${running}"]
excluded = ["ubuntu1", "fa30c26ed699"]
```

Please note that plural form 's' is attached
[servers.172-31-4-82.container] -> [servers.172-31-4-82.container**s**]


## What did you implement:

Closes #285 

## How did you implement it:

- Change config.toml to specify containers not to be scanned.
- Exclude non-scanned containers during scan.

## How can we verify it:

- scan

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** YES
