### PR TITLE
fix report option Loaded error-info

### DIFF
--- a/commands/report.go
+++ b/commands/report.go
@@ -385,7 +385,7 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 		util.Log.Error(err)
 		return subcommands.ExitFailure
 	}
-	util.Log.Infof("Loaded: %s", jsonDir)
+	util.Log.Infof("Loaded: %s", dir)
 
 	var results []models.ScanResult
 	for _, r := range history.ScanResults {


### PR DESCRIPTION
## What did you implement:

"vuls report" returns the following error

```
[vuls@testvuls vuls]$ ./vuls report -format-short-text
[Mar 30 22:59:51]  INFO [localhost] Validating config...
[Mar 30 22:59:51]  INFO [localhost] cve-dictionary: /opt/vuls/cve.sqlite3
[Mar 30 22:59:51]  INFO [localhost] Loaded: %!s(func([]string) (string, error)=0x48b470)

vuls-server (centos6.8)
=======================
Total: 0 (High:0 Medium:0 Low:0 ?:0)    0 updatable packages
...
```

## How did you implement it:

fix L388.

## How can we verify it:

I checked the operation in the environment where phenomena occurred.

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
