### PR TITLE
Insert `sudo` only at the beginning of command in deep scan #495

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -954,13 +954,13 @@ For details, see [-ssh-native-insecure option](#-ssh-native-insecure-option)
 
 - RHEL 5 / Oracle Linux 5
 ```
-vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never list-security --security, /usr/bin/yum --color=never info-security, /usr/bin/repoquery
+vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never list-security --security, /usr/bin/yum --color=never info-security, /usr/bin/repoquery, /usr/bin/yum --color=never changelog all *
 Defaults:vuls env_keep="http_proxy https_proxy HTTP_PROXY HTTPS_PROXY"
 ```
 
 - RHEL 6, 7 / Oracle Linux 6, 7
 ```
-vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never --security updateinfo list updates, /usr/bin/yum --color=never --security updateinfo updates, /usr/bin/repoquery
+vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never --security updateinfo list updates, /usr/bin/yum --color=never --security updateinfo updates, /usr/bin/repoquery, /usr/bin/yum --color=never  changelog all *
 Defaults:vuls env_keep="http_proxy https_proxy HTTP_PROXY HTTPS_PROXY"
 ```
 

--- a/README.md
+++ b/README.md
@@ -961,13 +961,13 @@ Example of /etc/sudoers on target servers
 
 - RHEL 5 / Oracle Linux 5
 ```
-vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never list-security --security, /usr/bin/yum --color=never info-security, /usr/bin/repoquery
+vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never list-security --security, /usr/bin/yum --color=never info-security, /usr/bin/repoquery, /usr/bin/yum --color=never changelog all *
 Defaults:vuls env_keep="http_proxy https_proxy HTTP_PROXY HTTPS_PROXY"
 ```
 
 - RHEL 6, 7 / Oracle Linux 6, 7
 ```
-vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never --security updateinfo list updates, /usr/bin/yum --color=never --security updateinfo updates, /usr/bin/repoquery
+vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never --security updateinfo list updates, /usr/bin/yum --color=never --security updateinfo updates, /usr/bin/repoquery, /usr/bin/yum --color=never changelog all *
 Defaults:vuls env_keep="http_proxy https_proxy HTTP_PROXY HTTPS_PROXY"
 ```
 

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -327,7 +327,6 @@ func getSSHLogger(log ...*logrus.Entry) *logrus.Entry {
 func decorateCmd(c conf.ServerInfo, cmd string, sudo bool) string {
 	if sudo && c.User != "root" && !c.IsContainer() {
 		cmd = fmt.Sprintf("sudo -S %s", cmd)
-		cmd = strings.Replace(cmd, "|", "| sudo ", -1)
 	}
 
 	// If you are using pipe and you want to detect preprocessing errors, remove comment out

--- a/scan/executil_test.go
+++ b/scan/executil_test.go
@@ -63,7 +63,7 @@ func TestDecorateCmd(t *testing.T) {
 			conf:     config.ServerInfo{User: "non-roor"},
 			cmd:      "ls | grep hoge",
 			sudo:     true,
-			expected: "sudo -S ls | sudo  grep hoge",
+			expected: "sudo -S ls | grep hoge",
 		},
 		// -------------docker-------------
 		// root sudo false docker


### PR DESCRIPTION
## What did you implement:

Solve the problem that RedHat's deep scan stops halfway.
https://github.com/future-architect/vuls/pull/495#issuecomment-341893414

## How did you implement it:

- Do not add sudo to Piped command
  In the current implementation, the command to be PIPE only existed in `yum changelog` in redhat.go
- Fix README

## How can we verify it:
scan RedHat with --deep

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
