### PR TITLE
Add changelog local cache for RedHat based linux.

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -615,29 +615,31 @@ Vulsをスキャン対象サーバにデプロイする。Vulsはローカルホ
 | Distribution|                            Scan Speed |       Need Root Privilege |      OVAL | Need Internet Access <br>on scan tareget|
 |:------------|:-------------------------------------:|:-------------------------:|:---------:|:---------------------------------------:|
 | Alpine      |                                  Fast |　                      No | Supported |                                    Need |
-| CentOS      |                                  Slow |　                      No | Supported |                                    Need |
-| RHEL        |                                  Slow |　                    Need | Supported |                                    Need |
-| Oracle      |                                  Slow |　                    Need | Supported |                                    Need |
+| CentOS      |1st time: Slow <br> From 2nd time: Fast|　                    Need | Supported |                                    Need | 
+| RHEL        |1st time: Slow <br> From 2nd time: Fast|　                    Need | Supported |                                    Need |
+| Oracle      |1st time: Slow <br> From 2nd time: Fast|　                    Need | Supported |                                    Need |
+| Amazon      |1st time: Slow <br> From 2nd time: Fast|　                    Need |        No |                                    Need |
 | Ubuntu      |1st time: Slow <br> From 2nd time: Fast|                      Need | Supported |                                    Need |
 | Debian      |1st time: Slow <br> From 2nd time: Fast|                      Need | Supported |                                    Need |
 | Raspbian    |1st time: Slow <br> From 2nd time: Fast|                      Need |        No |                                    Need |
 | FreeBSD     |                                  Fast |　                      No |        No |                                    Need |
-| Amazon      |                                  Slow |　                      No |        No |                                    Need |
 | SUSE Enterprise |                              Fast |　                      No |  Supported |                                     No |
 
-
-- On Ubuntu, Debian and Raspbian
-`apt-get changelog`でアップデート対象のパッケージのチェンジログを取得し、含まれるCVE IDをパースする。
+- Ubuntu, Debian and Raspbian, RedHat, CentOS, Oracle Linux and Amazon Linux
+`apt-get changelog` や `yum changelog` でアップデート対象のパッケージのチェンジログを取得する。
 アップデート対象のパッケージが沢山ある場合、チェンジログの取得に時間がかかるので、初回のスキャンは遅い。  
 ただ、２回目以降はキャッシュしたchangelogを使うので速くなる。  
 
-- On CentOS
-`yum changelog`でアップデート対象のパッケージのチェンジログを取得し、含まれるCVE IDをパースする。
+- Ubuntu, Debian and Raspbian
+チェンジログに含まれるCVE IDをパースする。
 
-- On RHEL, Oracle, Amazon and FreeBSD
+- CentOS  
+チェンジログに含まれるCVE IDをパースする。
+
+- RHEL, Oracle, Amazon and FreeBSD
 `yum changelog`でアップデート対象のパッケージのチェンジログを取得する(パースはしない)。
 
-- On SUSE Enterprise Linux and Alpine Linux
+- SUSE Enterprise Linux and Alpine Linux
 Same as fast scan mode for now.
 
 ----

--- a/README.md
+++ b/README.md
@@ -620,30 +620,32 @@ On the aggregation server, you can refer to the scanning result of each scan tar
 | Distribution|                            Scan Speed |       Need Root Privilege |      OVAL | Need Internet Access <br>on scan tareget|
 |:------------|:-------------------------------------:|:-------------------------:|:---------:|:---------------------------------------:|
 | Alpine      |                                  Fast |　                      No | Supported |                                    Need |
-| CentOS      |                                  Slow |　                      No | Supported |                                    Need |
-| RHEL        |                                  Slow |　                    Need | Supported |                                    Need |
-| Oracle      |                                  Slow |　                    Need | Supported |                                    Need |
+| CentOS      |1st time: Slow <br> From 2nd time: Fast|　                    Need | Supported |                                    Need | 
+| RHEL        |1st time: Slow <br> From 2nd time: Fast|　                    Need | Supported |                                    Need |
+| Oracle      |1st time: Slow <br> From 2nd time: Fast|　                    Need | Supported |                                    Need |
+| Amazon      |1st time: Slow <br> From 2nd time: Fast|　                    Need |        No |                                    Need |
 | Ubuntu      |1st time: Slow <br> From 2nd time: Fast|                      Need | Supported |                                    Need |
 | Debian      |1st time: Slow <br> From 2nd time: Fast|                      Need | Supported |                                    Need |
 | Raspbian    |1st time: Slow <br> From 2nd time: Fast|                      Need |        No |                                    Need |
 | FreeBSD     |                                  Fast |　                      No |        No |                                    Need |
-| Amazon      |                                  Slow |　                      No |        No |                                    Need |
 | SUSE Enterprise |                              Fast |　                      No |  Supported |                                     No |
 
-
-- On Ubuntu, Debian and Raspbian
-Vuls issues `apt-get changelog` for each upgradable packages and parse the changelog.  
-`apt-get changelog` is slow and resource usage is heavy when there are many updatable packages on target server.   
+- Ubuntu, Debian and Raspbian, RedHat, CentOS, Oracle Linux and Amazon Linux
+Vuls issues `apt-get changelog` or `yum changelog` for each upgradable package.
+`apt-get changelog` and `yum changelog` is slow and resource usage is heavy when there are many updatable packages on target server.   
 Vuls stores these changelogs to KVS([boltdb](https://github.com/boltdb/bolt)).  
 From the second time on, the scan speed is fast by using the local cache.
 
-- On CentOS
-Vuls issues `yum changelog` to get changelogs of upgradable packages at once and parse the changelog.  
+- Ubuntu, Debian and Raspbian
+Parse the changelog to get the CVE-IDs.  
 
-- On RHEL, Oracle, Amazon and FreeBSD
+- CentOS
+Parse the changelog to get the CVE-IDs.  
+
+- RHEL, Oracle Linux, Amazon Linux and FreeBSD
 Detect CVE IDs by using package manager.
 
-- On SUSE Enterprise Linux and Alpine Linux
+- SUSE Enterprise Linux and Alpine Linux
 Same as fast scan mode for now.
 
 ----

--- a/models/packages.go
+++ b/models/packages.go
@@ -141,7 +141,7 @@ func (p Package) FormatChangelog() string {
 	case FailedToGetChangelog:
 		clog = "No changelogs"
 	case FailedToFindVersionInChangelog:
-		clog = "Failed to parse changelogs. For detials, check yourself"
+		// clog = "Failed to parse changelogs. For detials, check yourself"
 	}
 	buf = append(buf, packVer, delim.String(), clog)
 	return strings.Join(buf, "\n")

--- a/report/util.go
+++ b/report/util.go
@@ -234,18 +234,6 @@ func cweJvnURL(cweID string) string {
 	return fmt.Sprintf("http://jvndb.jvn.jp/ja/cwe/%s.html", cweID)
 }
 
-func formatChangelogs(r models.ScanResult) string {
-	buf := []string{}
-	for _, p := range r.Packages {
-		if p.NewVersion == "" {
-			continue
-		}
-		clog := p.FormatChangelog()
-		buf = append(buf, clog, "\n\n")
-	}
-	return strings.Join(buf, "\n")
-}
-
 func needToRefreshCve(r models.ScanResult) bool {
 	if r.Lang != config.Conf.Lang {
 		return true

--- a/scan/serverapi.go
+++ b/scan/serverapi.go
@@ -436,7 +436,7 @@ func setupChangelogCache() error {
 		case config.Raspbian:
 			needToSetupCache = true
 			break
-		case config.Ubuntu, config.Debian:
+		case config.Ubuntu, config.Debian, config.CentOS, config.Oracle, config.RedHat, config.Amazon:
 			//TODO changelopg cache for RedHat, Oracle, Amazon, CentOS is not implemented yet.
 			if config.Conf.Deep {
 				needToSetupCache = true


### PR DESCRIPTION
# TODO 

Fix README ... yum changelog to /etc/sudoers on RHEL, Oracle

## What did you implement:

When Vuls scan with --deep option, the server issues `yum changelog` for each upgradable packages. `yum changelog` is too slow because the changelog will be fetched via Internet.
So Vuls stores the fetched changelog to the local cache(boltDB). 
1st scan is slow, but from second time will be fast. 

## How did you implement it:

Store fetched changelogs to boltdb.

## How can we verify it:

./scan --deep

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
