### PR TITLE
Update redhat.go

### DIFF
--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -462,7 +462,7 @@ func (o *redhat) getAvailableChangelogs(packNames []string) (map[string]string, 
 	cmd := `yum --color=never %s changelog all %s | grep -A 10000 '==================== Available Packages ===================='`
 	cmd = fmt.Sprintf(cmd, yumopts, strings.Join(packNames, " "))
 
-	r := o.exec(util.PrependProxyEnv(cmd), o.sudo())
+	r := o.exec(util.PrependProxyEnv(cmd), noSudo)
 	if !r.isSuccess(0, 1) {
 		return nil, fmt.Errorf("Failed to SSH: %s", r)
 	}


### PR DESCRIPTION
Yanking sudo. There's no reason to call sudo on these commands. The alternative (that I know of) is to wildcard yum changelog command which is a bad idea.

## What did you implement:

Closes #494 

## How did you implement it:
Swapped out the sudo call for noSudo.

## How can we verify it:
Test. See if you get hangs on Red Hat 7 boxes because of sudo prompt when there are vulnerabilities. 

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [X ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** yes  
***Is it a breaking change?:*** NO
