### PR TITLE
notify whether new or updated CVE with diff option

### DIFF
--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -129,6 +129,7 @@ type VulnInfo struct {
 	DistroAdvisories []DistroAdvisory // for Aamazon, RHEL, FreeBSD
 	CpeNames         []string
 	CveContents      CveContents
+	UpdatedStatus    string // for diff
 }
 
 // Titles returns tilte (TUI)

--- a/report/slack.go
+++ b/report/slack.go
@@ -308,7 +308,8 @@ func attachmentText(vinfo models.VulnInfo, osFamily string) string {
 		severity = "?"
 	}
 
-	return fmt.Sprintf("*%4.1f (%s)* %s\n%s\n```%s```",
+	return fmt.Sprintf("%s\n *%4.1f (%s)* %s\n%s\n```%s```",
+		vinfo.UpdatedStatus,
 		maxCvss.Value.Score,
 		severity,
 		cweIDs(vinfo, osFamily),

--- a/report/util.go
+++ b/report/util.go
@@ -345,15 +345,18 @@ func getDiffCves(previous, current models.ScanResult) models.VulnInfos {
 	for _, v := range current.ScannedCves {
 		if previousCveIDsSet[v.CveID] {
 			if isCveInfoUpdated(v.CveID, previous, current) {
+				v.UpdatedStatus = "updated"
 				updated[v.CveID] = v
 				util.Log.Debugf("updated: %s", v.CveID)
 			} else if isCveFixed(v, previous) {
+				v.UpdatedStatus = "updated"
 				updated[v.CveID] = v
 				util.Log.Debugf("fixed: %s", v.CveID)
 			} else {
 				util.Log.Debugf("same: %s", v.CveID)
 			}
 		} else {
+			v.UpdatedStatus = "new"
 			util.Log.Debugf("new: %s", v.CveID)
 			new[v.CveID] = v
 		}

--- a/report/util_test.go
+++ b/report/util_test.go
@@ -295,6 +295,7 @@ func TestDiff(t *testing.T) {
 						AffectedPackages: models.PackageStatuses{{Name: "mysql-libs"}},
 						DistroAdvisories: []models.DistroAdvisory{},
 						CpeNames:         []string{},
+						UpdatedStatus:    "new",
 					},
 				},
 				Packages: models.Packages{


### PR DESCRIPTION
# What did you implement:
With this implementation, you can see if cve notified by the diff option is update notification or new notification.

## How did you implement it:


## How can we verify it:
- make test 
- Change LastModified in one json and actually notify.


## Todos:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO