### PR TITLE
fix link nvd on hipchat

### DIFF
--- a/report/hipchat.go
+++ b/report/hipchat.go
@@ -31,7 +31,7 @@ func (w HipChatWriter) Write(rs ...models.ScanResult) (err error) {
 				severity = "?"
 			}
 
-			message = `<a href="https://nvd.nist.gov/vuln/detail\">` + vinfo.CveID + "</a>" + "<br/>" + strconv.FormatFloat(maxCvss.Value.Score, 'f', 1, 64) + " " + "(" + severity + ")" + "<br/>" + vinfo.Summaries(config.Conf.Lang, r.Family)[0].Value
+			message = `<a href="https://nvd.nist.gov/vuln/detail\` + vinfo.CveID + ">" + vinfo.CveID + ">" + vinfo.CveID + "</a>" + "<br/>" + strconv.FormatFloat(maxCvss.Value.Score, 'f', 1, 64) + " " + "(" + severity + ")" + "<br/>" + vinfo.Summaries(config.Conf.Lang, r.Family)[0].Value
 
 			err = postMessage(conf.Room, conf.AuthToken, message)
 			if err != nil {


### PR DESCRIPTION
## What did you implement:

Closes #XXXXX

## How did you implement it:
for example

https://nvd.nist.gov/vuln/detail\         ->          https://nvd.nist.gov/vuln/detail/CVE-2015-2328


## How can we verify it:
vuls report -to-hipchat

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
