### PR TITLE
Enable -timeout option when detecting OS

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -774,10 +774,10 @@ scan:
                 [-skip-broken]
                 [-http-proxy=http://192.168.0.1:8080]
                 [-ask-key-password]
+                [-timeout=300]
+                [-timeout-scan=7200]
                 [-debug]
                 [-pipe]
-                [-timeout]
-                [-timeout-scan]
 
                 [SERVER]...
   -ask-key-password
@@ -803,7 +803,7 @@ scan:
   -ssh-native-insecure
         Use Native Go implementation of SSH. Default: Use the external command
   -timeout int
-        Number of seconds for detecting platform for all servers (default 60)
+        Number of seconds for processing other than scan (default 300)
   -timeout-scan int
         Number of second for scaning vulnerabilities for all servers (default 7200)
 ```

--- a/README.md
+++ b/README.md
@@ -783,10 +783,10 @@ scan:
                 [-skip-broken]
                 [-http-proxy=http://192.168.0.1:8080]
                 [-ask-key-password]
+                [-timeout=300]
+                [-timeout-scan=7200]
                 [-debug]
                 [-pipe]
-                [-timeout]
-                [-timeout-scan]
 
                 [SERVER]...
   -ask-key-password
@@ -812,7 +812,7 @@ scan:
   -ssh-native-insecure
         Use Native Go implementation of SSH. Default: Use the external command
   -timeout int
-        Number of seconds for detecting platform for all servers (default 60)
+        Number of seconds for processing other than scan (default 300)
   -timeout-scan int
         Number of second for scaning vulnerabilities for all servers (default 7200)
 ```

--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -164,7 +164,7 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 	}
 
 	util.Log.Info("Detecting Server/Container OS... ")
-	if err := scan.InitServers(); err != nil {
+	if err := scan.InitServers(p.timeoutSec); err != nil {
 		util.Log.Errorf("Failed to init servers: %s", err)
 		return subcommands.ExitFailure
 	}

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -35,19 +35,19 @@ import (
 
 // ScanCmd is Subcommand of host discovery mode
 type ScanCmd struct {
-	debug            bool
-	configPath       string
-	resultsDir       string
-	logDir           string
-	cacheDBPath      string
-	httpProxy        string
-	askKeyPassword   bool
-	containersOnly   bool
-	skipBroken       bool
-	sshNative        bool
-	pipe             bool
-	scanTimeoutSec   int
-	detectTimeoutSec int
+	debug          bool
+	configPath     string
+	resultsDir     string
+	logDir         string
+	cacheDBPath    string
+	httpProxy      string
+	askKeyPassword bool
+	containersOnly bool
+	skipBroken     bool
+	sshNative      bool
+	pipe           bool
+	timeoutSec     int
+	scanTimeoutSec int
 }
 
 // Name return subcommand name
@@ -69,10 +69,10 @@ func (*ScanCmd) Usage() string {
 		[-skip-broken]
 		[-http-proxy=http://192.168.0.1:8080]
 		[-ask-key-password]
+		[-timeout=300]
+		[-timeout-scan=7200]
 		[-debug]
 		[-pipe]
-		[-timeout]
-		[-timeout-detect-platform]
 
 		[SERVER]...
 `
@@ -139,17 +139,17 @@ func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 		"Use stdin via PIPE")
 
 	f.IntVar(
-		&p.detectTimeoutSec,
+		&p.timeoutSec,
 		"timeout",
-		1*60,
-		"Number of seconds for detecting platform for all servers",
+		5*60,
+		"Number of seconds for processing other than scan",
 	)
 
 	f.IntVar(
 		&p.scanTimeoutSec,
 		"timeout-scan",
 		120*60,
-		"Number of second for scaning vulnerabilities for all servers",
+		"Number of seconds for scaning vulnerabilities for all servers",
 	)
 }
 
@@ -231,13 +231,13 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	}
 
 	util.Log.Info("Detecting Server/Container OS... ")
-	if err := scan.InitServers(); err != nil {
+	if err := scan.InitServers(p.timeoutSec); err != nil {
 		util.Log.Errorf("Failed to init servers: %s", err)
 		return subcommands.ExitFailure
 	}
 
 	util.Log.Info("Detecting Platforms... ")
-	scan.DetectPlatforms(p.detectTimeoutSec)
+	scan.DetectPlatforms(p.timeoutSec)
 
 	util.Log.Info("Scanning vulnerabilities... ")
 	if err := scan.Scan(p.scanTimeoutSec); err != nil {


### PR DESCRIPTION
## What did you implement:
I got the following error.

```
$ vuls configtest
[Mar 31 20:12:18]  INFO [localhost] Validating config...
[Mar 31 20:12:18]  INFO [localhost] Detecting Server/Container OS...
[Mar 31 20:12:18]  INFO [localhost] Detecting OS of servers...
[Mar 31 20:12:28] ERROR [localhost] Timed out while detecting servers
[Mar 31 20:12:28] ERROR [localhost] (1/1) Timed out: ubuntu1404
[Mar 31 20:12:28] ERROR [localhost] Failed to init servers: No scannable servers
exit status 1
```
The timeout for detecting server OS is hard coded to 30 seconds.
https://github.com/future-architect/vuls/blob/master/scan/serverapi.go#L156
https://github.com/future-architect/vuls/blob/master/scan/serverapi.go#L218

I fixed this.

## How did you implement it:

For `configtest`,  `-timeout` option has already implemented, so I used it.
For `scan`, I added `-timeout` option.

## How can we verify it:

```
$ vuls configtest -timeout 120
$ vuls scan -timeout 120
```

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
