### PR TITLE
Don't check reboot-notifier package for debian containers

### DIFF
--- a/scan/debian.go
+++ b/scan/debian.go
@@ -162,7 +162,9 @@ func (o *debian) checkDependencies() error {
 
 	case config.Debian:
 		// https://askubuntu.com/a/742844
-		packNames = append(packNames, "reboot-notifier")
+		if !o.ServerInfo.IsContainer() {
+			packNames = append(packNames, "reboot-notifier")
+		}
 
 		if config.Conf.Deep {
 			// Debian needs aptitude to get changelogs.


### PR DESCRIPTION
## What did you implement:
`vuls configtest` was complaining about the official mysql image:  *reboot-notifier is not installed*.
Debian's `reboot-notifier`  packages depends on `gnome-packagekit` which I don't think it will be installed for any of the debian based docker images, so its safe to disable it.

## How did you implement it:


## How can we verify it:
config.toml
```
[servers]
[servers.localhost]
host = "localhost"
port = "local"
[servers.localhost.containers]
includes = ["debian"]
````
```
docker run -d --rm --name=debian debian tail -f /dev/null`
vuls configtest -containers-only
```

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [X] Check that there aren't other open pull requests for the same issue/feature
- [X] Format your source code by `make fmt`
- [X] Pass the test by `make test`
- [X] Provide verification config / commands
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES 
***Is it a breaking change?:*** NO
