### PR TITLE
If the OWASP dc XML does not exist, continue reporting after warning #580

### DIFF
--- a/contrib/owasp-dependency-check/parser/parser.go
+++ b/contrib/owasp-dependency-check/parser/parser.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type analysis struct {
@@ -34,13 +36,15 @@ func appendIfMissing(slice []string, str string) []string {
 func Parse(path string) ([]string, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to open: %s", err)
+		log.Warnf("OWASP Dependency Check XML is not found: %s", path)
+		return []string{}, nil
 	}
 	defer file.Close()
 
 	b, err := ioutil.ReadAll(file)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read: %s", err)
+		log.Warnf("Failed to read OWASP Dependency Check XML: %s", path)
+		return []string{}, nil
 	}
 
 	var anal analysis


### PR DESCRIPTION
## What did you implement:

Closes #580

https://github.com/future-architect/vuls#usage-integrate-with-owasp-dependency-check-to-automatic-update-when-the-libraries-are-updated-experimental
```
[servers]

[servers.172-31-4-82]
host         = "172.31.4.82"
user        = "ec2-user"
keyPath     = "/home/username/.ssh/id_rsa"
dependencyCheckXMLPath = "/tmp/dependency-check-report.xml"
```

In the previous implementations, at report time, when the file specified as `dependencyCheckXMLPath` does not exist, it terminated abnormally.

Execute OWASP dependency check in the CI process and output it to a certain path, and specify the path with `dependencyCheckXMLPath` in the config.toml. 
If a file exists on the path, Vuls reads it. 
Ignore the result of OWASP-DC XML if the file does not exist.

## How did you implement it:

If the OWASP dc XML does not exist, continue reporting after warning #580

## How can we verify it:

Specify `/tmp/non-exist-owasp-dc-xml` in the config.toml and check the report will be generated.

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
