### PR TITLE
Fix package query fails on debian based container (#519)

### DIFF
--- a/scan/debian.go
+++ b/scan/debian.go
@@ -240,7 +240,7 @@ func (o *debian) rebootRequired() (bool, error) {
 
 func (o *debian) scanInstalledPackages() (models.Packages, models.Packages, models.SrcPackages, error) {
 	installed, updatable, srcPacks := models.Packages{}, models.Packages{}, models.SrcPackages{}
-	r := o.exec(`dpkg-query -W -f='${binary:Package},${db:Status-Abbrev},${Version},${Source},${source:Version}\n'`, noSudo)
+	r := o.exec(`dpkg-query -W -f="\${binary:Package},\${db:Status-Abbrev},\${Version},\${Source},\${source:Version}\n"`, noSudo)
 	if !r.isSuccess() {
 		return nil, nil, nil, fmt.Errorf("Failed to SSH: %s", r)
 	}

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -342,9 +342,9 @@ func decorateCmd(c conf.ServerInfo, cmd string, sudo bool) string {
 	if c.IsContainer() {
 		switch c.Containers.Type {
 		case "", "docker":
-			cmd = fmt.Sprintf(`docker exec --user 0 %s /bin/bash -c "%s"`, c.Container.ContainerID, cmd)
+			cmd = fmt.Sprintf(`docker exec --user 0 %s /bin/bash -c '%s'`, c.Container.ContainerID, cmd)
 		case "lxd":
-			cmd = fmt.Sprintf(`lxc exec %s -- /bin/bash -c "%s"`, c.Container.Name, cmd)
+			cmd = fmt.Sprintf(`lxc exec %s -- /bin/bash -c '%s'`, c.Container.Name, cmd)
 		}
 	}
 	//  cmd = fmt.Sprintf("set -x; %s", cmd)

--- a/scan/executil_test.go
+++ b/scan/executil_test.go
@@ -75,7 +75,7 @@ func TestDecorateCmd(t *testing.T) {
 			},
 			cmd:      "ls",
 			sudo:     false,
-			expected: `docker exec --user 0 abc /bin/bash -c "ls"`,
+			expected: `docker exec --user 0 abc /bin/bash -c 'ls'`,
 		},
 		// root sudo true docker
 		{
@@ -86,7 +86,7 @@ func TestDecorateCmd(t *testing.T) {
 			},
 			cmd:      "ls",
 			sudo:     true,
-			expected: `docker exec --user 0 abc /bin/bash -c "ls"`,
+			expected: `docker exec --user 0 abc /bin/bash -c 'ls'`,
 		},
 		// non-root sudo false, docker
 		{
@@ -97,7 +97,7 @@ func TestDecorateCmd(t *testing.T) {
 			},
 			cmd:      "ls",
 			sudo:     false,
-			expected: `docker exec --user 0 abc /bin/bash -c "ls"`,
+			expected: `docker exec --user 0 abc /bin/bash -c 'ls'`,
 		},
 		// non-root sudo true, docker
 		{
@@ -108,7 +108,7 @@ func TestDecorateCmd(t *testing.T) {
 			},
 			cmd:      "ls",
 			sudo:     true,
-			expected: `docker exec --user 0 abc /bin/bash -c "ls"`,
+			expected: `docker exec --user 0 abc /bin/bash -c 'ls'`,
 		},
 		// non-root sudo true, docker
 		{
@@ -119,7 +119,7 @@ func TestDecorateCmd(t *testing.T) {
 			},
 			cmd:      "ls | grep hoge",
 			sudo:     true,
-			expected: `docker exec --user 0 abc /bin/bash -c "ls | grep hoge"`,
+			expected: `docker exec --user 0 abc /bin/bash -c 'ls | grep hoge'`,
 		},
 		// -------------lxd-------------
 		// root sudo false lxd
@@ -131,7 +131,7 @@ func TestDecorateCmd(t *testing.T) {
 			},
 			cmd:      "ls",
 			sudo:     false,
-			expected: `lxc exec def -- /bin/bash -c "ls"`,
+			expected: `lxc exec def -- /bin/bash -c 'ls'`,
 		},
 		// root sudo true lxd
 		{
@@ -142,7 +142,7 @@ func TestDecorateCmd(t *testing.T) {
 			},
 			cmd:      "ls",
 			sudo:     true,
-			expected: `lxc exec def -- /bin/bash -c "ls"`,
+			expected: `lxc exec def -- /bin/bash -c 'ls'`,
 		},
 		// non-root sudo false, lxd
 		{
@@ -153,7 +153,7 @@ func TestDecorateCmd(t *testing.T) {
 			},
 			cmd:      "ls",
 			sudo:     false,
-			expected: `lxc exec def -- /bin/bash -c "ls"`,
+			expected: `lxc exec def -- /bin/bash -c 'ls'`,
 		},
 		// non-root sudo true, lxd
 		{
@@ -164,7 +164,7 @@ func TestDecorateCmd(t *testing.T) {
 			},
 			cmd:      "ls",
 			sudo:     true,
-			expected: `lxc exec def -- /bin/bash -c "ls"`,
+			expected: `lxc exec def -- /bin/bash -c 'ls'`,
 		},
 		// non-root sudo true lxd
 		{
@@ -175,7 +175,7 @@ func TestDecorateCmd(t *testing.T) {
 			},
 			cmd:      "ls | grep hoge",
 			sudo:     true,
-			expected: `lxc exec def -- /bin/bash -c "ls | grep hoge"`,
+			expected: `lxc exec def -- /bin/bash -c 'ls | grep hoge'`,
 		},
 	}
 


### PR DESCRIPTION
## What did you implement:

Closes #519 

## How did you implement it:
- Escaped the dollars with a backslash. 
- Swapped the double quotes and single quotes so that correctly executed.
```
$ bash -c 'dpkg-query -W -f="\${binary:Package},\${db:Status-Abbrev},\${Version},\${Source},\${source:Version}\n"'
$ dpkg-query -W -f="\${binary:Package},\${db:Status-Abbrev},\${Version},\${Source},\${source:Version}\n"
```

## Todos:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
