### PR TITLE
feat(syslog): add all CVSS scores/vectors

### DIFF
--- a/report/syslog.go
+++ b/report/syslog.go
@@ -77,12 +77,13 @@ func (w SyslogWriter) encodeSyslog(result models.ScanResult) (messages []string)
 
 		kvPairs = append(kvPairs, fmt.Sprintf(`cve_id="%s"`, cveID))
 		for _, cvss := range vinfo.Cvss2Scores() {
-			if cvss.Type != models.NVD {
-				continue
-			}
-			kvPairs = append(kvPairs, fmt.Sprintf(`severity="%s"`, cvss.Value.Severity))
-			kvPairs = append(kvPairs, fmt.Sprintf(`cvss_score_v2="%.2f"`, cvss.Value.Score))
-			kvPairs = append(kvPairs, fmt.Sprintf(`cvss_vector_v2="%s"`, cvss.Value.Vector))
+			kvPairs = append(kvPairs, fmt.Sprintf(`cvss_score_%s_v2="%.2f"`, cvss.Type, cvss.Value.Score))
+			kvPairs = append(kvPairs, fmt.Sprintf(`cvss_vector_%s_v2="%s"`, cvss.Type, cvss.Value.Vector))
+		}
+
+		for _, cvss := range vinfo.Cvss3Scores() {
+			kvPairs = append(kvPairs, fmt.Sprintf(`cvss_score_%s_v3="%.2f"`, cvss.Type, cvss.Value.Score))
+			kvPairs = append(kvPairs, fmt.Sprintf(`cvss_vector_%s_v3="%s"`, cvss.Type, cvss.Value.Vector))
 		}
 
 		if content, ok := vinfo.CveContents[models.NVD]; ok {

--- a/report/syslog_test.go
+++ b/report/syslog_test.go
@@ -44,7 +44,7 @@ func TestSyslogWriterEncodeSyslog(t *testing.T) {
 			},
 			expectedMessages: []string{
 				`scanned_at="2018-06-13 16:10:00 +0000 UTC" server_name="teste01" os_family="ubuntu" os_release="16.04" ipv4_addr="192.168.0.1,10.0.2.15" ipv6_addr="" packages="pkg1,pkg2" cve_id="CVE-2017-0001"`,
-				`scanned_at="2018-06-13 16:10:00 +0000 UTC" server_name="teste01" os_family="ubuntu" os_release="16.04" ipv4_addr="192.168.0.1,10.0.2.15" ipv6_addr="" packages="pkg3,pkg4" cve_id="CVE-2017-0002" severity="MEDIUM" cvss_score_v2="5.00" cvss_vector_v2="AV:L/AC:L/Au:N/C:N/I:N/A:C" cwe_id="CWE-20"`,
+				`scanned_at="2018-06-13 16:10:00 +0000 UTC" server_name="teste01" os_family="ubuntu" os_release="16.04" ipv4_addr="192.168.0.1,10.0.2.15" ipv6_addr="" packages="pkg3,pkg4" cve_id="CVE-2017-0002" cvss_score_nvd_v2="5.00" cvss_vector_nvd_v2="AV:L/AC:L/Au:N/C:N/I:N/A:C" cwe_id="CWE-20"`,
 			},
 		},
 		{
@@ -71,7 +71,7 @@ func TestSyslogWriterEncodeSyslog(t *testing.T) {
 				},
 			},
 			expectedMessages: []string{
-				`scanned_at="2018-06-13 17:10:00 +0000 UTC" server_name="teste02" os_family="centos" os_release="6" ipv4_addr="" ipv6_addr="2001:0DB8::1" packages="pkg5" cve_id="CVE-2017-0003" title="RHSA-2017:0001: pkg5 security update (Important)"`,
+				`scanned_at="2018-06-13 17:10:00 +0000 UTC" server_name="teste02" os_family="centos" os_release="6" ipv4_addr="" ipv6_addr="2001:0DB8::1" packages="pkg5" cve_id="CVE-2017-0003" cvss_score_redhat_v3="5.00" cvss_vector_redhat_v3="AV:L/AC:L/Au:N/C:N/I:N/A:C" title="RHSA-2017:0001: pkg5 security update (Important)"`,
 			},
 		},
 		{


### PR DESCRIPTION
## What did you implement:

Add all CVSS scores (NVD, JVN, RedHat, etc.)

## How did you implement it:

Iterate all CveContents

## How can we verify it:

```
$ vuls report -to-syslog
```

```
$ nc -l 514
<129>2018-06-06T20:44:11+09:00 MBP vuls[77805]: scanned_at="2018-06-06 16:19:18.923111854 +0900 JST" server_name="debian8" os_family="debian" os_release="8.10" ipv4_addr="10.0.2.15,192.168.33.11" ipv6_addr="" packages="linux-image-3.16.0-4-amd64" cve_id="CVE-2018-5750" cvss_score_nvd_v2="2.10" cvss_vector_nvd_v2="AV:L/AC:L/Au:N/C:P/I:N/A:N" cwe_id="CWE-200" source_link="https://nvd.nist.gov/vuln/detail/CVE-2018-5750" summary="The acpi_smbus_hc_add function in drivers/acpi/sbshc.c in the Linux kernel through 4.14.15 allows local users to obtain sensitive address information by reading dmesg data from an SBS HC printk call."
```

## Todos:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO
