### PR TITLE
Fixed comparison target of kernel related packages

### DIFF
--- a/oval/util.go
+++ b/oval/util.go
@@ -296,7 +296,7 @@ func isOvalDefAffected(def ovalmodels.Definition, req request, family string, ru
 			case config.RedHat, config.CentOS:
 				// For kernel related packages, ignore OVAL information with different major versions
 				if _, ok := kernelRelatedPackNames[ovalPack.Name]; ok {
-					if major(ovalPack.Version) != major(running.Release) {
+					if major(ovalPack.Version) != major(req.versionRelease) {
 						continue
 					}
 				}


### PR DESCRIPTION
## What did you implement:

Fix #541 again

## How did you implement it:

When comparing the version with the running kernel, it did not work properly in the container environment.

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
