### PR TITLE
Move to alpine based docker images

### DIFF
--- a/setup/docker/go-cve-dictionary/latest/Dockerfile
+++ b/setup/docker/go-cve-dictionary/latest/Dockerfile
@@ -1,15 +1,28 @@
-FROM golang:latest
+FROM golang:alpine as builder
+
+RUN apk add --no-cache \
+        git \
+        make \
+        gcc \
+        musl-dev
+
+ENV REPOSITORY github.com/kotakanbe/go-cve-dictionary
+RUN git clone https://$REPOSITORY.git $GOPATH/src/$REPOSITORY \
+    && cd $GOPATH/src/$REPOSITORY \
+    && make install
+
+
+FROM alpine:3.7
 
 MAINTAINER hikachan sadayuki-matsuno
 
-ENV REPOSITORY github.com/kotakanbe/go-cve-dictionary
 ENV LOGDIR /var/log/vuls
 ENV WORKDIR /vuls
-# go-cve-dictionary install
-RUN git clone https://$REPOSITORY.git $GOPATH/src/$REPOSITORY \
-    && cd $GOPATH/src/$REPOSITORY \
-    && make install \
-    && mkdir -p $LOGDIR
+
+RUN apk add --no-cache ca-certificates \
+    && mkdir -p $WORKDIR $LOGDIR
+
+COPY --from=builder /go/bin/go-cve-dictionary /usr/local/bin/
 
 VOLUME [$WORKDIR, $LOGDIR]
 WORKDIR $WORKDIR

--- a/setup/docker/goval-dictionary/latest/Dockerfile
+++ b/setup/docker/goval-dictionary/latest/Dockerfile
@@ -1,15 +1,28 @@
-FROM golang:latest
+FROM golang:alpine as builder
+
+RUN apk add --no-cache \
+        git \
+        make \
+        gcc \
+        musl-dev
+
+ENV REPOSITORY github.com/kotakanbe/goval-dictionary
+RUN git clone https://$REPOSITORY.git $GOPATH/src/$REPOSITORY \
+    && cd $GOPATH/src/$REPOSITORY \
+    && make install
+
+
+FROM alpine:3.7
 
 MAINTAINER sadayuki-matsuno
 
-ENV REPOSITORY github.com/kotakanbe/goval-dictionary
 ENV LOGDIR /var/log/vuls
 ENV WORKDIR /vuls
-# goval-dictionary install
-RUN git clone https://$REPOSITORY.git $GOPATH/src/$REPOSITORY \
-    && cd $GOPATH/src/$REPOSITORY \
-    && make install \
-    && mkdir -p $LOGDIR
+
+RUN apk add --no-cache ca-certificates \
+    && mkdir -p $WORKDIR $LOGDIR
+
+COPY --from=builder /go/bin/goval-dictionary /usr/local/bin/
 
 VOLUME [$WORKDIR, $LOGDIR]
 WORKDIR $WORKDIR

--- a/setup/docker/vuls/latest/Dockerfile
+++ b/setup/docker/vuls/latest/Dockerfile
@@ -1,15 +1,28 @@
-FROM golang:latest
+FROM golang:alpine as builder
+
+RUN apk add --no-cache \
+        git \
+        make \
+        gcc \
+        musl-dev
+
+ENV REPOSITORY github.com/future-architect/vuls
+RUN git clone https://$REPOSITORY.git $GOPATH/src/$REPOSITORY \
+    && cd $GOPATH/src/$REPOSITORY \
+    && make install
+
+
+FROM alpine:3.7
 
 MAINTAINER hikachan sadayuki-matsuno
 
-ENV REPOSITORY github.com/future-architect/vuls
 ENV LOGDIR /var/log/vuls
 ENV WORKDIR /vuls
-# go-cve-dictionary install
-RUN git clone https://$REPOSITORY.git $GOPATH/src/$REPOSITORY \
-    && cd $GOPATH/src/$REPOSITORY \
-    && make install \
-    && mkdir -p $LOGDIR
+
+RUN apk add --no-cache openssh-client \
+    && mkdir -p $WORKDIR $LOGDIR
+
+COPY --from=builder /go/bin/vuls /usr/local/bin/
 
 VOLUME [$WORKDIR, $LOGDIR]
 WORKDIR $WORKDIR

--- a/setup/docker/vulsrepo/latest/Dockerfile
+++ b/setup/docker/vulsrepo/latest/Dockerfile
@@ -1,18 +1,32 @@
-FROM alpine:3.6
+FROM golang:alpine as builder
+
+RUN apk --no-cache add git
+
+ENV REPOSITORY github.com/usiusi360/vulsrepo
+
+RUN git clone https://$REPOSITORY.git $GOPATH/src/$REPOSITORY \
+    && cd $GOPATH/src/$REPOSITORY/server \
+    && go get -u github.com/golang/dep/... \
+    && dep ensure \
+    && go build -ldflags "-s -w" -o $GOPATH/bin/vulsrepo-server
+
+RUN mkdir /vulsrepo \
+    && mv $GOPATH/src/$REPOSITORY/server/vulsrepo-config.toml.sample /vulsrepo/vulsrepo-config.toml \
+    && mv $GOPATH/src/$REPOSITORY /vulsrepo/www \
+    && rm -rf /vulsrepo/www/.git* /vulsrepo/www/server \
+    && sed -i -e 's/vulsrepo/www/g' /vulsrepo/vulsrepo-config.toml \
+    && sed -i -e 's/home\/vuls-user/vulsrepo/g' /vulsrepo/vulsrepo-config.toml \
+    && sed -i -e 's/\/opt//g' /vulsrepo/vulsrepo-config.toml
+
+FROM alpine:3.7
 
 MAINTAINER hikachan sadayuki-matsuno usiusi360
 
+COPY --from=builder /go/bin/vulsrepo-server /usr/local/bin/
+COPY --from=builder /vulsrepo /vulsrepo
+
 VOLUME /vuls
-
-RUN apk --no-cache add git \
-   && git clone https://github.com/usiusi360/vulsrepo.git
-
-RUN cd /vulsrepo/server \
-   && cp vulsrepo-config.toml.sample vulsrepo-config.toml \
-   && sed -i -e 's/\/home\/vuls-user//g' vulsrepo-config.toml \
-   && sed -i -e 's/\/opt//g' vulsrepo-config.toml \
-   && mkdir /lib64 \
-   && ln -s /lib/ld-musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+WORKDIR /vulsrepo
 
 EXPOSE 5111
-CMD ["/vulsrepo/server/vulsrepo-server"]
+CMD ["vulsrepo-server"]


### PR DESCRIPTION
## What did you implement:
Use alpine based images to reduce size.

Uncompressid sizes:
vulsrepo: from **66.8MB** to **15.8MB**
vuls: from **1.54GB** to **36.5MB**
goval-dictionary: from **967MB** to **23.6MB**
go-cve-dictionary: from **1.05GB** to **23.8MB**

## How did you implement it:
Multistage builds with **golang:alpine** image

## How can we verify it:
`docker build`

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [X] Check that there aren't other open pull requests for the same issue/feature
- [X] Format your source code by `make fmt`
- [X] Pass the test by `make test`
- [X] Provide verification config / commands
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
