### PR TITLE
Define timeout for vulnerabilities scan and platform detection

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -776,6 +776,8 @@ scan:
                 [-ask-key-password]
                 [-debug]
                 [-pipe]
+                [-timeout]
+                [-timeout-scan]
 
                 [SERVER]...
   -ask-key-password
@@ -800,6 +802,10 @@ scan:
         [For CentOS] yum update changelog with --skip-broken option
   -ssh-native-insecure
         Use Native Go implementation of SSH. Default: Use the external command
+  -timeout int
+        Number of seconds for detecting platform for all servers (default 60)
+  -timeout-scan int
+        Number of second for scaning vulnerabilities for all servers (default 7200)
 ```
 
 ## -ssh-native-insecure option

--- a/README.md
+++ b/README.md
@@ -785,6 +785,8 @@ scan:
                 [-ask-key-password]
                 [-debug]
                 [-pipe]
+                [-timeout]
+                [-timeout-scan]
 
                 [SERVER]...
   -ask-key-password
@@ -809,6 +811,10 @@ scan:
         [For CentOS] yum update changelog with --skip-broken option
   -ssh-native-insecure
         Use Native Go implementation of SSH. Default: Use the external command
+  -timeout int
+        Number of seconds for detecting platform for all servers (default 60)
+  -timeout-scan int
+        Number of second for scaning vulnerabilities for all servers (default 7200)
 ```
 
 ## -ssh-native-insecure option

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -35,17 +35,19 @@ import (
 
 // ScanCmd is Subcommand of host discovery mode
 type ScanCmd struct {
-	debug          bool
-	configPath     string
-	resultsDir     string
-	logDir         string
-	cacheDBPath    string
-	httpProxy      string
-	askKeyPassword bool
-	containersOnly bool
-	skipBroken     bool
-	sshNative      bool
-	pipe           bool
+	debug            bool
+	configPath       string
+	resultsDir       string
+	logDir           string
+	cacheDBPath      string
+	httpProxy        string
+	askKeyPassword   bool
+	containersOnly   bool
+	skipBroken       bool
+	sshNative        bool
+	pipe             bool
+	scanTimeoutSec   int
+	detectTimeoutSec int
 }
 
 // Name return subcommand name
@@ -69,6 +71,8 @@ func (*ScanCmd) Usage() string {
 		[-ask-key-password]
 		[-debug]
 		[-pipe]
+		[-timeout]
+		[-timeout-detect-platform]
 
 		[SERVER]...
 `
@@ -133,6 +137,20 @@ func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 		"pipe",
 		false,
 		"Use stdin via PIPE")
+
+	f.IntVar(
+		&p.detectTimeoutSec,
+		"timeout",
+		1*60,
+		"Number of seconds for detecting platform for all servers",
+	)
+
+	f.IntVar(
+		&p.scanTimeoutSec,
+		"timeout-scan",
+		120*60,
+		"Number of second for scaning vulnerabilities for all servers",
+	)
 }
 
 // Execute execute
@@ -219,10 +237,10 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	}
 
 	util.Log.Info("Detecting Platforms... ")
-	scan.DetectPlatforms()
+	scan.DetectPlatforms(p.detectTimeoutSec)
 
 	util.Log.Info("Scanning vulnerabilities... ")
-	if err := scan.Scan(); err != nil {
+	if err := scan.Scan(p.scanTimeoutSec); err != nil {
 		util.Log.Errorf("Failed to scan. err: %s", err)
 		return subcommands.ExitFailure
 	}

--- a/scan/serverapi.go
+++ b/scan/serverapi.go
@@ -358,8 +358,8 @@ func CheckIfSudoNoPasswd(timeoutSec int) {
 }
 
 // DetectPlatforms detects the platform of each servers.
-func DetectPlatforms() {
-	detectPlatforms()
+func DetectPlatforms(timeoutSec int) {
+	detectPlatforms(timeoutSec)
 	for i, s := range servers {
 		if s.getServerInfo().IsContainer() {
 			util.Log.Infof("(%d/%d) %s on %s is running on %s",
@@ -380,8 +380,7 @@ func DetectPlatforms() {
 	return
 }
 
-func detectPlatforms() {
-	timeoutSec := 1 * 60
+func detectPlatforms(timeoutSec int) {
 	parallelExec(func(o osTypeInterface) error {
 		o.detectPlatform()
 		// Logging only if platform can not be specified
@@ -391,7 +390,7 @@ func detectPlatforms() {
 }
 
 // Scan scan
-func Scan() error {
+func Scan(timeoutSec int) error {
 	if len(servers) == 0 {
 		return fmt.Errorf("No server defined. Check the configuration")
 	}
@@ -411,7 +410,7 @@ func Scan() error {
 	if err != nil {
 		return err
 	}
-	if err := scanVulns(dir, scannedAt); err != nil {
+	if err := scanVulns(dir, scannedAt, timeoutSec); err != nil {
 		return err
 	}
 
@@ -435,9 +434,8 @@ func setupChangelogCache() error {
 	return nil
 }
 
-func scanVulns(jsonDir string, scannedAt time.Time) error {
+func scanVulns(jsonDir string, scannedAt time.Time, timeoutSec int) error {
 	var results models.ScanResults
-	timeoutSec := 120 * 60
 	parallelExec(func(o osTypeInterface) error {
 		return o.scanPackages()
 	}, timeoutSec)


### PR DESCRIPTION
## What did you implement:

I added configuration for timeouts inside of scan command, which were hard-coded until now. I came across issue with timeouts for platform detection when testing with servers in Europe.

## How did you implement it:

By adding two new flags for scan command.

## How can we verify it:

Either try connect to servers in opposite side of world with default configuration or decrease timeouts configuration to see that values are used.


## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes  
***Is it a breaking change?:*** No
