### PR TITLE
fix(report): use the CVSS score not calculated from severity preferentially

### DIFF
--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -514,18 +514,11 @@ func severityToV2ScoreRoughly(severity string) float64 {
 
 // FormatMaxCvssScore returns Max CVSS Score
 func (v VulnInfo) FormatMaxCvssScore() string {
-	v2Max := v.MaxCvss2Score()
-	v3Max := v.MaxCvss3Score()
-	if v2Max.Value.Score <= v3Max.Value.Score {
-		return fmt.Sprintf("%3.1f %s (%s)",
-			v3Max.Value.Score,
-			strings.ToUpper(v3Max.Value.Severity),
-			v3Max.Type)
-	}
+	max := v.MaxCvssScore()
 	return fmt.Sprintf("%3.1f %s (%s)",
-		v2Max.Value.Score,
-		strings.ToUpper(v2Max.Value.Severity),
-		v2Max.Type)
+		max.Value.Score,
+		strings.ToUpper(max.Value.Severity),
+		max.Type)
 }
 
 // Cvss2CalcURL returns CVSS v2 caluclator's URL


### PR DESCRIPTION
## What did you implement:

Vuls displays the wrong CVSS scores.
```
CVE-2018-1111      10.0 CRITICAL (redhat) 
```

The correct score is `7.5`.

Alghough `10.0` is calculated by the severity, this score is used because it is higher than the actual score.

I fixed this bug.

## How did you implement it:

Use `MaxCvssScore()` 

## How can we verify it:

Scan RedHat OS.

```
$ vuls scan
...
CVE-2018-1111   7.5 CRITICAL (redhat)
...
```

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
