### PR TITLE
Send logs via syslog when no CVE-IDs found

### DIFF
--- a/report/syslog_test.go
+++ b/report/syslog_test.go
@@ -73,6 +73,19 @@ func TestSyslogWriterEncodeSyslog(t *testing.T) {
 				`scanned_at="2018-06-13 17:10:00 +0000 UTC" server_name="teste02" os_family="centos" os_release="6" ipv4_addr="" ipv6_addr="2001:0DB8::1" packages="pkg5" cve_id="CVE-2017-0003"`,
 			},
 		},
+		{
+			result: models.ScanResult{
+				ScannedAt:   time.Date(2018, 6, 13, 12, 10, 0, 0, time.UTC),
+				ServerName:  "teste03",
+				Family:      "centos",
+				Release:     "7",
+				IPv6Addrs:   []string{"2001:0DB8::1"},
+				ScannedCves: models.VulnInfos{},
+			},
+			expectedMessages: []string{
+				`scanned_at="2018-06-13 12:10:00 +0000 UTC" server_name="teste03" os_family="centos" os_release="7" ipv4_addr="" ipv6_addr="2001:0DB8::1" message="No CVE-IDs are found"`,
+			},
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
## What did you implement:
Send logs via syslog even if no CVE-IDs found.

## How did you implement it:
If `messages` are empty slice, add `messages` to "No CVE-IDs are found".

## How can we verify it:
```
$ vuls report -to-syslog
```

```
$ nc -l 5140
<38>2018-05-16T12:41:42+09:00 iMac.local vuls[40916]: scanned_at="2018-05-16 12:35:14.625713325 +0900 JST" server_name="debian8" os_family="debian" os_release="8.10" ipv4_addr="10.0.2.15,192.168.33.16" ipv6_addr="" message="No CVE-IDs are found"
```

## Todos:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
