### PR TITLE
Add offline option to scan and configtest

### DIFF
--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -36,10 +36,13 @@ type ConfigtestCmd struct {
 	logDir         string
 	askKeyPassword bool
 	containersOnly bool
-	deep           bool
 	sshNative      bool
 	httpProxy      string
 	timeoutSec     int
+
+	fast    bool
+	offline bool
+	deep    bool
 
 	debug bool
 }
@@ -54,6 +57,8 @@ func (*ConfigtestCmd) Synopsis() string { return "Test configuration" }
 func (*ConfigtestCmd) Usage() string {
 	return `configtest:
 	configtest
+			[-fast]
+			[-offline]
 			[-deep]
 			[-config=/path/to/config.toml]
 			[-log-dir=/path/to/log]
@@ -87,6 +92,18 @@ func (p *ConfigtestCmd) SetFlags(f *flag.FlagSet) {
 		false,
 		"Ask ssh privatekey password before scanning",
 	)
+
+	f.BoolVar(
+		&p.fast,
+		"fast",
+		false,
+		"Config test for online fast scan mode")
+
+	f.BoolVar(
+		&p.offline,
+		"offline",
+		false,
+		"Config test for offline scan mode")
 
 	f.BoolVar(&p.deep, "deep", false, "Config test for deep scan mode")
 
@@ -137,7 +154,13 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 	c.Conf.SSHNative = p.sshNative
 	c.Conf.HTTPProxy = p.httpProxy
 	c.Conf.ContainersOnly = p.containersOnly
+
+	c.Conf.Fast = p.fast
+	c.Conf.Offline = p.offline
 	c.Conf.Deep = p.deep
+	if !(c.Conf.Fast || c.Conf.Offline || c.Conf.Deep) {
+		c.Conf.Fast = true
+	}
 
 	var servernames []string
 	if 0 < len(f.Args()) {

--- a/config/config.go
+++ b/config/config.go
@@ -103,6 +103,8 @@ type Config struct {
 
 	SSHNative      bool
 	ContainersOnly bool
+	Fast           bool
+	Offline        bool
 	Deep           bool
 	SkipBroken     bool
 
@@ -196,6 +198,16 @@ func (c Config) ValidateOnScan() bool {
 			errs = append(errs, fmt.Errorf(
 				"Cache DB path must be a *Absolute* file path. -cache-dbpath: %s", c.CacheDBPath))
 		}
+	}
+
+	numTrue := 0
+	for _, b := range []bool{c.Fast, c.Offline, c.Deep} {
+		if b {
+			numTrue++
+		}
+	}
+	if numTrue != 1 {
+		errs = append(errs, fmt.Errorf("Specify only one of -fast, -fast-offline, -deep"))
 	}
 
 	_, err := valid.ValidateStruct(c)

--- a/models/packages.go
+++ b/models/packages.go
@@ -21,6 +21,8 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+
+	"github.com/future-architect/vuls/config"
 )
 
 // Packages is Map of Package
@@ -62,13 +64,17 @@ func (ps Packages) Merge(other Packages) Packages {
 
 // FormatUpdatablePacksSummary returns a summary of updatable packages
 func (ps Packages) FormatUpdatablePacksSummary() string {
+	if config.Conf.Offline {
+		return fmt.Sprintf("%d installed", len(ps))
+	}
+
 	nUpdatable := 0
 	for _, p := range ps {
 		if p.NewVersion != "" {
 			nUpdatable++
 		}
 	}
-	return fmt.Sprintf("%d updatable packages", nUpdatable)
+	return fmt.Sprintf("%d installed, %d updatable", len(ps), nUpdatable)
 }
 
 // FindOne search a element by name-newver-newrel-arch

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -164,7 +164,7 @@ func (o *debian) checkDependencies() error {
 		// https://askubuntu.com/a/742844
 		packNames = append(packNames, "reboot-notifier")
 
-		if !config.Conf.Deep {
+		if config.Conf.Deep {
 			// Debian needs aptitude to get changelogs.
 			// Because unable to get changelogs via apt-get changelog on Debian.
 			packNames = append(packNames, "aptitude")
@@ -211,6 +211,10 @@ func (o *debian) scanPackages() error {
 	}
 	o.Packages = installed
 	o.SrcPackages = srcPacks
+
+	if config.Conf.Offline {
+		return nil
+	}
 
 	if config.Conf.Deep || o.Distro.Family == config.Raspbian {
 		unsecures, err := o.scanUnsecurePackages(updatable)
@@ -300,6 +304,13 @@ func (o *debian) scanInstalledPackages() (models.Packages, models.Packages, mode
 		delete(srcPacks, name)
 	}
 
+	if config.Conf.Offline {
+		return installed, updatable, srcPacks, nil
+	}
+
+	if err := o.aptGetUpdate(); err != nil {
+		return nil, nil, nil, err
+	}
 	updatableNames, err := o.getUpdatablePackNames()
 	if err != nil {
 		return nil, nil, nil, err
@@ -346,14 +357,12 @@ func (o *debian) aptGetUpdate() error {
 	o.log.Infof("apt-get update...")
 	cmd := util.PrependProxyEnv("apt-get update")
 	if r := o.exec(cmd, sudo); !r.isSuccess() {
-		return fmt.Errorf("Failed to SSH: %s", r)
+		return fmt.Errorf("Failed to apt-get update: %s", r)
 	}
 	return nil
 }
 
 func (o *debian) scanUnsecurePackages(updatable models.Packages) (models.VulnInfos, error) {
-	o.aptGetUpdate()
-
 	// Setup changelog cache
 	current := cache.Meta{
 		Name:   o.getServerInfo().GetServerName(),

--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -177,8 +177,11 @@ func (o *redhat) checkIfSudoNoPasswd() error {
 	return nil
 }
 
-// - Fast scan mode
+// - Fast offline scan mode
 //    Amazon        ... yum-utils
+//
+// - Fast scan mode
+//    All           ... yum-utils
 //
 // - Deep scan mode
 //    CentOS 6,7    ... yum-utils, yum-plugin-changelog
@@ -203,11 +206,13 @@ func (o *redhat) checkDependencies() error {
 	}
 
 	packNames := []string{}
-
-	if !config.Conf.Deep {
-		// Fast Scan
+	if config.Conf.Fast {
+		// Online fast scan needs yum-utils to issue repoquery cmd
+		packNames = append(packNames, "yum-utils")
+	} else if config.Conf.Offline {
 		switch o.Distro.Family {
 		case config.Amazon:
+			// Offline scan doesn't support Amazon Linux
 			packNames = append(packNames, "yum-utils")
 		}
 	} else {
@@ -255,7 +260,7 @@ func (o *redhat) scanPackages() error {
 	}
 	o.Kernel.RebootRequired = rebootRequired
 
-	if !config.Conf.Deep {
+	if config.Conf.Offline {
 		switch o.Distro.Family {
 		case config.Amazon:
 			// nop


### PR DESCRIPTION
## What did you implement:

Closes #561 

## How did you implement it:

Add offline option to scan and configtest subcommand.

## How can we verify it:
 
`./vuls scan` ... show the number of new version 
`./vuls scan -fast` ... show the number of new version
`./vuls scan -offline` ... Don't show the number of new version

## Todos:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
