### PR TITLE
change logrus package to lowercase and update other packages

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,20 +10,14 @@
 [[projects]]
   name = "github.com/Azure/go-autorest"
   packages = ["autorest","autorest/adal","autorest/azure","autorest/date"]
-  revision = "58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d"
-  version = "v8.0.0"
+  revision = "10791a4516e77c53ab10f198f144804cca3d5b43"
+  version = "v8.1.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
-  revision = "8b58b6030fce084b58a61e2bc3fdf183d5881ab4"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/Sirupsen/logrus"
-  packages = ["."]
-  revision = "acfabf31db8f45a9174f54a0d48ea4d15627af4d"
+  revision = "a368813c5e648fee92e5f6c30e3944ff9d5e8895"
 
 [[projects]]
   name = "github.com/asaskevich/govalidator"
@@ -63,8 +57,8 @@
 [[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "e7fea39b01aea8d5671f6858f0532f56e8bff3a5"
-  version = "v1.27.0"
+  revision = "d3de07a94d22b4a0972deb4b96d790c2c0ce8333"
+  version = "v1.28.0"
 
 [[projects]]
   name = "github.com/go-redis/redis"
@@ -133,9 +127,10 @@
   revision = "9865fe14d09b1c729188ac810466dde90f897ee3"
 
 [[projects]]
+  branch = "master"
   name = "github.com/kotakanbe/go-cve-dictionary"
   packages = ["config","db","jvn","log","models","nvd","util"]
-  revision = "c57d73c89e4d1a71f417ffcef6e13978a5add7ac"
+  revision = "89e381b4e7e5a31097bbd5779cbb555f5bd3fe87"
 
 [[projects]]
   name = "github.com/kotakanbe/go-pingscanner"
@@ -144,15 +139,16 @@
   version = "v0.1.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/kotakanbe/goval-dictionary"
   packages = ["config","db","db/rdb","log","models"]
-  revision = "233459d2cc9ae85d8fcfb6a3d1412fdba6b0ea65"
+  revision = "adf0b39cd7fea8f4493f7b65e7316179634be95d"
 
 [[projects]]
   branch = "master"
   name = "github.com/kotakanbe/logrus-prefixed-formatter"
   packages = ["."]
-  revision = "e7519b8c80ba008a3bfc57ffa31232bf2a77f455"
+  revision = "5ea278a9a3f980f7cdf1dc787dc4a85ac72502d9"
 
 [[projects]]
   name = "github.com/labstack/gommon"
@@ -169,8 +165,8 @@
 [[projects]]
   name = "github.com/mattn/go-colorable"
   packages = ["."]
-  revision = "d228849504861217f796da67fae4f6e347643f15"
-  version = "v0.0.7"
+  revision = "941b50ebc6efddf4c41c8e4537a5f68a4e686b24"
+  version = "v0.0.8"
 
 [[projects]]
   name = "github.com/mattn/go-isatty"
@@ -206,7 +202,7 @@
   branch = "master"
   name = "github.com/nsf/termbox-go"
   packages = ["."]
-  revision = "7994c181db7761ca3c67a217068cf31826113f5f"
+  revision = "72800b73ab9a3c78df350738298b0361354772ff"
 
 [[projects]]
   name = "github.com/parnurzeal/gorequest"
@@ -223,14 +219,20 @@
 [[projects]]
   name = "github.com/rifflock/lfshook"
   packages = ["."]
-  revision = "2adb3e0c4ddd8778c4adde609d2dfd4fbe6096ea"
-  version = "1.6"
+  revision = "6844c808343cb8fa357d7f141b1b990e05d24e41"
+  version = "1.7"
 
 [[projects]]
   name = "github.com/satori/uuid"
   packages = ["."]
   revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
   version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "3d4380f53a34dcdc95f0c1db702615992b38d9a4"
 
 [[projects]]
   branch = "master"
@@ -260,29 +262,29 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["curve25519","ed25519","ed25519/internal/edwards25519","ssh","ssh/agent","ssh/terminal"]
-  revision = "ab89591268e0c8b748cbe4047b00197516011af5"
+  revision = "adbae1b6b6fb4b02448a0fc0dbbc9ba2b95b294d"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","idna","publicsuffix"]
-  revision = "84f0e6f92b10139f986b1756e149a7d9de270cdc"
+  revision = "455220fa52c866a8aa14ff5e8cc68cde16b8395e"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "1e99a4f9d247b28c670884b9a8d6801f39a47b77"
+  revision = "90796e5a05ce440b41c768bd9af257005e470461"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
   packages = ["internal/gen","internal/triegen","internal/ucd","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
-  revision = "19e51611da83d6be54ddafce4a4af510cb3e9ea4"
+  revision = "6353ef0f924300eea566d3438817aa4d3374817e"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2f4b3e869b7567e51d9bff86e52b3960d8c8304164b40d69f03a9e690032c9f5"
+  inputs-digest = "a6b387c74e75e1f971ee643c8904f6fd4e3dfdb7fa36119ab7bc28d9cfd66427"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,7 +9,7 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
@@ -24,11 +24,11 @@
   name = "github.com/k0kubun/pp"
 
 [[constraint]]
+  branch = "master"
   name = "github.com/kotakanbe/go-cve-dictionary"
-  revision = "c57d73c89e4d1a71f417ffcef6e13978a5add7ac"
 
 [[constraint]]
-  revision = "233459d2cc9ae85d8fcfb6a3d1412fdba6b0ea65"
+  branch = "master"
   name = "github.com/kotakanbe/goval-dictionary"
 
 [[constraint]]

--- a/cache/bolt.go
+++ b/cache/bolt.go
@@ -22,9 +22,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
 	"github.com/future-architect/vuls/util"
+	"github.com/sirupsen/logrus"
 )
 
 // Bolt holds a pointer of bolt.DB

--- a/cache/bolt_test.go
+++ b/cache/bolt_test.go
@@ -22,10 +22,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/models"
+	"github.com/sirupsen/logrus"
 )
 
 const path = "/tmp/vuls-test-cache-11111111.db"

--- a/commands/discover.go
+++ b/commands/discover.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/google/subcommands"
 
-	"github.com/Sirupsen/logrus"
 	ps "github.com/kotakanbe/go-pingscanner"
+	"github.com/sirupsen/logrus"
 )
 
 // DiscoverCmd is Subcommand of host discovery mode

--- a/config/config.go
+++ b/config/config.go
@@ -24,8 +24,8 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	valid "github.com/asaskevich/govalidator"
+	log "github.com/sirupsen/logrus"
 )
 
 // Conf has Configuration

--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	log "github.com/Sirupsen/logrus"
 	"github.com/future-architect/vuls/contrib/owasp-dependency-check/parser"
+	log "github.com/sirupsen/logrus"
 )
 
 // TOMLLoader loads config

--- a/report/cve_client.go
+++ b/report/cve_client.go
@@ -26,12 +26,12 @@ import (
 	"github.com/cenkalti/backoff"
 	"github.com/parnurzeal/gorequest"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/util"
 	cveconfig "github.com/kotakanbe/go-cve-dictionary/config"
 	cvedb "github.com/kotakanbe/go-cve-dictionary/db"
 	cve "github.com/kotakanbe/go-cve-dictionary/models"
+	log "github.com/sirupsen/logrus"
 )
 
 // CveClient is api client of CVE disctionary service.

--- a/report/slack.go
+++ b/report/slack.go
@@ -24,11 +24,11 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/cenkalti/backoff"
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/models"
 	"github.com/parnurzeal/gorequest"
+	log "github.com/sirupsen/logrus"
 )
 
 type field struct {

--- a/report/tui.go
+++ b/report/tui.go
@@ -26,13 +26,13 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/models"
 	"github.com/future-architect/vuls/util"
 	"github.com/google/subcommands"
 	"github.com/gosuri/uitable"
 	"github.com/jroimartin/gocui"
+	log "github.com/sirupsen/logrus"
 )
 
 var scanResults models.ScanResults

--- a/scan/base.go
+++ b/scan/base.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/models"
+	"github.com/sirupsen/logrus"
 )
 
 type base struct {

--- a/scan/debian_test.go
+++ b/scan/debian_test.go
@@ -22,11 +22,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/future-architect/vuls/cache"
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/models"
 	"github.com/k0kubun/pp"
+	"github.com/sirupsen/logrus"
 )
 
 func TestParseScannedPackagesLineDebian(t *testing.T) {

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -33,10 +33,10 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/cenkalti/backoff"
 	conf "github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/util"
+	"github.com/sirupsen/logrus"
 )
 
 type execResult struct {

--- a/util/logutil.go
+++ b/util/logutil.go
@@ -22,8 +22,8 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/rifflock/lfshook"
+	"github.com/sirupsen/logrus"
 
 	"github.com/future-architect/vuls/config"
 	formatter "github.com/kotakanbe/logrus-prefixed-formatter"


### PR DESCRIPTION
## What did you implement:

This errors occurred.

```
grouped write of manifest, lock and vendor: error while writing out vendor tree: error while exporting github.com/sirupsen/logrus: /var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/.gitignore already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/.travis.yml already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/CHANGELOG.md already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/LICENSE already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/README.md already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/alt_exit.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/alt_exit_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/doc.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/entry.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/entry_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/examples/basic/basic.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/examples/hook/hook.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/exported.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/formatter.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/formatter_bench_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hook_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/syslog/README.md already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/syslog/syslog.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/syslog/syslog_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/test/test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/hooks/test/test_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/json_formatter.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/json_formatter_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/logger.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/logger_bench_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/logrus.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/logrus_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_appengine.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_bsd.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_linux.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_notwindows.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_solaris.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/terminal_windows.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/text_formatter.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/text_formatter_test.go already exists, no checkout
/var/folders/wc/20f2d7j91rq4cvf5rz27h68h0000gn/T/dep434114490/vendor/github.com/sirupsen/logrus/writer.go already exists, no checkout
```

Packages conflict with uppercase and lowercase, because logrus changed packagename to lowercase.
https://github.com/sirupsen/logrus/issues/553

I want to update all vuls package's logrus package name to avoid this errors.
Target repositories are below.

1. [kotakanbe/logrus-prefixed-formatter](https://github.com/kotakanbe/logrus-prefixed-formatter/pull/1)
1. [kotakanbe/go-cve-dictionary](https://github.com/kotakanbe/go-cve-dictionary/pull/63)
1. [kotakanbe/goval-dictionary](https://github.com/kotakanbe/goval-dictionary/pull/10)
1. future-architect/vuls

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 
***Is it a breaking change?:*** YES
