### PR TITLE
add kali linux support

### DIFF
--- a/scan/debian.go
+++ b/scan/debian.go
@@ -141,7 +141,7 @@ func (o *debian) checkIfSudoNoPasswd() error {
 
 func (o *debian) checkDependencies() error {
 	switch o.Distro.Family {
-	case "ubuntu", "raspbian":
+	case "ubuntu", "raspbian", "kali":
 		return nil
 
 	case "debian":


### PR DESCRIPTION
## What did you implement:

Closes #398 

## How did you implement it:

when `o.Distro.Family` is `kali`, the host is classification to "debian like linux"

## How can we verify it:

running to vm.

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
