### PR TITLE
Debian: Use --showformat flag to get status of packages and ignore n(not-inst…

### DIFF
--- a/scan/debian.go
+++ b/scan/debian.go
@@ -252,11 +252,18 @@ func (o *debian) scanInstalledPackages() (models.Packages, models.Packages, erro
 	for _, line := range lines {
 		if trimmed := strings.TrimSpace(line); len(trimmed) != 0 {
 			name, status, version, err := o.parseScannedPackagesLine(trimmed)
-			installStatus := status[1]
-			// n -- not-installed
-			// c -- config-files
-			if installStatus == 'n' || installStatus == 'c' {
-				o.log.Debugf("%s status is '%c', ignoring", name, installStatus)
+			packageStatus := status[1]
+			// Package status:
+			//     n = Not-installed
+			//     c = Config-files
+			//     H = Half-installed
+			//     U = Unpacked
+			//     F = Half-configured
+			//     W = Triggers-awaiting
+			//     t = Triggers-pending
+			//     i = Installed
+			if packageStatus != 'i' {
+				o.log.Debugf("%s package status is '%c', ignoring", name, packageStatus)
 				continue
 			}
 			if err != nil {

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -240,7 +240,7 @@ func (o *debian) rebootRequired() (bool, error) {
 
 func (o *debian) scanInstalledPackages() (models.Packages, models.Packages, error) {
 	installed, updatable := models.Packages{}, models.Packages{}
-	r := o.exec("dpkg-query -W -f=\"\\${binary:Package}\\t\\${db:Status-Abbrev}\\t\\${Version}\n\"", noSudo)
+	r := o.exec(`dpkg-query -W -f='${binary:Package}\t${db:Status-Abbrev}\t${Version}\n'`, noSudo)
 	if !r.isSuccess() {
 		return nil, nil, fmt.Errorf("Failed to SSH: %s", r)
 	}

--- a/scan/debian_test.go
+++ b/scan/debian_test.go
@@ -34,22 +34,26 @@ func TestParseScannedPackagesLineDebian(t *testing.T) {
 	var packagetests = []struct {
 		in      string
 		name    string
+		status  string
 		version string
 	}{
-		{"base-passwd	3.5.33", "base-passwd", "3.5.33"},
-		{"bzip2	1.0.6-5", "bzip2", "1.0.6-5"},
-		{"adduser	3.113+nmu3ubuntu3", "adduser", "3.113+nmu3ubuntu3"},
-		{"bash	4.3-7ubuntu1.5", "bash", "4.3-7ubuntu1.5"},
-		{"bsdutils	1:2.20.1-5.1ubuntu20.4", "bsdutils", "1:2.20.1-5.1ubuntu20.4"},
-		{"ca-certificates	20141019ubuntu0.14.04.1", "ca-certificates", "20141019ubuntu0.14.04.1"},
-		{"apt	1.0.1ubuntu2.8", "apt", "1.0.1ubuntu2.8"},
+		{"base-passwd	ii 	3.5.33", "base-passwd", "ii ", "3.5.33"},
+		{"bzip2	ii 	1.0.6-5", "bzip2", "ii ", "1.0.6-5"},
+		{"adduser	ii 	3.113+nmu3ubuntu3", "adduser", "ii ", "3.113+nmu3ubuntu3"},
+		{"bash	ii 	4.3-7ubuntu1.5", "bash", "ii ", "4.3-7ubuntu1.5"},
+		{"bsdutils	ii 	1:2.20.1-5.1ubuntu20.4", "bsdutils", "ii ", "1:2.20.1-5.1ubuntu20.4"},
+		{"ca-certificates	ii 	20141019ubuntu0.14.04.1", "ca-certificates", "ii ", "20141019ubuntu0.14.04.1"},
+		{"apt	rc 	1.0.1ubuntu2.8", "apt", "rc ", "1.0.1ubuntu2.8"},
 	}
 
 	d := newDebian(config.ServerInfo{})
 	for _, tt := range packagetests {
-		n, v, _ := d.parseScannedPackagesLine(tt.in)
+		n, s, v, _ := d.parseScannedPackagesLine(tt.in)
 		if n != tt.name {
 			t.Errorf("name: expected %s, actual %s", tt.name, n)
+		}
+		if s != tt.status {
+			t.Errorf("status: expected %s, actual %s", tt.name, n)
 		}
 		if v != tt.version {
 			t.Errorf("version: expected %s, actual %s", tt.version, v)

--- a/scan/debian_test.go
+++ b/scan/debian_test.go
@@ -53,7 +53,7 @@ func TestParseScannedPackagesLineDebian(t *testing.T) {
 			t.Errorf("name: expected %s, actual %s", tt.name, n)
 		}
 		if s != tt.status {
-			t.Errorf("status: expected %s, actual %s", tt.name, n)
+			t.Errorf("status: expected %s, actual %s", tt.status, s)
 		}
 		if v != tt.version {
 			t.Errorf("version: expected %s, actual %s", tt.version, v)


### PR DESCRIPTION
…alled) and c(removed, only has config files remaining) packages.

## What did you implement:

Ignore uninstalled packages on debian hosts.

## How did you implement it:

1. passing --showformat flag to display status
2. ignoring packages having status 'not-installed' or 'config-files'

## How can we verify it:


## Todos:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
