### PR TITLE
send slack msg by api

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -205,6 +205,12 @@
   revision = "9ac6cf4d929b2fa8fd2d2e6dec5bb0feb4f4911d"
 
 [[projects]]
+  name = "github.com/nlopes/slack"
+  packages = ["."]
+  revision = "c86337c0ef2486a15edd804355d9c73d2f2caed1"
+  version = "v0.1.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/nsf/termbox-go"
   packages = ["."]
@@ -255,7 +261,7 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","idna","publicsuffix"]
+  packages = ["context","idna","publicsuffix","websocket"]
   revision = "0a9397675ba34b2845f758fe3cd68828369c6517"
 
 [[projects]]
@@ -273,6 +279,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0c23b5c957347ae72a4d8ca746920d2236b8e39ede1eb78290ead8c42fcaa1a7"
+  inputs-digest = "a1a930024748f9419c11b784649bc52492fb0b5a1c95c3dc4a36d52a688dcc48"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.ja.md
+++ b/README.ja.md
@@ -740,6 +740,7 @@ host         = "172.31.4.82"
     ```
     [slack]
     hookURL      = "https://hooks.slack.com/services/abc123/defghijklmnopqrstuvwxyz"
+    #legacyToken  = "xoxp-11111111111-222222222222-3333333333"
     channel      = "#channel-name"
     #channel      = "${servername}"
     iconEmoji    = ":ghost:"
@@ -747,10 +748,12 @@ host         = "172.31.4.82"
     notifyUsers  = ["@username"]
     ```
 
-    - hookURL : Incoming webhook's URL  
+    - hookURL : Incoming webhook's URL (legacyTokenが設定されている場合、hookURLは無視される。)
+    - legacyToken : slack legacy token (https://api.slack.com/custom-integrations/legacy-tokens)
     - channel : channel name.  
     channelに`${servername}`を指定すると、結果レポートをサーバごとに別チャネルにすることが出来る。
     以下のサンプルでは、`#server1`チャネルと`#server2`チャネルに送信される。スキャン前にチャネルを作成する必要がある。
+    **legacyTokenが設定されている場合、channelは実在するchannelでなければならない。**
       ```
       [slack]
       channel      = "${servername}"

--- a/README.md
+++ b/README.md
@@ -754,6 +754,7 @@ You can customize your configuration using this template.
     ```
     [slack]
     hookURL      = "https://hooks.slack.com/services/abc123/defghijklmnopqrstuvwxyz"
+    #legacyToken  = "xoxp-11111111111-222222222222-3333333333"
     channel      = "#channel-name"
     #channel      = "${servername}"
     iconEmoji    = ":ghost:"
@@ -761,11 +762,13 @@ You can customize your configuration using this template.
     notifyUsers  = ["@username"]
     ```
 
-    - hookURL : Incoming webhook's URL  
-    - channel : channel name.  
+    - hookURL : Incoming webhook's URL (hookURL is ignored when legacyToken is set.)
+    - legacyToken : slack legacy token (https://api.slack.com/custom-integrations/legacy-tokens)
+    - channel : channel name. 
     If you set `${servername}` to channel, the report will be sent to each channel.  
     In the following example, the report will be sent to the `#server1` and `#server2`.  
     Be sure to create these channels before scanning.
+    **if legacyToken is set, you must set up an existing channel**
       ```
       [slack]
       channel      = "${servername}"
@@ -1392,6 +1395,17 @@ Confidence              100 / OvalMatch
 
 
 ## Example: Send scan results to Slack
+```
+$ vuls report \
+      -to-slack \
+      -cvss-over=7 \
+      -cvedb-path=$PWD/cve.sqlite3
+```
+With this sample command, it will ..
+- Send scan results to slack
+- Only Report CVEs that CVSS score is over 7
+
+
 ```
 $ vuls report \
       -to-slack \

--- a/config/config.go
+++ b/config/config.go
@@ -375,6 +375,7 @@ func (c *SMTPConf) Validate() (errs []error) {
 
 // SlackConf is slack config
 type SlackConf struct {
+	LegacyToken string   `json:"token" toml:"legacyToken,omitempty"`
 	HookURL     string   `valid:"url" json:"-" toml:"hookURL,omitempty"`
 	Channel     string   `json:"channel" toml:"channel,omitempty"`
 	IconEmoji   string   `json:"icon_emoji" toml:"iconEmoji,omitempty"`


### PR DESCRIPTION
## What did you implement:

Fix to send slack notification using API.
By using thread in API, slack message does not become chaos.

## How did you implement it:

add function to send msg by api

## How can we verify it:

- get slack legacy api token

https://api.slack.com/custom-integrations/legacy-tokens

-  add slack api token into config.toml

```
[slack]
#hookURL      = "https://hooks.slack.com/services/abc123/defghijklmnopqrstuvwxyz"
legacyToken =       "xoxp-11111111111-legacytoken-1111111111"
channel      = "#channel"
iconEmoji    = ":ghost:"
authUser     = "vuls"
notifyUsers  = ["@matsuno"]
```

- run vuls report

```
$ vuls report -to-slack -cvss-over=7
```

- result

<img width="616" alt="2017-10-21 6 27 33" src="https://user-images.githubusercontent.com/8997330/31842418-02b703f2-b629-11e7-8ec3-beda5d3a397e.png">


## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** YES
