### PR TITLE
Check whether repoquery with sudo nopasswd in deep scan mode on RedHat

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -919,13 +919,13 @@ For details, see [-ssh-native-insecure option](#-ssh-native-insecure-option)
 
 - RHEL 5 / Oracle Linux 5
 ```
-vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never list-security --security, /usr/bin/yum --color=never info-security
+vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never list-security --security, /usr/bin/yum --color=never info-security, /usr/bin/repoquery
 Defaults:vuls env_keep="http_proxy https_proxy HTTP_PROXY HTTPS_PROXY"
 ```
 
 - RHEL 6, 7 / Oracle Linux 6, 7
 ```
-vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never --security updateinfo list updates, /usr/bin/yum --color=never --security updateinfo updates
+vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never --security updateinfo list updates, /usr/bin/yum --color=never --security updateinfo updates, /usr/bin/repoquery
 Defaults:vuls env_keep="http_proxy https_proxy HTTP_PROXY HTTPS_PROXY"
 ```
 

--- a/README.md
+++ b/README.md
@@ -928,13 +928,13 @@ Example of /etc/sudoers on target servers
 
 - RHEL 5 / Oracle Linux 5
 ```
-vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never list-security --security, /usr/bin/yum --color=never info-security
+vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never list-security --security, /usr/bin/yum --color=never info-security, /usr/bin/repoquery
 Defaults:vuls env_keep="http_proxy https_proxy HTTP_PROXY HTTPS_PROXY"
 ```
 
 - RHEL 6, 7 / Oracle Linux 6, 7
 ```
-vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never --security updateinfo list updates, /usr/bin/yum --color=never --security updateinfo updates
+vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never --security updateinfo list updates, /usr/bin/yum --color=never --security updateinfo updates, /usr/bin/repoquery
 Defaults:vuls env_keep="http_proxy https_proxy HTTP_PROXY HTTPS_PROXY"
 ```
 

--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -153,6 +153,10 @@ func (o *redhat) checkIfSudoNoPasswd() error {
 				{"yum --color=never --security updateinfo updates", zero},
 			}
 		}
+
+		if o.Distro.Family == config.RedHat {
+			cmds = append(cmds, cmd{"repoquery -h", zero})
+		}
 	}
 
 	for _, c := range cmds {


### PR DESCRIPTION

## How did you implement it:

Add a check logic to CheckIfSudoNopasswd()


```
$ /vuls configtest --deep rhel
[Sep 14 08:48:40]  INFO [localhost] Validating config...
[Sep 14 08:48:40]  INFO [localhost] Detecting Server/Container OS...
[Sep 14 08:48:40]  INFO [localhost] Detecting OS of servers...
[Sep 14 08:48:47]  INFO [localhost] (1/1) Detected: rhel: redhat 7.2
[Sep 14 08:48:47]  INFO [localhost] Detecting OS of containers...
[Sep 14 08:48:47]  INFO [localhost] Checking dependencies...
[Sep 14 08:48:50]  INFO [rhel] Dependencies ... Pass
[Sep 14 08:48:50]  INFO [localhost] Checking sudo settings...
[Sep 14 08:48:50]  INFO [rhel] Checking... sudo yum --color=never repolist
[Sep 14 08:48:52]  INFO [rhel] Checking... sudo yum --color=never --security updateinfo list updates
[Sep 14 08:48:54]  INFO [rhel] Checking... sudo yum --color=never --security updateinfo updates
[Sep 14 08:48:59]  INFO [rhel] Checking... sudo repoquery -h
[Sep 14 08:49:00]  INFO [rhel] Sudo... Pass
```

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
