### PR TITLE
feat(scan): add -ssh-config option #417

### DIFF
--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -37,6 +37,7 @@ type ConfigtestCmd struct {
 	askKeyPassword bool
 	containersOnly bool
 	sshNative      bool
+	sshConfig      bool
 	httpProxy      string
 	timeoutSec     int
 
@@ -123,6 +124,12 @@ func (p *ConfigtestCmd) SetFlags(f *flag.FlagSet) {
 		"Use Native Go implementation of SSH. Default: Use the external command")
 
 	f.BoolVar(
+		&p.sshConfig,
+		"ssh-config",
+		false,
+		"Use SSH options specified in ssh_config preferentially")
+
+	f.BoolVar(
 		&p.containersOnly,
 		"containers-only",
 		false,
@@ -161,6 +168,8 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 		return subcommands.ExitUsageError
 	}
 	c.Conf.SSHNative = p.sshNative
+	c.Conf.SSHConfig = p.sshConfig
+
 	c.Conf.HTTPProxy = p.httpProxy
 	c.Conf.ContainersOnly = p.containersOnly
 

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -48,6 +48,7 @@ type ScanCmd struct {
 	deep           bool
 	skipBroken     bool
 	sshNative      bool
+	sshConfig      bool
 	pipe           bool
 	vvv            bool
 	timeoutSec     int
@@ -72,6 +73,7 @@ func (*ScanCmd) Usage() string {
 		[-log-dir=/path/to/log]
 		[-cachedb-path=/path/to/cache.db]
 		[-ssh-native-insecure]
+		[-ssh-config]
 		[-containers-only]
 		[-skip-broken]
 		[-http-proxy=http://192.168.0.1:8080]
@@ -113,6 +115,12 @@ func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 		"ssh-native-insecure",
 		false,
 		"Use Native Go implementation of SSH. Default: Use the external command")
+
+	f.BoolVar(
+		&p.sshConfig,
+		"ssh-config",
+		false,
+		"Use SSH options specified in ssh_config preferentially")
 
 	f.BoolVar(
 		&p.containersOnly,
@@ -254,6 +262,7 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	c.Conf.ResultsDir = p.resultsDir
 	c.Conf.CacheDBPath = p.cacheDBPath
 	c.Conf.SSHNative = p.sshNative
+	c.Conf.SSHConfig = p.sshConfig
 	c.Conf.HTTPProxy = p.httpProxy
 	c.Conf.ContainersOnly = p.containersOnly
 	c.Conf.SkipBroken = p.skipBroken

--- a/config/config.go
+++ b/config/config.go
@@ -107,7 +107,9 @@ type Config struct {
 	IgnoreUnscoredCves bool
 	IgnoreUnfixed      bool
 
-	SSHNative      bool
+	SSHNative bool
+	SSHConfig bool
+
 	ContainersOnly bool
 	Fast           bool
 	Offline        bool

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -271,25 +271,29 @@ func sshExecExternal(c conf.ServerInfo, cmd string, sudo bool) (result execResul
 		return sshExecNative(c, cmd, sudo)
 	}
 
-	home, err := homedir.Dir()
-	if err != nil {
-		msg := fmt.Sprintf("Failed to get HOME directory: %s", err)
-		result.Stderr = msg
-		result.ExitStatus = 997
-		return
-	}
-	controlPath := filepath.Join(home, ".vuls", `controlmaster-%r-`+c.ServerName+`.%p`)
+	defaultSSHArgs := []string{"-tt"}
 
-	defaultSSHArgs := []string{
-		"-tt",
-		"-o", "StrictHostKeyChecking=yes",
-		"-o", "LogLevel=quiet",
-		"-o", "ConnectionAttempts=3",
-		"-o", "ConnectTimeout=10",
-		"-o", "ControlMaster=auto",
-		"-o", fmt.Sprintf("ControlPath=%s", controlPath),
-		"-o", "Controlpersist=10m",
+	if !conf.Conf.SSHConfig {
+		home, err := homedir.Dir()
+		if err != nil {
+			msg := fmt.Sprintf("Failed to get HOME directory: %s", err)
+			result.Stderr = msg
+			result.ExitStatus = 997
+			return
+		}
+		controlPath := filepath.Join(home, ".vuls", `controlmaster-%r-`+c.ServerName+`.%p`)
+
+		defaultSSHArgs = append(defaultSSHArgs,
+			"-o", "StrictHostKeyChecking=yes",
+			"-o", "LogLevel=quiet",
+			"-o", "ConnectionAttempts=3",
+			"-o", "ConnectTimeout=10",
+			"-o", "ControlMaster=auto",
+			"-o", fmt.Sprintf("ControlPath=%s", controlPath),
+			"-o", "Controlpersist=10m",
+		)
 	}
+
 	if conf.Conf.Vvv {
 		defaultSSHArgs = append(defaultSSHArgs, "-vvv")
 	}


### PR DESCRIPTION
## What did you implement:

Closes #417 

## How did you implement it:

add -ssh-config option to scan and configtest.

## How can we verify it:

scan with -vvv option In order to check the option of SSH actually being executed.

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
