### PR TITLE
Change error handling of "Reboot Required" detection

### DIFF
--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -262,8 +262,10 @@ func (o *redhat) scanPackages() error {
 func (o *redhat) rebootRequired() (bool, error) {
 	r := o.exec("rpm -q --last kernel", noSudo)
 	scanner := bufio.NewScanner(strings.NewReader(r.Stdout))
+	if !r.isSuccess(0, 1) {
+		return false, fmt.Errorf("Failed to detect the last installed kernel : %v", r)
+	}
 	if !r.isSuccess() || !scanner.Scan() {
-		o.log.Warn("Failed to detect the last installed kernel : %v", r)
 		return false, nil
 	}
 	lastInstalledKernelVer := strings.Fields(scanner.Text())[0]


### PR DESCRIPTION
## What did you implement:

Error handling of "Reboot Required" detection was strict.

## How did you implement it:

If the return value is 0 and the string exists on the standard output, detection continues.
If the return value is 1, detection is omitted but no warning is issued.
In other cases (when the execution of the rpm command fails), an error occurs.

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
