### PR TITLE
fix: Kindness error message in reporting

### DIFF
--- a/report/report.go
+++ b/report/report.go
@@ -188,6 +188,9 @@ func FillWithOval(r *models.ScanResult) (err error) {
 	case c.ServerTypePseudo:
 		return nil
 	default:
+		if r.Family == "" {
+			return fmt.Errorf("Probably an error occurred during scanning. Check the error message")
+		}
 		return fmt.Errorf("OVAL for %s is not implemented yet", r.Family)
 	}
 


### PR DESCRIPTION
When executing report with an error in scanning, the following error message is output
```
[Feb 12 10:46:13] ERROR [localhost] Failed to fill OVAL information: OVAL for  is not implemented yet
```

Change to show a kindness message :)
```
[Feb 12 10:55:34] ERROR [localhost] Failed to fill OVAL information: Probably an error occurred during scanning. Check the error message
```

related
#598
#600 
