### PR TITLE
Add support for PostgreSQL as a DB storage back-end

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -91,7 +91,7 @@ memo = "404d058cf6b46d820e153afc5721e1ab2aa2b10ec345d969b9c460097f99add3"
 
 [[projects]]
   name = "github.com/jinzhu/gorm"
-  packages = [".","dialects/mysql","dialects/sqlite"]
+  packages = [".","dialects/mysql","dialects/postgres","dialects/sqlite"]
   revision = "5174cc5c242a728b435ea2be8a2f7f998e15429b"
   version = "v1.0"
 
@@ -123,7 +123,7 @@ memo = "404d058cf6b46d820e153afc5721e1ab2aa2b10ec345d969b9c460097f99add3"
   branch = "master"
   name = "github.com/kotakanbe/go-cve-dictionary"
   packages = ["config","db","jvn","log","models","nvd","util"]
-  revision = "8fb43afc719094af43ed782c567d30b58557ac78"
+  revision = "d47709be4cc24d2c77a7be9096dcfcf211ba1d57"
 
 [[projects]]
   name = "github.com/kotakanbe/go-pingscanner"
@@ -136,6 +136,12 @@ memo = "404d058cf6b46d820e153afc5721e1ab2aa2b10ec345d969b9c460097f99add3"
   name = "github.com/kotakanbe/logrus-prefixed-formatter"
   packages = ["."]
   revision = "e7519b8c80ba008a3bfc57ffa31232bf2a77f455"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/lib/pq"
+  packages = [".","hstore","oid"]
+  revision = "2704adc878c21e1329f46f6e56a1c387d788ff94"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"

--- a/README.ja.md
+++ b/README.ja.md
@@ -81,6 +81,7 @@ Slackチームは[こちらから](http://goo.gl/forms/xm5KFo35tu)参加でき�
   * [Example: IgnoreCves](#example-ignorecves)
   * [Example: Add optional key-value pairs to JSON](#example-add-optional-key-value-pairs-to-json)
   * [Example: Use MySQL as a DB storage back-end](#example-use-mysql-as-a-db-storage-back-end)
+  * [Example: Use PostgreSQL as a DB storage back-end](#example-use-postgresql-as-a-db-storage-back-end)
 - [Usage: Scan vulnerability of non-OS package](#usage-scan-vulnerability-of-non-os-package)
 - [Usage: Integrate with OWASP Dependency Check to Automatic update when the libraries are updated (Experimental)](#usage-integrate-with-owasp-dependency-check-to-automatic-update-when-the-libraries-are-updated-experimental)
 - [Usage: TUI](#usage-tui)
@@ -1040,9 +1041,9 @@ report:
                 [-results-dir=/path/to/results]
                 [-log-dir=/path/to/log]
                 [-refresh-cve]
-                [-cvedb-type=sqlite3|mysql]
+                [-cvedb-type=sqlite3|mysql|postgres]
                 [-cvedb-path=/path/to/cve.sqlite3]
-                [-cvedb-url=http://127.0.0.1:1323 or mysql connection string]
+                [-cvedb-url=http://127.0.0.1:1323 or DB connection string]
                 [-cvss-over=7]
                 [-diff]
                 [-ignore-unscored-cves]
@@ -1087,9 +1088,9 @@ report:
   -cvedb-path string
         /path/to/sqlite3 (For get cve detail from cve.sqlite3)
   -cvedb-type string
-        DB type for fetching CVE dictionary (sqlite3 or mysql) (default "sqlite3")
+        DB type for fetching CVE dictionary (sqlite3, mysql or postgres) (default "sqlite3")
   -cvedb-url string
-        http://cve-dictionary.com:8080 or mysql connection string
+        http://cve-dictionary.com:8080 or DB connection string
   -cvss-over float
         -cvss-over=6.5 means reporting CVSS Score 6.5 and over (default: 0 (means report all))
   -diff
@@ -1427,6 +1428,14 @@ $ vuls report \
       -cvedb-url="user:pass@tcp(localhost:3306)/dbname?parseTime=true"
 ```
 
+## Example: Use PostgreSQL as a DB storage back-end
+
+```
+$ vuls report \
+      -cvedb-type=postgres \
+      -cvedb-url=""host=myhost user=user dbname=dbname sslmode=disable password=password""
+```
+
 ----
 
 # Usage: Scan vulnerability of non-OS package
@@ -1487,9 +1496,9 @@ VulsとDependency Checkを連携すると以下の利点がある
 ```
 tui:
         tui
-                [-cvedb-type=sqlite3|mysql]
+                [-cvedb-type=sqlite3|mysql|postgres]
                 [-cvedb-path=/path/to/cve.sqlite3]
-                [-cvedb-url=http://127.0.0.1:1323 or mysql connection string]
+                [-cvedb-url=http://127.0.0.1:1323 DB connection string]
                 [-refresh-cve]
                 [-results-dir=/path/to/results]
                 [-log-dir=/path/to/log]
@@ -1500,9 +1509,9 @@ tui:
   -cvedb-path string
         /path/to/sqlite3 (For get cve detail from cve.sqlite3) 
   -cvedb-type string
-        DB type for fetching CVE dictionary (sqlite3 or mysql) (default "sqlite3")
+        DB type for fetching CVE dictionary (sqlite3, mysql or postgres) (default "sqlite3")
   -cvedb-url string
-        http://cve-dictionary.com:8080 or mysql connection string
+        http://cve-dictionary.com:8080 or DB connection string
   -debug
         debug mode
   -debug-sql

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ We have a slack team. [Join slack team](http://goo.gl/forms/xm5KFo35tu)
   * [Example: IgnoreCves](#example-ignorecves)
   * [Example: Add optional key-value pairs to JSON](#example-add-optional-key-value-pairs-to-json)
   * [Example: Use MySQL as a DB storage back-end](#example-use-mysql-as-a-db-storage-back-end)
+  * [Example: Use PostgreSQL as a DB storage back-end](#example-use-postgresql-as-a-db-storage-back-end)
 - [Usage: Scan vulnerabilites of non-OS packages](#usage-scan-vulnerabilites-of-non-os-packages)
 - [Usage: Integrate with OWASP Dependency Check to Automatic update when the libraries are updated (Experimental)](#usage-integrate-with-owasp-dependency-check-to-automatic-update-when-the-libraries-are-updated-experimental)
 - [Usage: TUI](#usage-tui)
@@ -1049,9 +1050,9 @@ report:
                 [-results-dir=/path/to/results]
                 [-log-dir=/path/to/log]
                 [-refresh-cve]
-                [-cvedb-type=sqlite3|mysql]
+                [-cvedb-type=sqlite3|mysql|postgres]
                 [-cvedb-path=/path/to/cve.sqlite3]
-                [-cvedb-url=http://127.0.0.1:1323 or mysql connection string]
+                [-cvedb-url=http://127.0.0.1:1323 DB connection string]
                 [-cvss-over=7]
                 [-diff]
                 [-ignore-unscored-cves]
@@ -1096,9 +1097,9 @@ report:
   -cvedb-path string
         /path/to/sqlite3 (For get cve detail from cve.sqlite3)
   -cvedb-type string
-        DB type for fetching CVE dictionary (sqlite3 or mysql) (default "sqlite3")
+        DB type for fetching CVE dictionary (sqlite3, mysql or postgres) (default "sqlite3")
   -cvedb-url string
-        http://cve-dictionary.com:8080 or mysql connection string
+        http://cve-dictionary.com:8080 DB connection string
   -cvss-over float
         -cvss-over=6.5 means reporting CVSS Score 6.5 and over (default: 0 (means report all))
   -diff
@@ -1429,6 +1430,14 @@ $ vuls report \
       -cvedb-url="user:pass@tcp(localhost:3306)/dbname?parseTime=true"
 ```
 
+## Example: Use PostgreSQL as a DB storage back-end
+
+```
+$ vuls report \
+      -cvedb-type=postgres \
+      -cvedb-url=""host=myhost user=user dbname=dbname sslmode=disable password=password""
+```
+
 ----
 
 # Usage: Scan vulnerabilites of non-OS packages
@@ -1487,9 +1496,9 @@ How to integrate Vuls with OWASP Dependency Check
 ```
 tui:
         tui
-                [-cvedb-type=sqlite3|mysql]
+                [-cvedb-type=sqlite3|mysql|postgres]
                 [-cvedb-path=/path/to/cve.sqlite3]
-                [-cvedb-url=http://127.0.0.1:1323 or mysql connection string]
+                [-cvedb-url=http://127.0.0.1:1323 DB connection string]
                 [-refresh-cve]
                 [-results-dir=/path/to/results]
                 [-log-dir=/path/to/log]
@@ -1500,9 +1509,9 @@ tui:
   -cvedb-path string
         /path/to/sqlite3 (For get cve detail from cve.sqlite3) 
   -cvedb-type string
-        DB type for fetching CVE dictionary (sqlite3 or mysql) (default "sqlite3")
+        DB type for fetching CVE dictionary (sqlite3, mysql or postgres) (default "sqlite3")
   -cvedb-url string
-        http://cve-dictionary.com:8080 or mysql connection string
+        http://cve-dictionary.com:8080 DB connection string
   -debug
         debug mode
   -debug-sql

--- a/commands/report.go
+++ b/commands/report.go
@@ -93,9 +93,9 @@ func (*ReportCmd) Usage() string {
 		[-results-dir=/path/to/results]
 		[-log-dir=/path/to/log]
 		[-refresh-cve]
-		[-cvedb-type=sqlite3|mysql]
+		[-cvedb-type=sqlite3|mysql|postgres]
 		[-cvedb-path=/path/to/cve.sqlite3]
-		[-cvedb-url=http://127.0.0.1:1323 or mysql connection string]
+		[-cvedb-url=http://127.0.0.1:1323 or DB connection string]
 		[-cvss-over=7]
 		[-diff]
 		[-ignore-unscored-cves]
@@ -153,7 +153,7 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 		&p.cvedbtype,
 		"cvedb-type",
 		"sqlite3",
-		"DB type for fetching CVE dictionary (sqlite3 or mysql)")
+		"DB type for fetching CVE dictionary (sqlite3, mysql or postgres)")
 
 	defaultCveDBPath := filepath.Join(wd, "cve.sqlite3")
 	f.StringVar(
@@ -166,7 +166,7 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 		&p.cvedbURL,
 		"cvedb-url",
 		"",
-		"http://cve-dictionary.com:8080 or mysql connection string")
+		"http://cve-dictionary.com:8080 or DB connection string")
 
 	f.Float64Var(
 		&p.cvssScoreOver,

--- a/commands/tui.go
+++ b/commands/tui.go
@@ -56,9 +56,9 @@ func (*TuiCmd) Synopsis() string { return "Run Tui view to anayze vulnerabilites
 func (*TuiCmd) Usage() string {
 	return `tui:
 	tui
-		[-cvedb-type=sqlite3|mysql]
+		[-cvedb-type=sqlite3|mysql|postgres]
 		[-cvedb-path=/path/to/cve.sqlite3]
-		[-cvedb-url=http://127.0.0.1:1323 or mysql connection string]
+		[-cvedb-url=http://127.0.0.1:1323 or DB connection string]
 		[-refresh-cve]
 		[-results-dir=/path/to/results]
 		[-log-dir=/path/to/log]
@@ -92,7 +92,7 @@ func (p *TuiCmd) SetFlags(f *flag.FlagSet) {
 		&p.cvedbtype,
 		"cvedb-type",
 		"sqlite3",
-		"DB type for fetching CVE dictionary (sqlite3 or mysql)")
+		"DB type for fetching CVE dictionary (sqlite3, mysql or postgres)")
 
 	defaultCveDBPath := filepath.Join(wd, "cve.sqlite3")
 	f.StringVar(
@@ -105,7 +105,7 @@ func (p *TuiCmd) SetFlags(f *flag.FlagSet) {
 		&p.cveDictionaryURL,
 		"cvedb-url",
 		"",
-		"http://cve-dictionary.com:8080 or mysql connection string")
+		"http://cve-dictionary.com:8080 or DB connection string")
 
 	f.BoolVar(
 		&p.pipe,

--- a/config/config.go
+++ b/config/config.go
@@ -167,9 +167,14 @@ func (c Config) ValidateOnReport() bool {
 			errs = append(errs, fmt.Errorf(
 				`MySQL connection string is needed. -cvedb-url="user:pass@tcp(localhost:3306)/dbname"`))
 		}
+	case "postgres":
+		if c.CveDBURL == "" {
+			errs = append(errs, fmt.Errorf(
+				`PostgreSQL connection string is needed. -cvedb-url=""host=myhost user=user dbname=dbname sslmode=disable password=password""`))
+		}
 	default:
 		errs = append(errs, fmt.Errorf(
-			"CVE DB type must be either 'sqlite3' or 'mysql'.  -cvedb-type: %s", c.CveDBType))
+			"CVE DB type must be either 'sqlite3', 'mysql' or 'postgres'.  -cvedb-type: %s", c.CveDBType))
 	}
 
 	_, err := valid.ValidateStruct(c)
@@ -203,9 +208,9 @@ func (c Config) ValidateOnTui() bool {
 		}
 	}
 
-	if c.CveDBType != "sqlite3" && c.CveDBType != "mysql" {
+	if c.CveDBType != "sqlite3" && c.CveDBType != "mysql" && c.CveDBType != "postgres" {
 		errs = append(errs, fmt.Errorf(
-			"CVE DB type must be either 'sqlite3' or 'mysql'.  -cve-dictionary-dbtype: %s", c.CveDBType))
+			"CVE DB type must be either 'sqlite3', 'mysql' or 'postgres'.  -cve-dictionary-dbtype: %s", c.CveDBType))
 	}
 
 	if c.CveDBType == "sqlite3" {

--- a/cveapi/cve_client.go
+++ b/cveapi/cve_client.go
@@ -47,7 +47,7 @@ func (api *cvedictClient) initialize() {
 }
 
 func (api cvedictClient) CheckHealth() (ok bool, err error) {
-	if config.Conf.CveDBURL == "" || config.Conf.CveDBType == "mysql" {
+	if config.Conf.CveDBURL == "" || config.Conf.CveDBType == "mysql" || config.Conf.CveDBType == "postgres" {
 		util.Log.Debugf("get cve-dictionary from %s", config.Conf.CveDBType)
 		return true, nil
 	}
@@ -71,7 +71,7 @@ type response struct {
 
 func (api cvedictClient) FetchCveDetails(cveIDs []string) (cveDetails cve.CveDetails, err error) {
 	switch config.Conf.CveDBType {
-	case "sqlite3", "mysql":
+	case "sqlite3", "mysql", "postgres":
 		return api.FetchCveDetailsFromCveDB(cveIDs)
 	}
 
@@ -198,7 +198,7 @@ type responseGetCveDetailByCpeName struct {
 
 func (api cvedictClient) FetchCveDetailsByCpeName(cpeName string) ([]cve.CveDetail, error) {
 	switch config.Conf.CveDBType {
-	case "sqlite3", "mysql":
+	case "sqlite3", "mysql", "postgres":
 		return api.FetchCveDetailsByCpeNameFromDB(cpeName)
 	}
 


### PR DESCRIPTION
## What did you implement:

Add support for PostgreSQL as a DB storage back-end

## How did you implement it:

Add gorm's dialects of PostgreSQL.

## How can we verify it:

Use postgresSQL as a vuls DB back-end.

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 
***Is it a breaking change?:*** NO
