### PR TITLE
Fix false positive: ignore oval info when kernel major version is different

### DIFF
--- a/commands/tui.go
+++ b/commands/tui.go
@@ -197,6 +197,7 @@ func (p *TuiCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 	c.Conf.CvssScoreOver = p.cvssScoreOver
 	c.Conf.IgnoreUnscoredCves = p.ignoreUnscoredCves
 	c.Conf.IgnoreUnfixed = p.ignoreUnfixed
+	c.Conf.RefreshCve = p.refreshCve
 
 	log.Info("Validating config...")
 	if !c.Conf.ValidateOnTui() {

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -67,6 +67,35 @@ func (o RedHatBase) FillWithOval(r *models.ScanResult) (err error) {
 	return nil
 }
 
+var kernelRelatedPackNames = map[string]bool{
+	"kernel":                  true,
+	"kernel-aarch64":          true,
+	"kernel-abi-whitelists":   true,
+	"kernel-bootwrapper":      true,
+	"kernel-debug":            true,
+	"kernel-debug-devel":      true,
+	"kernel-devel":            true,
+	"kernel-doc":              true,
+	"kernel-headers":          true,
+	"kernel-kdump":            true,
+	"kernel-kdump-devel":      true,
+	"kernel-rt":               true,
+	"kernel-rt-debug":         true,
+	"kernel-rt-debug-devel":   true,
+	"kernel-rt-debug-kvm":     true,
+	"kernel-rt-devel":         true,
+	"kernel-rt-doc":           true,
+	"kernel-rt-kvm":           true,
+	"kernel-rt-trace":         true,
+	"kernel-rt-trace-devel":   true,
+	"kernel-rt-trace-kvm":     true,
+	"kernel-rt-virt":          true,
+	"kernel-rt-virt-devel":    true,
+	"kernel-tools":            true,
+	"kernel-tools-libs":       true,
+	"kernel-tools-libs-devel": true,
+}
+
 func (o RedHatBase) update(r *models.ScanResult, defPacks defPacks) {
 	ctype := models.NewCveContentType(o.family)
 	for _, cve := range defPacks.def.Advisory.Cves {


### PR DESCRIPTION
## What did you implement:

Dirty Cow was miss-detected on RedHat based linux because RedHat7's  OVAL has below entry(DIRTY COW).
```
 <definition class="patch" id="oval:com.redhat.rhsa:def:20170372" version="602">
  ...
  <criterion comment="kernel is earlier than 0:4.5.0-15.2.1.el7" test_ref="oval:com.redhat.rhsa:tst:20170372013"/>
```

If the running kernel is 3 series, the version comparison would be wrong.

This CVE was also fixed in kernel 3 series.
https://access.redhat.com/errata/RHSA-2016:2098
```
kernel-3.10.0-327.36.3.el7.x86_64.rpm
```

So, if the major version of running kernel is different from oval's version, vuls ignore the oval entry.

## How did you implement it:

see diff

## How can we verify it:

```
yum -y update on CentOS7.
vuls scan 
vuls report
```
Confirm that the DIRTY COW is not detected.
 


## Todos:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
