### PR TITLE
Fix a bug of sending to closed socket while oval access via HTTP #578

### DIFF
--- a/oval/util.go
+++ b/oval/util.go
@@ -109,15 +109,14 @@ func getDefsByPackNameViaHTTP(r *models.ScanResult) (
 				NewVersionRelease: pack.FormatVer(),
 				isSrcPack:         false,
 			}
-			for _, pack := range r.SrcPackages {
-				reqChan <- request{
-					packName:        pack.Name,
-					binaryPackNames: pack.BinaryNames,
-					versionRelease:  pack.Version,
-					isSrcPack:       true,
-				}
+		}
+		for _, pack := range r.SrcPackages {
+			reqChan <- request{
+				packName:        pack.Name,
+				binaryPackNames: pack.BinaryNames,
+				versionRelease:  pack.Version,
+				isSrcPack:       true,
 			}
-
 		}
 	}()
 


### PR DESCRIPTION
## What did you implement:

Closes #578 

## How did you implement it:

see diff

## How can we verify it:

report with -ovaldb-url

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
