### PR TITLE
add s3 dirctory option

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -44,10 +44,10 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/cheggaaa/pb"
   packages = ["."]
-  revision = "f6ccf2184de4dd34495277e38dc19b6e7fbe0ea2"
-  version = "v1.0.15"
+  revision = "0af82b7d15eb9371fbdf8f468ff10cbba62e0414"
 
 [[projects]]
   name = "github.com/dgrijalva/jwt-go"

--- a/README.ja.md
+++ b/README.ja.md
@@ -1063,6 +1063,7 @@ report:
                 [-aws-profile=default]
                 [-aws-region=us-west-2]
                 [-aws-s3-bucket=bucket_name]
+                [-aws-s3-results-dir=/bucket/path/to/results]
                 [-azure-account=accout]
                 [-azure-key=key]
                 [-azure-container=container]
@@ -1078,6 +1079,8 @@ report:
         AWS region to use (default "us-east-1")
   -aws-s3-bucket string
         S3 bucket name
+  -aws-s3-results-dir string
+        /bucket/path/to/results (option)
   -azure-account string
         Azure account name to use. AZURE_STORAGE_ACCOUNT environment variable is used if not specified
   -azure-container string
@@ -1135,7 +1138,7 @@ report:
   -to-localfile
         Write report to localfile
   -to-s3
-        Write report to S3 (bucket/yyyyMMdd_HHmm/servername.json/xml/txt)
+        Write report to S3 (bucket/dir/yyyyMMdd_HHmm/servername.json/xml/txt)
   -to-slack
         Send report via Slack
 ```

--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,7 @@ report:
                 [-aws-profile=default]
                 [-aws-region=us-west-2]
                 [-aws-s3-bucket=bucket_name]
+                [-aws-s3-results-dir=/bucket/path/to/results]
                 [-azure-account=accout]
                 [-azure-key=key]
                 [-azure-container=container]
@@ -1087,6 +1088,8 @@ report:
         AWS region to use (default "us-east-1")
   -aws-s3-bucket string
         S3 bucket name
+  -aws-s3-results-dir string
+        /bucket/path/to/results (option)
   -azure-account string
         Azure account name to use. AZURE_STORAGE_ACCOUNT environment variable is used if not specified
   -azure-container string
@@ -1144,7 +1147,7 @@ report:
   -to-localfile
         Write report to localfile
   -to-s3
-        Write report to S3 (bucket/yyyyMMdd_HHmm/servername.json/xml/txt)
+        Write report to S3 (bucket/dir/yyyyMMdd_HHmm/servername.json/xml/txt)
   -to-slack
         Send report via Slack
 ```
@@ -1315,6 +1318,7 @@ $ vuls report \
       -format-json \
       -aws-region=ap-northeast-1 \
       -aws-s3-bucket=vuls \
+      -aws-s3-results-dir=/bucket/path/to/results \
       -aws-profile=default
 ```
 With this sample command, it will ..

--- a/commands/report.go
+++ b/commands/report.go
@@ -69,9 +69,10 @@ type ReportCmd struct {
 
 	gzip bool
 
-	awsProfile  string
-	awsS3Bucket string
-	awsRegion   string
+	awsProfile      string
+	awsS3Bucket     string
+	awsS3ResultsDir string
+	awsRegion       string
 
 	azureAccount   string
 	azureKey       string
@@ -121,6 +122,7 @@ func (*ReportCmd) Usage() string {
 		[-aws-profile=default]
 		[-aws-region=us-west-2]
 		[-aws-s3-bucket=bucket_name]
+		[-aws-s3-results-dir=/bucket/path/to/results]
 		[-azure-account=accout]
 		[-azure-key=key]
 		[-azure-container=container]
@@ -263,6 +265,7 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&p.awsProfile, "aws-profile", "default", "AWS profile to use")
 	f.StringVar(&p.awsRegion, "aws-region", "us-east-1", "AWS region to use")
 	f.StringVar(&p.awsS3Bucket, "aws-s3-bucket", "", "S3 bucket name")
+	f.StringVar(&p.awsS3ResultsDir, "aws-s3-results-dir", "", "/bucket/path/to/results")
 
 	f.BoolVar(&p.toAzureBlob,
 		"to-azure-blob",
@@ -357,6 +360,7 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 		c.Conf.AwsRegion = p.awsRegion
 		c.Conf.AwsProfile = p.awsProfile
 		c.Conf.S3Bucket = p.awsS3Bucket
+		c.Conf.S3ResultsDir = p.awsS3ResultsDir
 		if err := report.CheckIfBucketExists(); err != nil {
 			util.Log.Errorf("Check if there is a bucket beforehand: %s, err: %s", c.Conf.S3Bucket, err)
 			return subcommands.ExitUsageError

--- a/config/config.go
+++ b/config/config.go
@@ -104,9 +104,10 @@ type Config struct {
 
 	GZIP bool
 
-	AwsProfile string
-	AwsRegion  string
-	S3Bucket   string
+	AwsProfile   string
+	AwsRegion    string
+	S3Bucket     string
+	S3ResultsDir string
 
 	AzureAccount   string
 	AzureKey       string

--- a/report/s3.go
+++ b/report/s3.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -147,8 +148,8 @@ func putObject(svc *s3.S3, k string, b []byte) error {
 	}
 
 	if _, err := svc.PutObject(&s3.PutObjectInput{
-		Bucket: &c.Conf.S3Bucket,
-		Key:    &k,
+		Bucket: aws.String(c.Conf.S3Bucket),
+		Key:    aws.String(path.Join(c.Conf.S3ResultsDir, k)),
 		Body:   bytes.NewReader(b),
 	}); err != nil {
 		return fmt.Errorf("Failed to upload data to %s/%s, %s",


### PR DESCRIPTION
## What did you implement:

I want to put to s3 with a specific directory name.

## How did you implement it:

Add S3 directory option `-aws-s3-dir=/path/to/results's/parent`

## How can we verify it:

```
$ vuls report -to-s3 -format-json -aws-region=ap-northeast-1 -aws-s3-bucket=vuls -aws-s3-dir=something/something -aws-profile=vuls
```

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 
***Is it a breaking change?:*** NO
