### PR TITLE
Add --user root to docker exec command

### DIFF
--- a/scan/executil.go
+++ b/scan/executil.go
@@ -341,7 +341,7 @@ func decorateCmd(c conf.ServerInfo, cmd string, sudo bool) string {
 	if c.IsContainer() {
 		switch c.Containers.Type {
 		case "", "docker":
-			cmd = fmt.Sprintf(`docker exec %s /bin/bash -c "%s"`, c.Container.ContainerID, cmd)
+			cmd = fmt.Sprintf(`docker exec --user root %s /bin/bash -c "%s"`, c.Container.ContainerID, cmd)
 		case "lxd":
 			cmd = fmt.Sprintf(`lxc exec %s -- /bin/bash -c "%s"`, c.Container.Name, cmd)
 		}

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -341,7 +341,7 @@ func decorateCmd(c conf.ServerInfo, cmd string, sudo bool) string {
 	if c.IsContainer() {
 		switch c.Containers.Type {
 		case "", "docker":
-			cmd = fmt.Sprintf(`docker exec --user root %s /bin/bash -c "%s"`, c.Container.ContainerID, cmd)
+			cmd = fmt.Sprintf(`docker exec --user 0 %s /bin/bash -c "%s"`, c.Container.ContainerID, cmd)
 		case "lxd":
 			cmd = fmt.Sprintf(`lxc exec %s -- /bin/bash -c "%s"`, c.Container.Name, cmd)
 		}


### PR DESCRIPTION
If containers were run with their user set to something other than root, docker exec will exec the command in the container as that user by default. Unfortunately, this causes many package manager commands to fail. This commit adds --user root to the docker exec command so that commands executed inside the container will always run as root.