### PR TITLE
feat: Add -vvv option (SSH) to scan cmd

### DIFF
--- a/commands/scan.go
+++ b/commands/scan.go
@@ -49,6 +49,7 @@ type ScanCmd struct {
 	skipBroken     bool
 	sshNative      bool
 	pipe           bool
+	vvv            bool
 	timeoutSec     int
 	scanTimeoutSec int
 }
@@ -79,6 +80,7 @@ func (*ScanCmd) Usage() string {
 		[-timeout-scan=7200]
 		[-debug]
 		[-pipe]
+		[-vvv]
 
 		[SERVER]...
 `
@@ -162,6 +164,8 @@ func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 		false,
 		"Use stdin via PIPE")
 
+	f.BoolVar(&p.vvv, "vvv", false, "ssh -vvv")
+
 	f.IntVar(
 		&p.timeoutSec,
 		"timeout",
@@ -206,6 +210,7 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	util.Log.Infof("config: %s", p.configPath)
 
 	c.Conf.Pipe = p.pipe
+	c.Conf.Vvv = p.vvv
 	var servernames []string
 	if 0 < len(f.Args()) {
 		servernames = f.Args()

--- a/config/config.go
+++ b/config/config.go
@@ -156,6 +156,7 @@ type Config struct {
 	AzureContainer string
 
 	Pipe bool
+	Vvv  bool
 	Diff bool
 }
 

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -279,6 +279,10 @@ func sshExecExternal(c conf.ServerInfo, cmd string, sudo bool) (result execResul
 		"-o", `ControlPath=~/.ssh/controlmaster-%r-%h.%p`,
 		"-o", "Controlpersist=10m",
 	}
+	if conf.Conf.Vvv {
+		defaultSSHArgs = append(defaultSSHArgs, "-vvv")
+	}
+
 	args := append(defaultSSHArgs, fmt.Sprintf("%s@%s", c.User, c.Host))
 	args = append(args, "-p", c.Port)
 


### PR DESCRIPTION
Add SSH -vvv option to scan subcommand.
It is useful for SSH connection trouble debugging.