### PR TITLE
Fix sort order of servers on TUI

### DIFF
--- a/report/tui.go
+++ b/report/tui.go
@@ -45,6 +45,12 @@ var currentChangelogLimitY int
 // RunTui execute main logic
 func RunTui(results models.ScanResults) subcommands.ExitStatus {
 	scanResults = results
+	sort.Slice(scanResults, func(i, j int) bool {
+		if scanResults[i].ServerName == scanResults[j].ServerName {
+			return scanResults[i].Container.Name < scanResults[j].Container.Name
+		}
+		return scanResults[i].ServerName < scanResults[j].ServerName
+	})
 
 	// g, err := gocui.NewGui(gocui.OutputNormal)
 	g := gocui.NewGui()


### PR DESCRIPTION
## How did you implement it:

Sort ScanResults by servername, container-name

***Is it a breaking change?:*** NO
