### PR TITLE
fix typo from "enviroment" to "environment"

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -109,7 +109,7 @@ func ProxyEnv() string {
 	return httpProxyEnv
 }
 
-// PrependProxyEnv prepends proxy enviroment variable
+// PrependProxyEnv prepends proxy environment variable
 func PrependProxyEnv(cmd string) string {
 	if len(config.Conf.HTTPProxy) == 0 {
 		return cmd


### PR DESCRIPTION
## What did you implement:

Closes #XXXXX

## How did you implement it:

Just fix typo in comments

## How can we verify it:

no need to verify,  just in comments

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
