### PR TITLE
Add scanned_at into syslog report

### DIFF
--- a/report/syslog.go
+++ b/report/syslog.go
@@ -59,6 +59,7 @@ func (w SyslogWriter) encodeSyslog(result models.ScanResult) (messages []string)
 
 	for cveID, vinfo := range result.ScannedCves {
 		var kvPairs []string
+		kvPairs = append(kvPairs, fmt.Sprintf(`scanned_at="%s"`, result.ScannedAt))
 		kvPairs = append(kvPairs, fmt.Sprintf(`server_name="%s"`, result.ServerName))
 		kvPairs = append(kvPairs, fmt.Sprintf(`os_family="%s"`, result.Family))
 		kvPairs = append(kvPairs, fmt.Sprintf(`os_release="%s"`, result.Release))

--- a/report/syslog_test.go
+++ b/report/syslog_test.go
@@ -3,6 +3,7 @@ package report
 import (
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/future-architect/vuls/models"
 )
@@ -14,6 +15,7 @@ func TestSyslogWriterEncodeSyslog(t *testing.T) {
 	}{
 		{
 			result: models.ScanResult{
+				ScannedAt:  time.Date(2018, 6, 13, 16, 10, 0, 0, time.UTC),
 				ServerName: "teste01",
 				Family:     "ubuntu",
 				Release:    "16.04",
@@ -41,12 +43,13 @@ func TestSyslogWriterEncodeSyslog(t *testing.T) {
 				},
 			},
 			expectedMessages: []string{
-				`server_name="teste01" os_family="ubuntu" os_release="16.04" ipv4_addr="192.168.0.1,10.0.2.15" ipv6_addr="" packages="pkg1,pkg2" cve_id="CVE-2017-0001"`,
-				`server_name="teste01" os_family="ubuntu" os_release="16.04" ipv4_addr="192.168.0.1,10.0.2.15" ipv6_addr="" packages="pkg3,pkg4" cve_id="CVE-2017-0002" severity="MEDIUM" cvss_score_v2="5.00" cvss_vector_v2="AV:L/AC:L/Au:N/C:N/I:N/A:C" cwe_id="CWE-20"`,
+				`scanned_at="2018-06-13 16:10:00 +0000 UTC" server_name="teste01" os_family="ubuntu" os_release="16.04" ipv4_addr="192.168.0.1,10.0.2.15" ipv6_addr="" packages="pkg1,pkg2" cve_id="CVE-2017-0001"`,
+				`scanned_at="2018-06-13 16:10:00 +0000 UTC" server_name="teste01" os_family="ubuntu" os_release="16.04" ipv4_addr="192.168.0.1,10.0.2.15" ipv6_addr="" packages="pkg3,pkg4" cve_id="CVE-2017-0002" severity="MEDIUM" cvss_score_v2="5.00" cvss_vector_v2="AV:L/AC:L/Au:N/C:N/I:N/A:C" cwe_id="CWE-20"`,
 			},
 		},
 		{
 			result: models.ScanResult{
+				ScannedAt:  time.Date(2018, 6, 13, 17, 10, 0, 0, time.UTC),
 				ServerName: "teste02",
 				Family:     "centos",
 				Release:    "6",
@@ -67,7 +70,7 @@ func TestSyslogWriterEncodeSyslog(t *testing.T) {
 				},
 			},
 			expectedMessages: []string{
-				`server_name="teste02" os_family="centos" os_release="6" ipv4_addr="" ipv6_addr="2001:0DB8::1" packages="pkg5" cve_id="CVE-2017-0003"`,
+				`scanned_at="2018-06-13 17:10:00 +0000 UTC" server_name="teste02" os_family="centos" os_release="6" ipv4_addr="" ipv6_addr="2001:0DB8::1" packages="pkg5" cve_id="CVE-2017-0003"`,
 			},
 		},
 	}


### PR DESCRIPTION
## What did you implement:

Add `scanned_at` into syslog report.

## How did you implement it:

Extract `ScannedAt` from `ScanResult`.

## How can we verify it:

```
$ vuls report -to-syslog
```

```
# nc -l 514
<129>2018-05-11T11:05:44+09:00 PC vuls[59729]: scanned_at="2018-05-11 10:58:40.381092554 +0900 JST" server_name="ubuntu1604" os_family="ubuntu" os_release="16.04" ipv4_addr="192.168.33.11" ipv6_addr="" packages="libncurses5,libncursesw5,libtinfo5,ncurses-base,ncurses-bin,ncurses-term" cve_id="CVE-2017-13731" severity="MEDIUM" cvss_score_v2="4.30" cvss_vector_v2="AV:N/AC:M/Au:N/C:N/I:N/A:P" cwe_id="CWE-119"
```

## Todos:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
