### PR TITLE
Add title to syslog

### DIFF
--- a/report/syslog.go
+++ b/report/syslog.go
@@ -92,6 +92,9 @@ func (w SyslogWriter) encodeSyslog(result models.ScanResult) (messages []string)
 				kvPairs = append(kvPairs, fmt.Sprintf(`summary="%s"`, content.Summary))
 			}
 		}
+		if content, ok := vinfo.CveContents[models.RedHat]; ok {
+			kvPairs = append(kvPairs, fmt.Sprintf(`title="%s"`, content.Title))
+		}
 
 		// message: key1="value1" key2="value2"...
 		messages = append(messages, strings.Join(kvPairs, " "))

--- a/report/syslog_test.go
+++ b/report/syslog_test.go
@@ -64,13 +64,14 @@ func TestSyslogWriterEncodeSyslog(t *testing.T) {
 								Cvss3Score:  5.0,
 								Cvss3Vector: "AV:L/AC:L/Au:N/C:N/I:N/A:C",
 								CweID:       "CWE-284",
+								Title:       "RHSA-2017:0001: pkg5 security update (Important)",
 							},
 						},
 					},
 				},
 			},
 			expectedMessages: []string{
-				`scanned_at="2018-06-13 17:10:00 +0000 UTC" server_name="teste02" os_family="centos" os_release="6" ipv4_addr="" ipv6_addr="2001:0DB8::1" packages="pkg5" cve_id="CVE-2017-0003"`,
+				`scanned_at="2018-06-13 17:10:00 +0000 UTC" server_name="teste02" os_family="centos" os_release="6" ipv4_addr="" ipv6_addr="2001:0DB8::1" packages="pkg5" cve_id="CVE-2017-0003" title="RHSA-2017:0001: pkg5 security update (Important)"`,
 			},
 		},
 		{


### PR DESCRIPTION
## What did you implement:

Add title to syslog

## How did you implement it:

Extract a title from `CveContents` of RedHat.

## How can we verify it:

```
$ vuls report -to-syslog
```

```
$ nc -l 514
<129>2018-06-05T16:15:42+09:00 MBP vuls[52919]: scanned_at="2018-06-05 14:40:05.611697546 +0900 JST" server_name="centos6" os_family="centos" os_release="6.9" ipv4_addr="10.0.2.15,192.168.33.10" ipv6_addr="" packages="procps" cve_id="CVE-2018-1126" cwe_id="" source_link="https://nvd.nist.gov/vuln/detail/CVE-2018-1126" summary="procps-ng before version 3.3.15 is vulnerable to an incorrect integer size in proc/alloc.* leading to truncation/integer overflow issues. This flaw is related to CVE-2018-1124." title="RHSA-2018:1777: procps security update (Important)"
```

## Todos:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
