### PR TITLE
Fix yum changelog option

### DIFF
--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -399,7 +399,7 @@ func (o *redhat) parseUpdatablePacksLine(line string) (models.Package, error) {
 }
 
 func (o *redhat) scanUnsecurePackages(updatable models.Packages) (models.VulnInfos, error) {
-	if config.Conf.Deep {
+	if config.Conf.Deep && o.Distro.Family != config.Amazon {
 		//TODO Cache changelogs to bolt
 		if err := o.fillChangelogs(updatable); err != nil {
 			return nil, err
@@ -453,7 +453,7 @@ func (o *redhat) getAvailableChangelogs(packNames []string) (map[string]string, 
 	if config.Conf.SkipBroken {
 		yumopts += " --skip-broken"
 	}
-	cmd := `yum --color=never %s changelog all %s | grep -A 10000 '==================== Available Packages ===================='`
+	cmd := `yum --color=never changelog all %s %s | grep -A 1000000 '==================== Available Packages ===================='`
 	cmd = fmt.Sprintf(cmd, yumopts, strings.Join(packNames, " "))
 
 	r := o.exec(util.PrependProxyEnv(cmd), o.sudo())


### PR DESCRIPTION
## What did you implement:

in README
```
vuls ALL=(ALL) NOPASSWD:/usr/bin/yum --color=never repolist, /usr/bin/yum --color=never --security updateinfo list updates, /usr/bin/yum --color=never --security updateinfo updates, /usr/bin/repoquery, /usr/bin/yum --color=never changelog all *
```

Scan with scan -skip-broken issues 
`
$ yum --color=never -skip-broken changelog all package-name 
`

It does not match the definition written in sudoers.
So I change the place to attach `yum changelog` option.
 
## How did you implement it:

see the diff

## How can we verify it:

scan with --deep, --skip-broken on redhat machine.

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
