### PR TITLE
Change default ssh method from go library to external command

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -648,8 +648,8 @@ host         = "172.31.4.82"
     - containers: see [Usage: Scan Docker containers](https://github.com/future-architect/vuls/blob/master/README.ja.md#usage-scan-docker-containers)
 
 
-    Vulsは各サーバにSSHで接続するが、Goのネイティブ実装と、OSコマンドの２種類のSSH接続方法をサポートしている。
-    詳細は [-ssh-external option](https://github.com/future-architect/vuls/blob/master/README.ja.md#-ssh-external-option) を参照。
+    Vulsは各サーバにSSHで接続するが、OSコマンドでの接続と、Goのネイティブ実装の２種類のSSH接続方法をサポートしている。
+    詳細は [-ssh-native-insecure option](https://github.com/future-architect/vuls/blob/master/README.ja.md#-ssh-native-insecure-option) を参照。
 
     また、以下のSSH認証をサポートしている。
     - SSH agent
@@ -667,7 +667,7 @@ configtest:
                         [-config=/path/to/config.toml]
                         [-log-dir=/path/to/log]
                         [-ask-key-password]
-                        [-ssh-external]
+                        [-ssh-native-insecure]
                         [-containers-only]
                         [-timeout=300]
                         [-http-proxy=http://192.168.0.1:8080]
@@ -686,8 +686,8 @@ configtest:
         http://proxy-url:port (default: empty)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
-  -ssh-external
-        Use external ssh command. Default: Use the Go native implementation
+  -ssh-native-insecure
+        Use Native Go implementation of SSH. Default: Use the external command
   -timeout int
         Timeout(Sec) (default 300)
 ```
@@ -761,7 +761,7 @@ scan:
                 [-results-dir=/path/to/results]
                 [-log-dir=/path/to/log]
                 [-cachedb-path=/path/to/cache.db]
-                [-ssh-external]
+                [-ssh-native-insecure]
                 [-containers-only]
                 [-skip-broken]
                 [-http-proxy=http://192.168.0.1:8080]
@@ -790,23 +790,23 @@ scan:
         /path/to/results
   -skip-broken
         [For CentOS] yum update changelog with --skip-broken option
-  -ssh-external
-        Use external ssh command. Default: Use the Go native implementation
+  -ssh-native-insecure
+        Use Native Go implementation of SSH. Default: Use the external command
 ```
 
-## -ssh-external option
+## -ssh-native-insecure option
 
 Vulsは２種類のSSH接続方法をサポートしている。
 
-デフォルトでは、Goのネイティブ実装 (crypto/ssh) を使ってスキャンする。
-これは、SSHコマンドがインストールされていない環境でも動作する（Windowsなど）  
 
-外部SSHコマンドを使ってスキャンするためには、`-ssh-external`を指定する。
+デフォルトでは、外部SSHコマンドを使ってスキャンする。
 SSH Configが使えるので、ProxyCommandを使った多段SSHなどが可能。  
 CentOSでは、スキャン対象サーバの/etc/sudoersに以下を追加する必要がある(user: vuls)
 ```
 Defaults:vuls !requiretty
 ```
+
+-ssh-native-insecureを指定すると、Goのネイティブ実装 (crypto/ssh) を使ってスキャンする。これは、SSHコマンドがインストールされていない環境でも動作する（Windowsなど）。-ssh-native-insecureは、ホストキーのチェックをしないことに注意すべき。
 
 ## -ask-key-password option
 

--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ You can customize your configuration using this template.
     - optional: Add additional information to JSON report.
     - containers: see [Example: Scan containers (Docker/LXD)(#example-scan-containers-dockerlxd)
 
-    Vuls supports two types of SSH. One is native go implementation. The other is external SSH command. For details, see [-ssh-external option](https://github.com/future-architect/vuls#-ssh-external-option)
+    Vuls supports two types of SSH. One is external command. The other is native go implementation. For details, see [-ssh-native-insecure option](https://github.com/future-architect/vuls#-ssh-native-insecure-option)
 
     Multiple SSH authentication methods are supported.  
     - SSH agent
@@ -675,7 +675,7 @@ configtest:
                         [-config=/path/to/config.toml]
                         [-log-dir=/path/to/log]
                         [-ask-key-password]
-                        [-ssh-external]
+                        [-ssh-native-insecure]
                         [-containers-only]
                         [-timeout=300]
                         [-debug]
@@ -693,8 +693,8 @@ configtest:
         http://proxy-url:port (default: empty)
   -log-dir string
         /path/to/log (default "/var/log/vuls")
-  -ssh-external
-        Use external ssh command. Default: Use the Go native implementation
+  -ssh-native-insecure
+        Use Native Go implementation of SSH. Default: Use the external command
   -timeout int
         Timeout(Sec) (default 300)
 
@@ -772,7 +772,7 @@ scan:
                 [-results-dir=/path/to/results]
                 [-log-dir=/path/to/log]
                 [-cachedb-path=/path/to/cache.db]
-                [-ssh-external]
+                [-ssh-native-insecure]
                 [-containers-only]
                 [-skip-broken]
                 [-http-proxy=http://192.168.0.1:8080]
@@ -801,23 +801,25 @@ scan:
         /path/to/results
   -skip-broken
         [For CentOS] yum update changelog with --skip-broken option
-  -ssh-external
-        Use external ssh command. Default: Use the Go native implementation
+  -ssh-native-insecure
+        Use Native Go implementation of SSH. Default: Use the external command
 ```
 
-## -ssh-external option
+## -ssh-native-insecure option
 
 Vuls supports different types of SSH.  
 
-By Default, using a native Go implementation from crypto/ssh.   
-This is useful in situations where you may not have access to traditional UNIX tools.
-
-To use external SSH command, specify this option.   
+By Default, external SSH command will be used.
 This is useful If you want to use ProxyCommand or cipher algorithm of SSH that is not supported by native go implementation.  
 Don't forget to add below line to /etc/sudoers on the target servers. (username: vuls)
 ```
 Defaults:vuls !requiretty
 ```
+
+To use native Go implementation from crypto/ssh, specify this option.   
+This is useful in situations where you may not have access to traditional UNIX tools.
+But It is important to note that this mode does not check the host key.
+
 
 
 ## -ask-key-password option

--- a/README.md
+++ b/README.md
@@ -818,7 +818,7 @@ Defaults:vuls !requiretty
 
 To use native Go implementation from crypto/ssh, specify this option.   
 This is useful in situations where you may not have access to traditional UNIX tools.
-But It is important to note that this mode does not check the host key.
+But it is important to note that this mode does not check the host key.
 
 
 

--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -36,7 +36,7 @@ type ConfigtestCmd struct {
 	logDir         string
 	askKeyPassword bool
 	containersOnly bool
-	sshExternal    bool
+	sshNative      bool
 	httpProxy      string
 	timeoutSec     int
 
@@ -94,10 +94,10 @@ func (p *ConfigtestCmd) SetFlags(f *flag.FlagSet) {
 	)
 
 	f.BoolVar(
-		&p.sshExternal,
-		"ssh-external",
+		&p.sshNative,
+		"ssh-native-insecure",
 		false,
-		"Use external ssh command. Default: Use the Go native implementation")
+		"Use Native Go implementation of SSH. Default: Use the external command")
 
 	f.BoolVar(
 		&p.containersOnly,
@@ -130,7 +130,7 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 		util.Log.Errorf("Please check README: https://github.com/future-architect/vuls#configuration")
 		return subcommands.ExitUsageError
 	}
-	c.Conf.SSHExternal = p.sshExternal
+	c.Conf.SSHNative = p.sshNative
 	c.Conf.HTTPProxy = p.httpProxy
 	c.Conf.ContainersOnly = p.containersOnly
 

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -44,7 +44,7 @@ type ScanCmd struct {
 	askKeyPassword bool
 	containersOnly bool
 	skipBroken     bool
-	sshExternal    bool
+	sshNative      bool
 	pipe           bool
 }
 
@@ -62,7 +62,7 @@ func (*ScanCmd) Usage() string {
 		[-results-dir=/path/to/results]
 		[-log-dir=/path/to/log]
 		[-cachedb-path=/path/to/cache.db]
-		[-ssh-external]
+		[-ssh-native-insecure]
 		[-containers-only]
 		[-skip-broken]
 		[-http-proxy=http://192.168.0.1:8080]
@@ -97,10 +97,10 @@ func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 		"/path/to/cache.db (local cache of changelog for Ubuntu/Debian)")
 
 	f.BoolVar(
-		&p.sshExternal,
-		"ssh-external",
+		&p.sshNative,
+		"ssh-native-insecure",
 		false,
-		"Use external ssh command. Default: Use the Go native implementation")
+		"Use Native Go implementation of SSH. Default: Use the external command")
 
 	f.BoolVar(
 		&p.containersOnly,
@@ -202,7 +202,7 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 
 	c.Conf.ResultsDir = p.resultsDir
 	c.Conf.CacheDBPath = p.cacheDBPath
-	c.Conf.SSHExternal = p.sshExternal
+	c.Conf.SSHNative = p.sshNative
 	c.Conf.HTTPProxy = p.httpProxy
 	c.Conf.ContainersOnly = p.containersOnly
 	c.Conf.SkipBroken = p.skipBroken

--- a/config/config.go
+++ b/config/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	CvssScoreOver      float64
 	IgnoreUnscoredCves bool
 
-	SSHExternal    bool
+	SSHNative      bool
 	ContainersOnly bool
 	SkipBroken     bool
 
@@ -82,8 +82,8 @@ type Config struct {
 func (c Config) ValidateOnConfigtest() bool {
 	errs := []error{}
 
-	if runtime.GOOS == "windows" && c.SSHExternal {
-		errs = append(errs, fmt.Errorf("-ssh-external cannot be used on windows"))
+	if runtime.GOOS == "windows" && !c.SSHNative {
+		errs = append(errs, fmt.Errorf("-ssh-native is needed on windows"))
 	}
 
 	_, err := valid.ValidateStruct(c)
@@ -114,8 +114,8 @@ func (c Config) ValidateOnScan() bool {
 		}
 	}
 
-	if runtime.GOOS == "windows" && c.SSHExternal {
-		errs = append(errs, fmt.Errorf("-ssh-external cannot be used on windows"))
+	if runtime.GOOS == "windows" && !c.SSHNative {
+		errs = append(errs, fmt.Errorf("-ssh-native-insecure is needed on windows"))
 	}
 
 	if len(c.ResultsDir) != 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -83,7 +83,7 @@ func (c Config) ValidateOnConfigtest() bool {
 	errs := []error{}
 
 	if runtime.GOOS == "windows" && !c.SSHNative {
-		errs = append(errs, fmt.Errorf("-ssh-native is needed on windows"))
+		errs = append(errs, fmt.Errorf("-ssh-native-insecure is needed on windows"))
 	}
 
 	_, err := valid.ValidateStruct(c)

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -151,10 +151,10 @@ func exec(c conf.ServerInfo, cmd string, sudo bool, log ...*logrus.Entry) (resul
 	if c.Port == "local" &&
 		(c.Host == "127.0.0.1" || c.Host == "localhost") {
 		result = localExec(c, cmd, sudo)
-	} else if conf.Conf.SSHExternal {
-		result = sshExecExternal(c, cmd, sudo)
-	} else {
+	} else if conf.Conf.SSHNative {
 		result = sshExecNative(c, cmd, sudo)
+	} else {
+		result = sshExecExternal(c, cmd, sudo)
 	}
 
 	logger := getSSHLogger(log...)


### PR DESCRIPTION
## What did you implement:

Closes #415 

## How did you implement it:

Remove ssh-external option.
Add ssh-native-insecure option.

## How can we verify it:

Run Vuls with/without this option.

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
