### PR TITLE
fix "not enough arguments in call to lfshook.NewHook" error in util/logutil.go

### DIFF
--- a/util/logutil.go
+++ b/util/logutil.go
@@ -68,7 +68,8 @@ func NewCustomLogger(c config.ServerInfo) *logrus.Entry {
 			logrus.ErrorLevel: path,
 			logrus.FatalLevel: path,
 			logrus.PanicLevel: path,
-		}))
+		},
+    &logrus.JSONFormatter{},))
 	}
 
 	fields := logrus.Fields{"prefix": whereami}


### PR DESCRIPTION

fix "not enough arguments in call to lfshook.NewHook" error in util/logutil.go