### PR TITLE
fix typo in reports/s3.go

### DIFF
--- a/report/s3.go
+++ b/report/s3.go
@@ -132,7 +132,7 @@ func CheckIfBucketExists() error {
 	}
 	if !found {
 		return fmt.Errorf(
-			"Failed to find the buckets. profile: %s, region: %s, bukdet: %s",
+			"Failed to find the buckets. profile: %s, region: %s, bucket: %s",
 			c.Conf.AwsProfile, c.Conf.AwsRegion, c.Conf.S3Bucket)
 	}
 	return nil


### PR DESCRIPTION
## What did you implement:

Fix typo of error message when using "-to-s3" option.

## How did you implement it:

fix typo.

## How can we verify it:

you can confirm error message with: `vuls report -to-s3`

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
