### PR TITLE
fix: change ControlPath to .vuls of SSH option

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -266,6 +266,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
+
+[[projects]]
+  branch = "master"
   name = "github.com/moul/http2curl"
   packages = ["."]
   revision = "9ac6cf4d929b2fa8fd2d2e6dec5bb0feb4f4911d"
@@ -377,6 +383,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1a43293a9ffc91270316199bec5474167594f96a3612f899842532c0f224d694"
+  inputs-digest = "17ca5502a80ae70140ecf819a5b2757898b42deca821221afebce63488b691ea"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -107,3 +107,7 @@
 [[constraint]]
   branch = "master"
   name = "golang.org/x/crypto"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/mitchellh/go-homedir"

--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -45,6 +45,7 @@ type ConfigtestCmd struct {
 	deep    bool
 
 	debug bool
+	vvv   bool
 }
 
 // Name return subcommand name
@@ -68,6 +69,7 @@ func (*ConfigtestCmd) Usage() string {
 			[-containers-only]
 			[-http-proxy=http://192.168.0.1:8080]
 			[-debug]
+			[-vvv]
 
 			[SERVER]...
 `
@@ -125,6 +127,8 @@ func (p *ConfigtestCmd) SetFlags(f *flag.FlagSet) {
 		"containers-only",
 		false,
 		"Test containers only. Default: Test both of hosts and containers")
+
+	f.BoolVar(&p.vvv, "vvv", false, "ssh -vvv")
 }
 
 // Execute execute
@@ -133,6 +137,11 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 	c.Conf.Debug = p.debug
 	c.Conf.LogDir = p.logDir
 	util.Log = util.NewCustomLogger(c.ServerInfo{})
+
+	if err := mkdirDotVuls(); err != nil {
+		util.Log.Errorf("Failed to create .vuls: %s", err)
+		return subcommands.ExitUsageError
+	}
 
 	var keyPass string
 	var err error
@@ -161,6 +170,7 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 	if !(c.Conf.Fast || c.Conf.Offline || c.Conf.Deep) {
 		c.Conf.Fast = true
 	}
+	c.Conf.Vvv = p.vvv
 
 	var servernames []string
 	if 0 < len(f.Args()) {

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -188,6 +188,11 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	c.Conf.LogDir = p.logDir
 	util.Log = util.NewCustomLogger(c.ServerInfo{})
 
+	if err := mkdirDotVuls(); err != nil {
+		util.Log.Errorf("Failed to create .vuls: %s", err)
+		return subcommands.ExitUsageError
+	}
+
 	var keyPass string
 	var err error
 	if p.askKeyPassword {

--- a/commands/util.go
+++ b/commands/util.go
@@ -19,8 +19,11 @@ package commands
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/howeyc/gopass"
+	homedir "github.com/mitchellh/go-homedir"
 )
 
 func getPasswd(prompt string) (string, error) {
@@ -35,4 +38,18 @@ func getPasswd(prompt string) (string, error) {
 		}
 	}
 
+}
+
+func mkdirDotVuls() error {
+	home, err := homedir.Dir()
+	if err != nil {
+		return err
+	}
+	dotVuls := filepath.Join(home, ".vuls")
+	if _, err := os.Stat(dotVuls); os.IsNotExist(err) {
+		if err := os.Mkdir(dotVuls, 0700); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Why did you implement:

I added #616 
Bug, when scanning with Docker dontainer with the following command, an error occurrs.
```
docker run --rm \
>        -v ~/.ssh:/root/.ssh:ro \
>        -v $PWD:/vuls \
>        -v $PWD/vuls-log:/var/log/vuls \
>        -v /etc/localtime:/etc/localtime:ro \
>        -e "TZ=Asia/Tokyo" \
>        vuls/vuls scan \
>        -debug \
```

The reason is that vuls do not have write permission for ControlPath.
```
"-o", `ControlPath=~/.ssh/controlmaster-%r-%h.%p`,
```
https://github.com/future-architect/vuls/commit/50b105c4afda4064457ed7512747abd28ba9f935#diff-d2cd8aa61e6589e85271b9ab653d911fR279

Because Docker mount it as readonly as Docker Volume.
```
>        -v ~/.ssh:/root/.ssh:ro \
```

So Vuls create at the beginning of scan or configtest to $HOME/.Vuls and set SSH ControlPath there.

## How did you implement it:

- Chagne ControlPath to $HOME/.vuls
- Add -vvv option to configtest

## How can we verify it:

scan 
configtest

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
