### PR TITLE
Add containers-only option to configtest

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -668,6 +668,7 @@ configtest:
                         [-log-dir=/path/to/log]
                         [-ask-key-password]
                         [-ssh-external]
+                        [-containers-only]
                         [-timeout=300]
                         [-http-proxy=http://192.168.0.1:8080]
                         [-debug]
@@ -677,6 +678,8 @@ configtest:
         Ask ssh privatekey password before scanning
   -config string
         /path/to/toml (default "/Users/kotakanbe/go/src/github.com/future-architect/vuls/config.toml")
+  -containers-only
+        Test containers only. Default: Test both of hosts and containers
   -debug
         debug mode
   -http-proxy string

--- a/README.md
+++ b/README.md
@@ -676,6 +676,7 @@ configtest:
                         [-log-dir=/path/to/log]
                         [-ask-key-password]
                         [-ssh-external]
+                        [-containers-only]
                         [-timeout=300]
                         [-debug]
 
@@ -684,6 +685,8 @@ configtest:
         Ask ssh privatekey password before scanning
   -config string
         /path/to/toml (default "/Users/kotakanbe/go/src/github.com/future-architect/vuls/config.toml")
+  -containers-only
+        Test containers only. Default: Test both of hosts and containers
   -debug
         debug mode
   -http-proxy string

--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -35,6 +35,7 @@ type ConfigtestCmd struct {
 	configPath     string
 	logDir         string
 	askKeyPassword bool
+	containersOnly bool
 	sshExternal    bool
 	httpProxy      string
 	timeoutSec     int
@@ -57,6 +58,7 @@ func (*ConfigtestCmd) Usage() string {
 			[-ask-key-password]
 			[-timeout=300]
 			[-ssh-external]
+			[-containers-only]
 			[-http-proxy=http://192.168.0.1:8080]
 			[-debug]
 
@@ -96,6 +98,12 @@ func (p *ConfigtestCmd) SetFlags(f *flag.FlagSet) {
 		"ssh-external",
 		false,
 		"Use external ssh command. Default: Use the Go native implementation")
+
+	f.BoolVar(
+		&p.containersOnly,
+		"containers-only",
+		false,
+		"Test containers only. Default: Test both of hosts and containers")
 }
 
 // Execute execute
@@ -124,6 +132,7 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 	}
 	c.Conf.SSHExternal = p.sshExternal
 	c.Conf.HTTPProxy = p.httpProxy
+	c.Conf.ContainersOnly = p.containersOnly
 
 	var servernames []string
 	if 0 < len(f.Args()) {


### PR DESCRIPTION
## What did you implement:

I'd like to scan only containers.
`scan` subcommand has `-containers-only` option.
https://github.com/future-architect/vuls/pull/190

However, `configtest` doesn't have `-containers-only` option.
Then, an error about a host server occur.

## How did you implement it:
I added `-containers-only` option to `configtest`.

## How can we verify it:
```
$ vuls configtest -containers-only
```

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
