### PR TITLE
Add missing ca-certificates, needed for slack webhook

### DIFF
--- a/setup/docker/vuls/latest/Dockerfile
+++ b/setup/docker/vuls/latest/Dockerfile
@@ -19,7 +19,9 @@ MAINTAINER hikachan sadayuki-matsuno
 ENV LOGDIR /var/log/vuls
 ENV WORKDIR /vuls
 
-RUN apk add --no-cache openssh-client \
+RUN apk add --no-cache \
+        openssh-client \
+        ca-certificates \
     && mkdir -p $WORKDIR $LOGDIR
 
 COPY --from=builder /go/bin/vuls /usr/local/bin/


### PR DESCRIPTION
## What did you implement:

Fix HTTP POST error for https webhooks

## How did you implement it:


## How can we verify it:
`vuls report -to-slack`

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [X] Check that there aren't other open pull requests for the same issue/feature
- [X] Format your source code by `make fmt`
- [X] Pass the test by `make test`
- [X] Provide verification config / commands
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
