### PR TITLE
Fix SSH dial error

### DIFF
--- a/scan/executil.go
+++ b/scan/executil.go
@@ -364,8 +364,9 @@ func getAgentAuth() (auth ssh.AuthMethod, ok bool) {
 func tryAgentConnect(c conf.ServerInfo) *ssh.Client {
 	if auth, ok := getAgentAuth(); ok {
 		config := &ssh.ClientConfig{
-			User: c.User,
-			Auth: []ssh.AuthMethod{auth},
+			User:            c.User,
+			Auth:            []ssh.AuthMethod{auth},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		}
 		client, _ := ssh.Dial("tcp", c.Host+":"+c.Port, config)
 		return client
@@ -385,8 +386,9 @@ func sshConnect(c conf.ServerInfo) (client *ssh.Client, err error) {
 
 	// http://blog.ralch.com/tutorial/golang-ssh-connection/
 	config := &ssh.ClientConfig{
-		User: c.User,
-		Auth: auths,
+		User:            c.User,
+		Auth:            auths,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
 	notifyFunc := func(e error, t time.Duration) {


### PR DESCRIPTION
Error message:
[Apr  2 13:36:49] DEBUG [localhost] Failed to Dial to u16, err: ssh: must specify HostKeyCallback, Retrying in 552.330144ms...

It is caused by breaking changes of Go library.
https://go-review.googlesource.com/c/38701/

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
