### PR TITLE
Fix some RPM related commands failed in the container

### DIFF
--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -336,7 +336,7 @@ func (o *redhat) parseInstalledPackagesLine(line string) (models.Package, error)
 }
 
 func (o *redhat) scanUpdatablePackages() (models.Packages, error) {
-	cmd := "repoquery --all --pkgnarrow=updates --qf='%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{REPO}'"
+	cmd := `repoquery --all --pkgnarrow=updates --qf="%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{REPO}"`
 	for _, repo := range o.getServerInfo().Enablerepo {
 		cmd += " --enablerepo=" + repo
 	}
@@ -453,7 +453,7 @@ func (o *redhat) getAvailableChangelogs(packNames []string) (map[string]string, 
 	if config.Conf.SkipBroken {
 		yumopts += " --skip-broken"
 	}
-	cmd := `yum --color=never changelog all %s %s | grep -A 1000000 '==================== Available Packages ===================='`
+	cmd := `yum --color=never changelog all %s %s | grep -A 1000000 "==================== Available Packages ===================="`
 	cmd = fmt.Sprintf(cmd, yumopts, strings.Join(packNames, " "))
 
 	r := o.exec(util.PrependProxyEnv(cmd), o.sudo())

--- a/scan/utils.go
+++ b/scan/utils.go
@@ -52,8 +52,8 @@ func isRunningKernel(pack models.Package, family string, kernel models.Kernel) (
 }
 
 func rpmQa(distro config.Distro) string {
-	const old = "rpm -qa --queryformat '%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{ARCH}\n'"
-	const new = "rpm -qa --queryformat '%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH}\n'"
+	const old = "rpm -qa --queryformat \"%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{ARCH}\n\""
+	const new = "rpm -qa --queryformat \"%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH}\n\""
 	switch distro.Family {
 	case config.SUSEEnterpriseServer:
 		if v, _ := distro.MajorVersion(); v < 12 {


### PR DESCRIPTION
## What did you implement:

Closes #553 

## How did you implement it:

Some commands do not use single quotes.

## How can we verify it:

See #553

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
