### PR TITLE
fix(scan): too long for Unix domain socket tmp file

### DIFF
--- a/scan/executil.go
+++ b/scan/executil.go
@@ -278,7 +278,7 @@ func sshExecExternal(c conf.ServerInfo, cmd string, sudo bool) (result execResul
 		result.ExitStatus = 997
 		return
 	}
-	controlPath := filepath.Join(home, ".vuls", `controlmaster-%r-%h.%p`)
+	controlPath := filepath.Join(home, ".vuls", `controlmaster-%r-`+c.ServerName+`.%p`)
 
 	defaultSSHArgs := []string{
 		"-tt",
@@ -296,11 +296,6 @@ func sshExecExternal(c conf.ServerInfo, cmd string, sudo bool) (result execResul
 
 	args := append(defaultSSHArgs, fmt.Sprintf("%s@%s", c.User, c.Host))
 	args = append(args, "-p", c.Port)
-
-	//  if conf.Conf.Debug {
-	//      args = append(args, "-v")
-	//  }
-
 	if 0 < len(c.KeyPath) {
 		args = append(args, "-i", c.KeyPath)
 		args = append(args, "-o", "PasswordAuthentication=no")


### PR DESCRIPTION
## What did you implement:

Closes #639

## How did you implement it:

Use servername for SSH ControlPath filename

## How can we verify it:

./vuls scan

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
