### PR TITLE
fix typos in commands.

### DIFF
--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -174,7 +174,7 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 		return subcommands.ExitFailure
 	}
 
-	util.Log.Info("Checking dependendies...")
+	util.Log.Info("Checking dependencies...")
 	scan.CheckDependencies(p.timeoutSec)
 
 	util.Log.Info("Checking sudo settings...")

--- a/commands/discover.go
+++ b/commands/discover.go
@@ -87,9 +87,9 @@ func (p *DiscoverCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface
 	return subcommands.ExitSuccess
 }
 
-// Output the tmeplate of config.toml
+// Output the template of config.toml
 func printConfigToml(ips []string) (err error) {
-	const tomlTempale = `
+	const tomlTemplate = `
 [slack]
 hookURL      = "https://hooks.slack.com/services/abc123/defghijklmnopqrstuvwxyz"
 channel      = "#channel-name"
@@ -99,13 +99,13 @@ authUser     = "username"
 notifyUsers  = ["@username"]
 
 [email]
-smtpAddr      = "smtp.gmail.com"
+smtpAddr      = "smtp.example.com"
 smtpPort      = "587"
 user          = "username"
 password      = "password"
-from          = "from@address.com"
-to            = ["to@address.com"]
-cc            = ["cc@address.com"]
+from          = "from@example.com"
+to            = ["to@example.com"]
+cc            = ["cc@example.com"]
 subjectPrefix = "[vuls]"
 
 [default]
@@ -140,7 +140,7 @@ host         = "{{$ip}}"
 #    ["key", "value"],
 #]
 #[servers.{{index $names $i}}.containers]
-#type = "docker" #or "lxd" defualt: docker
+#type = "docker" #or "lxd" default: docker
 #includes = ["${running}"]
 #excludes = ["container_name_a", "4aa37a8b63b9"]
 
@@ -149,7 +149,7 @@ host         = "{{$ip}}"
 
 `
 	var tpl *template.Template
-	if tpl, err = template.New("tempalte").Parse(tomlTempale); err != nil {
+	if tpl, err = template.New("template").Parse(tomlTemplate); err != nil {
 		return
 	}
 
@@ -167,7 +167,7 @@ host         = "{{$ip}}"
 	}
 	a.Names = names
 
-	fmt.Println("# Create config.toml using below and then ./vuls --config=/path/to/config.toml")
+	fmt.Println("# Create config.toml using below and then ./vuls -config=/path/to/config.toml")
 	if err = tpl.Execute(os.Stdout, a); err != nil {
 		return
 	}

--- a/commands/report.go
+++ b/commands/report.go
@@ -123,7 +123,7 @@ func (*ReportCmd) Usage() string {
 		[-aws-region=us-west-2]
 		[-aws-s3-bucket=bucket_name]
 		[-aws-s3-results-dir=/bucket/path/to/results]
-		[-azure-account=accout]
+		[-azure-account=account]
 		[-azure-key=key]
 		[-azure-container=container]
 		[-http-proxy=http://192.168.0.1:8080]
@@ -381,7 +381,7 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 
 		c.Conf.AzureContainer = p.azureContainer
 		if len(c.Conf.AzureContainer) == 0 {
-			util.Log.Error("Azure storage container name is requied with --azure-container option")
+			util.Log.Error("Azure storage container name is required with -azure-container option")
 			return subcommands.ExitUsageError
 		}
 		if err := report.CheckIfAzureContainerExists(); err != nil {
@@ -402,7 +402,7 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	}
 	if err := report.CveClient.CheckHealth(); err != nil {
 		util.Log.Errorf("CVE HTTP server is not running. err: %s", err)
-		util.Log.Errorf("Run go-cve-dictionary as server mode before reporting or run with --cvedb-path option")
+		util.Log.Errorf("Run go-cve-dictionary as server mode before reporting or run with -cvedb-path option")
 		return subcommands.ExitFailure
 	}
 	if c.Conf.CveDBURL != "" {
@@ -417,7 +417,7 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 		err := oval.Base{}.CheckHTTPHealth()
 		if err != nil {
 			util.Log.Errorf("OVAL HTTP server is not running. err: %s", err)
-			util.Log.Errorf("Run goval-dictionary as server mode before reporting or run with --ovaldb-path option")
+			util.Log.Errorf("Run goval-dictionary as server mode before reporting or run with -ovaldb-path option")
 			return subcommands.ExitFailure
 		}
 	}

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -138,7 +138,7 @@ func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 		&p.deep,
 		"deep",
 		false,
-		"Deep scan mode. Scan accuracy improves and scanned information becomes richer. Since analysis of changelog, issue commands requiring sudo, but it may be slower and high load on the tareget server")
+		"Deep scan mode. Scan accuracy improves and scanned information becomes richer. Since analysis of changelog, issue commands requiring sudo, but it may be slower and high load on the target server")
 
 	f.BoolVar(
 		&p.pipe,
@@ -157,7 +157,7 @@ func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 		&p.scanTimeoutSec,
 		"timeout-scan",
 		120*60,
-		"Number of seconds for scaning vulnerabilities for all servers",
+		"Number of seconds for scanning vulnerabilities for all servers",
 	)
 }
 

--- a/commands/tui.go
+++ b/commands/tui.go
@@ -56,7 +56,7 @@ type TuiCmd struct {
 func (*TuiCmd) Name() string { return "tui" }
 
 // Synopsis return synopsis
-func (*TuiCmd) Synopsis() string { return "Run Tui view to anayze vulnerabilites" }
+func (*TuiCmd) Synopsis() string { return "Run Tui view to analyze vulnerabilities" }
 
 // Usage return usage
 func (*TuiCmd) Usage() string {
@@ -118,7 +118,7 @@ func (p *TuiCmd) SetFlags(f *flag.FlagSet) {
 		&p.cveDictionaryURL,
 		"cvedb-url",
 		"",
-		"http://cve-dictionary.com:1323 or mysql connection string")
+		"http://cve-dictionary.example.com:1323 or mysql connection string")
 
 	f.StringVar(
 		&p.ovalDBType,
@@ -137,7 +137,7 @@ func (p *TuiCmd) SetFlags(f *flag.FlagSet) {
 		&p.ovalDBURL,
 		"ovaldb-url",
 		"",
-		"http://goval-dictionary.com:1324 or mysql connection string")
+		"http://goval-dictionary.example.com:1324 or mysql connection string")
 
 	f.BoolVar(
 		&p.pipe,


### PR DESCRIPTION
## What did you implement:

- fix some typos in fixed strings.
- modified to use the correct domain for documents. (example.com)

## How did you implement it:

none

## How can we verify it:

read diff.

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
