### PR TITLE
Support AWS S3 Server-Side Encryption

### DIFF
--- a/commands/report.go
+++ b/commands/report.go
@@ -71,10 +71,11 @@ type ReportCmd struct {
 
 	gzip bool
 
-	awsProfile      string
-	awsS3Bucket     string
-	awsS3ResultsDir string
-	awsRegion       string
+	awsProfile                string
+	awsRegion                 string
+	awsS3Bucket               string
+	awsS3ResultsDir           string
+	awsS3ServerSideEncryption string
 
 	azureAccount   string
 	azureKey       string
@@ -126,6 +127,7 @@ func (*ReportCmd) Usage() string {
 		[-aws-region=us-west-2]
 		[-aws-s3-bucket=bucket_name]
 		[-aws-s3-results-dir=/bucket/path/to/results]
+		[-aws-s3-server-side-encryption=AES256]
 		[-azure-account=account]
 		[-azure-key=key]
 		[-azure-container=container]
@@ -275,6 +277,7 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&p.awsRegion, "aws-region", "us-east-1", "AWS region to use")
 	f.StringVar(&p.awsS3Bucket, "aws-s3-bucket", "", "S3 bucket name")
 	f.StringVar(&p.awsS3ResultsDir, "aws-s3-results-dir", "", "/bucket/path/to/results")
+	f.StringVar(&p.awsS3ServerSideEncryption, "aws-s3-server-side-encryption", "", "AES256")
 
 	f.BoolVar(&p.toAzureBlob,
 		"to-azure-blob",
@@ -371,6 +374,7 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 		c.Conf.AwsProfile = p.awsProfile
 		c.Conf.S3Bucket = p.awsS3Bucket
 		c.Conf.S3ResultsDir = p.awsS3ResultsDir
+		c.Conf.S3ServerSideEncryption = p.awsS3ServerSideEncryption
 		if err := report.CheckIfBucketExists(); err != nil {
 			util.Log.Errorf("Check if there is a bucket beforehand: %s, err: %s", c.Conf.S3Bucket, err)
 			return subcommands.ExitUsageError

--- a/commands/report.go
+++ b/commands/report.go
@@ -277,7 +277,7 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&p.awsRegion, "aws-region", "us-east-1", "AWS region to use")
 	f.StringVar(&p.awsS3Bucket, "aws-s3-bucket", "", "S3 bucket name")
 	f.StringVar(&p.awsS3ResultsDir, "aws-s3-results-dir", "", "/bucket/path/to/results")
-	f.StringVar(&p.awsS3ServerSideEncryption, "aws-s3-server-side-encryption", "", "AES256")
+	f.StringVar(&p.awsS3ServerSideEncryption, "aws-s3-server-side-encryption", "", "The Server-side encryption algorithm used when storing the reports in S3 (e.g., AES256, aws:kms).")
 
 	f.BoolVar(&p.toAzureBlob,
 		"to-azure-blob",

--- a/config/config.go
+++ b/config/config.go
@@ -133,10 +133,11 @@ type Config struct {
 
 	GZIP bool
 
-	AwsProfile   string
-	AwsRegion    string
-	S3Bucket     string
-	S3ResultsDir string
+	AwsProfile             string
+	AwsRegion              string
+	S3Bucket               string
+	S3ResultsDir           string
+	S3ServerSideEncryption string
 
 	AzureAccount   string
 	AzureKey       string `json:"-"`

--- a/report/s3.go
+++ b/report/s3.go
@@ -147,11 +147,17 @@ func putObject(svc *s3.S3, k string, b []byte) error {
 		k = k + ".gz"
 	}
 
-	if _, err := svc.PutObject(&s3.PutObjectInput{
+	putObjectInput := &s3.PutObjectInput{
 		Bucket: aws.String(c.Conf.S3Bucket),
 		Key:    aws.String(path.Join(c.Conf.S3ResultsDir, k)),
 		Body:   bytes.NewReader(b),
-	}); err != nil {
+	}
+
+	if c.Conf.S3ServerSideEncryption != "" {
+		putObjectInput.ServerSideEncryption = aws.String(c.Conf.S3ServerSideEncryption)
+	}
+
+	if _, err := svc.PutObject(putObjectInput); err != nil {
 		return fmt.Errorf("Failed to upload data to %s/%s, %s",
 			c.Conf.S3Bucket, k, err)
 	}


### PR DESCRIPTION
## What did you implement:

Support AWS S3 Server-Side Encryption
https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html

## How did you implement it:

Adding a new `-aws-s3-server-side-encryption` option which can be used to set the SSE method.

## How can we verify it:

Publish reports to S3 with `-aws-s3-server-side-encryption=AES256`.
They should have the `Encryption` property set to `AES256`.

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
