### PR TITLE
Replace strings.HasPrefix with strings.Index for SuSE scanner

### DIFF
--- a/scan/suse.go
+++ b/scan/suse.go
@@ -157,8 +157,8 @@ func (o *suse) parseZypperLULines(stdout string) (models.Packages, error) {
 	scanner := bufio.NewScanner(strings.NewReader(stdout))
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, "S | Repository") ||
-			strings.HasPrefix(line, "--+----------------") {
+		if strings.Index(line, "S | Repository") != -1 ||
+			strings.Index(line, "--+----------------") != -1 {
 			continue
 		}
 		pack, err := o.parseZypperLUOneLine(line)


### PR DESCRIPTION
## What did you implement:

Closes #515

## How did you implement it:
I replaced strings.HasPrefix call with strings.Index call for the lines returned by `zypper q -lu` as it seems that output contains some extra bytes, confusing HasPrefix.

## How can we verify it:
I verified it by scanning a SLES 11 SP4 box.

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** yes  
***Is it a breaking change?:*** NO
