### PR TITLE
Adding Scientific Linux to vuls - Update.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,9 @@ const (
 	// CentOS is
 	CentOS = "centos"
 
+	// Scientific is
+	Scientific = "scientific"
+
 	// Fedora is
 	Fedora = "fedora"
 

--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -520,7 +520,7 @@ func (v VulnInfo) Cvss3CalcURL() string {
 func (v VulnInfo) VendorLinks(family string) map[string]string {
 	links := map[string]string{}
 	switch family {
-	case config.RedHat, config.CentOS, c.Scientific:
+	case config.RedHat, config.CentOS, config.Scientific:
 		links["RHEL-CVE"] = "https://access.redhat.com/security/cve/" + v.CveID
 		for _, advisory := range v.DistroAdvisories {
 			aidURL := strings.Replace(advisory.AdvisoryID, ":", "-", -1)

--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -520,7 +520,7 @@ func (v VulnInfo) Cvss3CalcURL() string {
 func (v VulnInfo) VendorLinks(family string) map[string]string {
 	links := map[string]string{}
 	switch family {
-	case config.RedHat, config.CentOS:
+	case config.RedHat, config.CentOS, c.Scientific:
 		links["RHEL-CVE"] = "https://access.redhat.com/security/cve/" + v.CveID
 		for _, advisory := range v.DistroAdvisories {
 			aidURL := strings.Replace(advisory.AdvisoryID, ":", "-", -1)

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -28,7 +28,7 @@ import (
 	ovalmodels "github.com/kotakanbe/goval-dictionary/models"
 )
 
-// RedHatBase is the base struct for RedHat and CentOS
+// RedHatBase is the base struct for RedHat, CentOS, and Scientific
 type RedHatBase struct {
 	Base
 }
@@ -233,6 +233,22 @@ func NewCentOS() CentOS {
 		RedHatBase{
 			Base{
 				family: config.CentOS,
+			},
+		},
+	}
+}
+
+// Scientific is the interface for Scientific OVAL
+type Scientific struct {
+	RedHatBase
+}
+
+// NewCentOS creates OVAL client for CentOS
+func NewScientific() Scientific {
+	return Scientific{
+		RedHatBase{
+			Base{
+				family: config.Scientific,
 			},
 		},
 	}

--- a/oval/util.go
+++ b/oval/util.go
@@ -293,7 +293,7 @@ func isOvalDefAffected(def ovalmodels.Definition, req request, family string, ru
 
 		if running.Release != "" {
 			switch family {
-			case config.RedHat, config.CentOS:
+			case config.RedHat, config.CentOS, config.Scientific:
 				// For kernel related packages, ignore OVAL information with different major versions
 				if _, ok := kernelRelatedPackNames[ovalPack.Name]; ok {
 					if major(ovalPack.Version) != major(running.Release) {
@@ -352,7 +352,7 @@ func lessThan(family, versionRelease string, packB ovalmodels.Package) (bool, er
 		vera := rpmver.NewVersion(versionRelease)
 		verb := rpmver.NewVersion(packB.Version)
 		return vera.LessThan(verb), nil
-	case config.RedHat, config.CentOS: // TODO: Suport config.Scientific
+	case config.RedHat, config.CentOS, config.Scientific:
 		rea := regexp.MustCompile(`\.[es]l(\d+)(?:_\d+)?(?:\.centos)?`)
 		reb := regexp.MustCompile(`\.el(\d+)(?:_\d+)?`)
 		vera := rpmver.NewVersion(rea.ReplaceAllString(versionRelease, ".el$1"))

--- a/report/report.go
+++ b/report/report.go
@@ -173,6 +173,10 @@ func FillWithOval(r *models.ScanResult) (err error) {
 		ovalClient = oval.NewCentOS()
 		//use RedHat's OVAL
 		ovalFamily = c.RedHat
+	case c.Scientific:
+		ovalClient = oval.NewScientific()
+		//use RedHat's OVAL
+		ovalFamily = c.RedHat
 	case c.Oracle:
 		ovalClient = oval.NewOracle()
 		ovalFamily = c.Oracle

--- a/scan/utils.go
+++ b/scan/utils.go
@@ -38,7 +38,7 @@ func isRunningKernel(pack models.Package, family string, kernel models.Kernel) (
 		}
 		return false, false
 
-	case config.RedHat, config.Oracle, config.CentOS, config.Amazon:
+	case config.RedHat, config.Scientific, config.Oracle, config.CentOS, config.Amazon:
 		if pack.Name == "kernel" {
 			ver := fmt.Sprintf("%s-%s.%s", pack.Version, pack.Release, pack.Arch)
 			return true, kernel.Release == ver


### PR DESCRIPTION
## What did you implement:
Adding Scientific Linux. This is an updated version from the previous WIP and replaces & closes  #497 . 

This should resolve and close #491 as I am able to run scans and deep scans against Scientific Linux systems. This also works with the tui which broke on the previous attempt.

I don't know enough to say how this compares with #564 .

## How did you implement it:
Adding Scientific as a subset of Red Hat. Because it tracks closer to Red Hat than CentOS does, I had to mimic the Red Hat configs.

## How can we verify it:
Test on Scientific Linux.
I've tested on several of my VM's. Expanding my tests later.

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [X] Check that there aren't other open pull requests for the same issue/feature
- [X] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [X] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** Yes  
***Is it a breaking change?:*** NO
