### PR TITLE
fix: support CentOS cloud image

### DIFF
--- a/report/util.go
+++ b/report/util.go
@@ -378,7 +378,7 @@ func isCveInfoUpdated(cveID string, previous, current models.ScanResult) bool {
 		}
 	}
 	for _, cType := range cTypes {
-		if equal := prevLastModified[cType].Equal(curLastModified[cType]); !equal {
+		if !prevLastModified[cType].Equal(curLastModified[cType]) {
 			return true
 		}
 	}

--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -78,6 +78,28 @@ func detectRedhat(c config.ServerInfo) (itsMe bool, red osTypeInterface) {
 		}
 	}
 
+	// https://bugzilla.redhat.com/show_bug.cgi?id=1332025
+	// CentOS cloud image
+	if r := exec(c, "ls /etc/centos-release", noSudo); r.isSuccess() {
+		if r := exec(c, "cat /etc/centos-release", noSudo); r.isSuccess() {
+			re := regexp.MustCompile(`(.*) release (\d[\d\.]*)`)
+			result := re.FindStringSubmatch(strings.TrimSpace(r.Stdout))
+			if len(result) != 3 {
+				util.Log.Warn("Failed to parse CentOS version: %s", r)
+				return true, red
+			}
+
+			release := result[2]
+			switch strings.ToLower(result[1]) {
+			case "centos", "centos linux":
+				red.setDistro(config.CentOS, release)
+				return true, red
+			default:
+				util.Log.Warn("Failed to parse CentOS: %s", r)
+			}
+		}
+	}
+
 	if r := exec(c, "ls /etc/redhat-release", noSudo); r.isSuccess() {
 		// https://www.rackaid.com/blog/how-to-determine-centos-or-red-hat-version/
 		// e.g.


### PR DESCRIPTION
## Error message 

```
[Mar  6 14:01:39]  WARN [localhost] Failed to parse RedHat/CentOS version: %sexecResult: servername: mystifying_newton@c7idcf
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=no -o ControlPath=none root@210.129.54.232 -p 7003 -i /Users/kota/.ssh/kanbe_idcf_id_rsa -o PasswordAuthentication=no stty cols 1000; docker exec --user 0 59bca0188fde /bin/sh -c 'cat /etc/redhat-release'
  exitstatus: 0
  stdout: Derived from Red Hat Enterprise Linux 7.1 (Source)

  stderr:
  err: %!s(<nil>)
```

## What did you implement:

support CentOS cloud image
https://bugzilla.redhat.com/show_bug.cgi?id=1332025
```
The cloud image is the standard CentOS image from
http://cloud.centos.org/centos/7/images/

They have split the release information out to
/etc/centos-release so we should parse that file in
preference to /etc/redhat-release.

```

## How did you implement it:

parse /etc/centos-release before /etc/redhat-release

## How can we verify it:

scan CentOS cloud image

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
