### PR TITLE
Add filter options to tui subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1614,13 +1614,16 @@ How to integrate Vuls with OWASP Dependency Check
 ```
 tui:
         tui
+                [-refresh-cve]
                 [-cvedb-type=sqlite3|mysql|postgres]
                 [-cvedb-path=/path/to/cve.sqlite3]
                 [-cvedb-url=http://127.0.0.1:1323 DB connection string]
                 [-ovaldb-type=sqlite3|mysql]
                 [-ovaldb-path=/path/to/oval.sqlite3]
                 [-ovaldb-url=http://127.0.0.1:1324 or DB connection string]
-                [-refresh-cve]
+				[-cvss-over=7]
+				[-ignore-unscored-cves]
+				[-ignore-unfixed]
                 [-results-dir=/path/to/results]
                 [-log-dir=/path/to/log]
                 [-debug]
@@ -1639,6 +1642,12 @@ tui:
         DB type for fetching OVAL dictionary (sqlite3 or mysql) (default "sqlite3")
   -ovaldb-url string
         http://goval-dictionary.com:1324 or mysql connection string
+  -cvss-over float
+        -cvss-over=6.5 means reporting CVSS Score 6.5 and over (default: 0 (means report all))
+  -ignore-unfixed
+        Don't report the unfixed CVEs
+  -ignore-unscored-cves
+        Don't report the unscored CVEs
   -debug
         debug mode
   -debug-sql

--- a/report/report.go
+++ b/report/report.go
@@ -82,6 +82,9 @@ func FillCveInfos(rs []models.ScanResult, dir string) ([]models.ScanResult, erro
 		r = r.FilterByCvssOver(c.Conf.CvssScoreOver)
 		r = r.FilterIgnoreCves(c.Conf.Servers[r.ServerName].IgnoreCves)
 		r = r.FilterUnfixed()
+		if c.Conf.IgnoreUnscoredCves {
+			r.ScannedCves = r.ScannedCves.FindScoredVulns()
+		}
 		filtered = append(filtered, r)
 	}
 	return filtered, nil

--- a/report/slack.go
+++ b/report/slack.go
@@ -165,13 +165,7 @@ func msgText(r models.ScanResult) string {
 }
 
 func toSlackAttachments(r models.ScanResult) (attaches []*attachment) {
-	var vinfos []models.VulnInfo
-	if config.Conf.IgnoreUnscoredCves {
-		vinfos = r.ScannedCves.FindScoredVulns().ToSortedSlice()
-	} else {
-		vinfos = r.ScannedCves.ToSortedSlice()
-	}
-
+	vinfos := r.ScannedCves.ToSortedSlice()
 	for _, vinfo := range vinfos {
 		curent := []string{}
 		for _, affected := range vinfo.AffectedPackages {

--- a/report/util.go
+++ b/report/util.go
@@ -93,12 +93,7 @@ func formatShortPlainText(r models.ScanResult) string {
 			header, r.Errors)
 	}
 
-	vulns := r.ScannedCves
-	if config.Conf.IgnoreUnscoredCves {
-		vulns = vulns.FindScoredVulns()
-	}
-
-	if len(vulns) == 0 {
+	if len(r.ScannedCves) == 0 {
 		return fmt.Sprintf(`
 %s
 No CVE-IDs are found in updatable packages.
@@ -109,7 +104,7 @@ No CVE-IDs are found in updatable packages.
 	stable := uitable.New()
 	stable.MaxColWidth = maxColWidth
 	stable.Wrap = true
-	for _, vuln := range vulns.ToSortedSlice() {
+	for _, vuln := range r.ScannedCves.ToSortedSlice() {
 		summaries := vuln.Summaries(config.Conf.Lang, r.Family)
 		links := vuln.CveContents.SourceLinks(
 			config.Conf.Lang, r.Family, vuln.CveID)
@@ -167,12 +162,7 @@ func formatFullPlainText(r models.ScanResult) string {
 			header, r.Errors)
 	}
 
-	vulns := r.ScannedCves
-	if config.Conf.IgnoreUnscoredCves {
-		vulns = vulns.FindScoredVulns()
-	}
-
-	if len(vulns) == 0 {
+	if len(r.ScannedCves) == 0 {
 		return fmt.Sprintf(`
 %s
 No CVE-IDs are found in updatable packages.
@@ -183,7 +173,7 @@ No CVE-IDs are found in updatable packages.
 	table := uitable.New()
 	table.MaxColWidth = maxColWidth
 	table.Wrap = true
-	for _, vuln := range vulns.ToSortedSlice() {
+	for _, vuln := range r.ScannedCves.ToSortedSlice() {
 		table.AddRow(vuln.CveID)
 		table.AddRow("----------------")
 		table.AddRow("Max Score", vuln.FormatMaxCvssScore())


### PR DESCRIPTION
Add below options to TUI subcommand.

[-cvss-over=7]
[-ignore-unscored-cves]
[-ignore-unfixed]

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
