### PR TITLE
Fix: Misdetection of OvalMatch for CentOS and Scientific in oval/util.go

### DIFF
--- a/oval/util.go
+++ b/oval/util.go
@@ -325,28 +325,11 @@ func lessThan(family, versionRelease string, packB ovalmodels.Package) (bool, er
 		vera := rpmver.NewVersion(versionRelease)
 		verb := rpmver.NewVersion(packB.Version)
 		return vera.LessThan(verb), nil
-	case config.RedHat:
-		// TODO: Separate code when supporting Scientific Linux
-		rea := regexp.MustCompile(`\.sl(\d+)`)
+	case config.RedHat, config.CentOS: // TODO: Suport config.Scientific
+		rea := regexp.MustCompile(`\.[es]l(\d+)(?:_\d+)?(?:\.centos)?`)
 		reb := regexp.MustCompile(`\.el(\d+)(?:_\d+)?`)
-		if rea.MatchString(versionRelease) {
-			vera := rpmver.NewVersion(rea.ReplaceAllString(versionRelease, ".el$1"))
-			verb := rpmver.NewVersion(reb.ReplaceAllString(packB.Version, ".el$1"))
-			return vera.LessThan(verb), nil
-		}
-		vera := rpmver.NewVersion(versionRelease)
-		verb := rpmver.NewVersion(packB.Version)
-		return vera.LessThan(verb), nil
-	case config.CentOS:
-		rea := regexp.MustCompile(`\.el(\d+)(?:_\d+)?\.centos`)
-		reb := regexp.MustCompile(`\.el(\d+)(?:_\d+)?`)
-		if rea.MatchString(versionRelease) {
-			vera := rpmver.NewVersion(rea.ReplaceAllString(versionRelease, ".el$1"))
-			verb := rpmver.NewVersion(reb.ReplaceAllString(packB.Version, ".el$1"))
-			return vera.LessThan(verb), nil
-		}
-		vera := rpmver.NewVersion(versionRelease)
-		verb := rpmver.NewVersion(packB.Version)
+		vera := rpmver.NewVersion(rea.ReplaceAllString(versionRelease, ".el$1"))
+		verb := rpmver.NewVersion(reb.ReplaceAllString(packB.Version, ".el$1"))
 		return vera.LessThan(verb), nil
 	default:
 		util.Log.Errorf("Not implemented yet: %s", family)

--- a/oval/util.go
+++ b/oval/util.go
@@ -321,7 +321,19 @@ func lessThan(family, versionRelease string, packB ovalmodels.Package) (bool, er
 			return false, err
 		}
 		return vera.LessThan(verb), nil
-	case config.RedHat, config.Oracle, config.SUSEEnterpriseServer:
+	case config.Oracle, config.SUSEEnterpriseServer:
+		vera := rpmver.NewVersion(versionRelease)
+		verb := rpmver.NewVersion(packB.Version)
+		return vera.LessThan(verb), nil
+	case config.RedHat:
+		// TODO: Separate code when supporting Scientific Linux
+		rea := regexp.MustCompile(`\.sl(\d+)`)
+		reb := regexp.MustCompile(`\.el(\d+)(?:_\d+)?`)
+		if rea.MatchString(versionRelease) {
+			vera := rpmver.NewVersion(rea.ReplaceAllString(versionRelease, ".el$1"))
+			verb := rpmver.NewVersion(reb.ReplaceAllString(packB.Version, ".el$1"))
+			return vera.LessThan(verb), nil
+		}
 		vera := rpmver.NewVersion(versionRelease)
 		verb := rpmver.NewVersion(packB.Version)
 		return vera.LessThan(verb), nil

--- a/oval/util.go
+++ b/oval/util.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -320,7 +321,18 @@ func lessThan(family, versionRelease string, packB ovalmodels.Package) (bool, er
 			return false, err
 		}
 		return vera.LessThan(verb), nil
-	case config.RedHat, config.CentOS, config.Oracle, config.SUSEEnterpriseServer:
+	case config.RedHat, config.Oracle, config.SUSEEnterpriseServer:
+		vera := rpmver.NewVersion(versionRelease)
+		verb := rpmver.NewVersion(packB.Version)
+		return vera.LessThan(verb), nil
+	case config.CentOS:
+		rea := regexp.MustCompile(`\.el(\d+)(?:_\d+)?\.centos`)
+		reb := regexp.MustCompile(`\.el(\d+)(?:_\d+)?`)
+		if rea.MatchString(versionRelease) {
+			vera := rpmver.NewVersion(rea.ReplaceAllString(versionRelease, ".el$1"))
+			verb := rpmver.NewVersion(reb.ReplaceAllString(packB.Version, ".el$1"))
+			return vera.LessThan(verb), nil
+		}
 		vera := rpmver.NewVersion(versionRelease)
 		verb := rpmver.NewVersion(packB.Version)
 		return vera.LessThan(verb), nil

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -261,7 +261,7 @@ func TestIsOvalDefAffected(t *testing.T) {
 		//   req.isSrcPack == false
 		//   Version comparison
 		//     oval vs NewVersion
-		//       oval.version < installed.newVersion
+		//       oval.version > installed.newVersion
 		{
 			in: in{
 				family: "ubuntu",
@@ -318,6 +318,618 @@ func TestIsOvalDefAffected(t *testing.T) {
 				},
 			},
 			affected:    true,
+			notFixedYet: false,
+		},
+		// RedHat
+		{
+			in: in{
+				family: "redhat",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6_7.7",
+				},
+			},
+			affected:    true,
+			notFixedYet: true,
+		},
+		{
+			in: in{
+				family: "redhat",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6_7.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "redhat",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6_7.9",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "redhat",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.el6_7.6",
+					NewVersionRelease: "0:1.2.3-45.el6_7.7",
+				},
+			},
+			affected:    true,
+			notFixedYet: true,
+		},
+		{
+			in: in{
+				family: "redhat",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.el6_7.6",
+					NewVersionRelease: "0:1.2.3-45.el6_7.8",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "redhat",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.el6_7.6",
+					NewVersionRelease: "0:1.2.3-45.el6_7.9",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "redhat",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "redhat",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6_7.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		// CentOS
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6.centos.7",
+				},
+			},
+			affected:    true,
+			notFixedYet: true,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6.centos.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6.centos.9",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.el6.centos.6",
+					NewVersionRelease: "0:1.2.3-45.el6.centos.7",
+				},
+			},
+			affected:    true,
+			notFixedYet: true,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.el6.centos.6",
+					NewVersionRelease: "0:1.2.3-45.el6.centos.8",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.el6.centos.6",
+					NewVersionRelease: "0:1.2.3-45.el6.centos.9",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6_7.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		// TODO: If vuls support Scientific, replace "centos" below to "scientific".
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.sl6.7",
+				},
+			},
+			affected:    true,
+			notFixedYet: true,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.sl6.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.sl6.9",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.sl6.6",
+					NewVersionRelease: "0:1.2.3-45.sl6.7",
+				},
+			},
+			affected:    true,
+			notFixedYet: true,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.sl6.6",
+					NewVersionRelease: "0:1.2.3-45.sl6.8",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.sl6.6",
+					NewVersionRelease: "0:1.2.3-45.sl6.9",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "centos",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6_7.8",
+				},
+			},
+			affected:    false,
 			notFixedYet: false,
 		},
 	}


### PR DESCRIPTION
## What did you implement:

Closes #535 

## How did you implement it:
Detect modified package versions of CentOS and Scientific with regular expressions.
Temporarily impersonate package version.

## How can we verify it:
Run OvalMatch to the modified package.
https://wiki.centos.org/Manuals/ReleaseNotes/CentOS7#head-45636299c88753daf7f91aaabffeb2cdb64470ec
https://wiki.centos.org/Manuals/ReleaseNotes/CentOS6.9#head-8d5fecfca6aa658ed4f76d3cbe3d1526ea2bc735

## Todos:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
