### PR TITLE
fix: SSH session multiplexing

### DIFF
--- a/scan/executil.go
+++ b/scan/executil.go
@@ -275,13 +275,9 @@ func sshExecExternal(c conf.ServerInfo, cmd string, sudo bool) (result execResul
 		"-o", "LogLevel=quiet",
 		"-o", "ConnectionAttempts=3",
 		"-o", "ConnectTimeout=10",
-		"-o", "ControlMaster=no",
-		"-o", "ControlPath=none",
-
-		// TODO ssh session multiplexing
-		//  "-o", "ControlMaster=auto",
-		//  "-o", `ControlPath=~/.ssh/controlmaster-%r-%h.%p`,
-		//  "-o", "Controlpersist=30m",
+		"-o", "ControlMaster=auto",
+		"-o", `ControlPath=~/.ssh/controlmaster-%r-%h.%p`,
+		"-o", "Controlpersist=10m",
 	}
 	args := append(defaultSSHArgs, fmt.Sprintf("%s@%s", c.User, c.Host))
 	args = append(args, "-p", c.Port)


### PR DESCRIPTION

To enables the sharing of multiple sessions over a single network connection to add controlmaster after host directive. 

https://www.cyberciti.biz/faq/linux-unix-reuse-openssh-connection/
https://en.wikibooks.org/wiki/OpenSSH/Cookbook/Multiplexing

## before

netstat -an | grep 10.1
```
tcp4       0      0  192.168.11.6.63618     10.1.54.232.7003    ESTABLISHED
tcp4       0      0  192.168.11.6.63696     10.1.54.232.7003    TIME_WAIT
tcp4       0      0  192.168.11.6.63697     10.1.54.232.7003    TIME_WAIT
tcp4       0      0  192.168.11.6.63698     10.1.54.232.7003    TIME_WAIT
tcp4       0      0  192.168.11.6.63699     10.1.54.232.7003    TIME_WAIT
tcp4       0      0  192.168.11.6.63700     10.1.54.232.7003    TIME_WAIT
tcp4       0      0  192.168.11.6.63701     10.1.54.232.7003    TIME_WAIT
tcp4       0      0  192.168.11.6.63702     10.1.54.232.7003    TIME_WAIT
ebf27116da1ccc13 stream      0      0 ebf27116dc530663                0                0
         0 /Users/kota/.ssh/controlmaster-root-10.1.54.232.7003.VjxphvT8EOdfAyop
```


## After
netstat -an | grep 10.1
```
tcp4       0      0  192.168.11.6.63618     10.1.54.232.7003    ESTABLISHED
ebf27116da1ccc13 stream      0      0 ebf27116dc530663                0                0
         0 /Users/kota/.ssh/controlmaster-root-10.1.54.232.7003.VjxphvT8EOdfAyop
```
