### PR TITLE
Add pseudo server type for non-ssh scanning (only cpe scan) #512

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -91,7 +91,7 @@ Table of Contents
       * [Example: Use MySQL as a DB storage back-end](#example-use-mysql-as-a-db-storage-back-end)
       * [Example: Use PostgreSQL as a DB storage back-end](#example-use-postgresql-as-a-db-storage-back-end)
       * [Example: Use Redis as a DB storage back-end](#example-use-redis-as-a-db-storage-back-end)
-   * [Usage: Scan vulnerability of non-OS package](#usage-scan-vulnerability-of-non-os-package)
+   * [Usage: Scan vulnerability of non-OS package](#usage-scan-vulnerabilites-of-non-os-packages)
    * [Usage: Integrate with OWASP Dependency Check to Automatic update when the libraries are updated (Experimental)](#usage-integrate-with-owasp-dependency-check-to-automatic-update-when-the-libraries-are-updated-experimental)
    * [Usage: TUI](#usage-tui)
       * [Display the latest scan results](#display-the-latest-scan-results)
@@ -721,6 +721,7 @@ host         = "172.31.4.82"
 #port        = "22"
 #user        = "root"
 #keyPath     = "/home/username/.ssh/id_rsa"
+#type 		 = "pseudo"
 #cpeNames = [
 #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
 #]
@@ -831,6 +832,7 @@ host         = "172.31.4.82"
     #cpeNames = [
     #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
     #]
+    #type 		 = "pseudo"
     #ignoreCves = ["CVE-2016-6314"]
     #optional = [
     #    ["key", "value"],
@@ -847,6 +849,7 @@ host         = "172.31.4.82"
     - port: SSH Port number
     - user: SSH username
     - keyPath: SSH private key path
+    - type: "pseudo" for non-ssh scanning. see [#531](https://github.com/future-architect/vuls/pull/531)
     - cpeNames: see [Usage: Scan vulnerability of non-OS package](#usage-scan-vulnerability-of-non-os-package)
     - ignoreCves: CVE IDs that will not be reported. But output to JSON file.
     - optional: JSONレポートに含めたい追加情報
@@ -1596,6 +1599,18 @@ Vulsは、[CPE](https://nvd.nist.gov/cpe.cfm)に登録されているソフト�
     host         = "172.31.4.82"
     user        = "ec2-user"
     keyPath     = "/home/username/.ssh/id_rsa"
+    cpeNames = [
+      "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
+    ]
+    ```
+
+- Configuration  
+ネットワーク機器など、スキャン対象にSSH接続しない場合は`type="pseudo"`を指定する。 
+    ```
+    [servers]
+
+    [servers.172-31-4-82]
+	type = "pseudo"
     cpeNames = [
       "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
     ]

--- a/README.md
+++ b/README.md
@@ -735,6 +735,7 @@ host         = "172.31.4.82"
 #port        = "22"
 #user        = "root"
 #keyPath     = "/home/username/.ssh/id_rsa"
+#type 		 = "pseudo"
 #cpeNames = [
 #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
 #]
@@ -839,6 +840,7 @@ You can customize your configuration using this template.
     #port        = "22"
     #user        = "root"
     #keyPath     = "/home/username/.ssh/id_rsa"
+    #type 		 = "pseudo"
     #cpeNames = [
     #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
     #]
@@ -858,6 +860,7 @@ You can customize your configuration using this template.
     - port: SSH Port number
     - user: SSH username
     - keyPath: SSH private key path
+    - type: "pseudo" for non-ssh scanning. see [#531](https://github.com/future-architect/vuls/pull/531)
     - cpeNames: see [Usage: Scan vulnerability of non-OS package](#usage-scan-vulnerability-of-non-os-package)
     - ignoreCves: CVE IDs that will not be reported. But output to JSON file.
     - optional: Add additional information to JSON report.
@@ -1608,6 +1611,20 @@ To detect the vulnerability of Ruby on Rails v4.2.1, cpeNames needs to be set in
     host         = "172.31.4.82"
     user        = "ec2-user"
     keyPath     = "/home/username/.ssh/id_rsa"
+    cpeNames = [
+      "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
+    ]
+    ```
+
+- type="pseudo"
+Specify this when you want to detect vulnerability by specifying cpename without SSH connection.
+The pseudo type does not do anything when scanning.
+Search for NVD at report time and detect vulnerability of software specified as cpenamae.
+    ```
+    [servers]
+
+    [servers.172-31-4-82]
+	type = "pseudo"
     cpeNames = [
       "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
     ]

--- a/commands/discover.go
+++ b/commands/discover.go
@@ -132,6 +132,7 @@ host         = "{{$ip}}"
 #port        = "22"
 #user        = "root"
 #keyPath     = "/home/username/.ssh/id_rsa"
+#type 		 = "pseudo"
 #cpeNames = [
 #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
 #]

--- a/config/config.go
+++ b/config/config.go
@@ -78,6 +78,11 @@ const (
 	SUSEOpenstackCloud = "suse.openstack.cloud"
 )
 
+const (
+	// ServerTypePseudo is used for ServerInfo.Type
+	ServerTypePseudo = "pseudo"
+)
+
 //Config is struct of Configuration
 type Config struct {
 	Debug    bool
@@ -445,6 +450,9 @@ type ServerInfo struct {
 
 	// For CentOS, RHEL, Amazon
 	Enablerepo []string
+
+	// "pseudo" or ""
+	Type string
 
 	// used internal
 	LogMsgAnsiColor string // DebugLog Color

--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -175,6 +175,8 @@ func (c TOMLLoader) Load(pathToToml, keyPass string) error {
 			}
 		}
 
+		s.Type = v.Type
+
 		s.LogMsgAnsiColor = Colors[i%len(Colors)]
 		i++
 

--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -62,7 +62,7 @@ func (c TOMLLoader) Load(pathToToml, keyPass string) error {
 		s := ServerInfo{ServerName: name}
 
 		s.Host = v.Host
-		if len(s.Host) == 0 {
+		if len(s.Host) == 0 && v.Type != ServerTypePseudo {
 			return fmt.Errorf("%s is invalid. host is empty", name)
 		}
 

--- a/report/report.go
+++ b/report/report.go
@@ -183,6 +183,8 @@ func FillWithOval(r *models.ScanResult) (err error) {
 		ovalFamily = c.SUSEEnterpriseServer
 	case c.Amazon, c.Raspbian, c.FreeBSD, c.Windows:
 		return nil
+	case c.ServerTypePseudo:
+		return nil
 	default:
 		return fmt.Errorf("OVAL for %s is not implemented yet", r.Family)
 	}

--- a/scan/pseudo.go
+++ b/scan/pseudo.go
@@ -1,0 +1,66 @@
+/* Vuls - Vulnerability Scanner
+Copyright (C) 2016  Future Architect, Inc. Japan.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package scan
+
+import (
+	"github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/models"
+	"github.com/future-architect/vuls/util"
+)
+
+// inherit OsTypeInterface
+type pseudo struct {
+	base
+}
+
+func detectPseudo(c config.ServerInfo) (itsMe bool, pseudo osTypeInterface, err error) {
+	p := newPseudo(c)
+	p.setDistro(config.ServerTypePseudo, "")
+	return c.Type == config.ServerTypePseudo, p, nil
+}
+
+func newPseudo(c config.ServerInfo) *pseudo {
+	d := &pseudo{
+		base: base{
+			osPackages: osPackages{
+				Packages:  models.Packages{},
+				VulnInfos: models.VulnInfos{},
+			},
+		},
+	}
+	d.log = util.NewCustomLogger(c)
+	d.setServerInfo(c)
+	return d
+}
+
+func (o *pseudo) checkIfSudoNoPasswd() error {
+	return nil
+}
+
+func (o *pseudo) checkDependencies() error {
+	return nil
+}
+
+func (o *pseudo) scanPackages() error {
+	return nil
+}
+
+func (o *pseudo) detectPlatform() {
+	o.setPlatform(models.Platform{Name: "other"})
+	return
+}

--- a/scan/serverapi.go
+++ b/scan/serverapi.go
@@ -41,7 +41,6 @@ type osTypeInterface interface {
 	detectPlatform()
 	getPlatform() models.Platform
 
-	// checkDependencies checks if dependencies are installed on the target server.
 	checkDependencies() error
 	checkIfSudoNoPasswd() error
 
@@ -74,6 +73,11 @@ type osPackages struct {
 func detectOS(c config.ServerInfo) (osType osTypeInterface) {
 	var itsMe bool
 	var fatalErr error
+
+	if itsMe, osType, _ = detectPseudo(c); itsMe {
+		util.Log.Debugf("Pseudo. Host: %s:%s", c.Host, c.Port)
+		return
+	}
 
 	itsMe, osType, fatalErr = detectDebian(c)
 	if fatalErr != nil {

--- a/scan/serverapi.go
+++ b/scan/serverapi.go
@@ -75,7 +75,7 @@ func detectOS(c config.ServerInfo) (osType osTypeInterface) {
 	var fatalErr error
 
 	if itsMe, osType, _ = detectPseudo(c); itsMe {
-		util.Log.Debugf("Pseudo. Host: %s:%s", c.Host, c.Port)
+		util.Log.Debugf("Pseudo")
 		return
 	}
 


### PR DESCRIPTION
## What did you implement:

Closes #512 

I added `type = "pseudo"` to config.toml setting.
Specify this when you want to detect vulnerability by specifying cpename without SSH connection.
The pseudo type does not do anything when scanning.
Search for NVD at report time and detect vulnerability of software specified as cpenamae.

```
  [servers.s1]
    type = "pseudo"
    cpeNames = ["cpe:/a:rubyonrails:ruby_on_rails:4.2.1"]
```

see also [Usage: Scan vulnerabilites of non-OS packages](https://github.com/future-architect/vuls#usage-scan-vulnerabilites-of-non-os-packages)

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO