### PR TITLE
pull request to add SLES variant OS SLES_SAP support

### DIFF
--- a/scan/suse.go
+++ b/scan/suse.go
@@ -46,12 +46,14 @@ func detectSUSE(c config.ServerInfo) (itsMe bool, suse osTypeInterface) {
 					name = config.OpenSUSE
 				} else if strings.Contains(r.Stdout, `NAME="SLES"`) {
 					name = config.SUSEEnterpriseServer
+				}else if strings.Contains(r.Stdout, `NAME="SLES_SAP"`) {
+					name = config.SUSEEnterpriseServer
 				} else {
 					util.Log.Warn("Failed to parse SUSE edition: %s", r)
 					return true, suse
 				}
 
-				re := regexp.MustCompile(`VERSION_ID=\"(\d+\.\d+|\d+)\"`)
+				re := regexp.MustCompile(`VERSION_ID=\"(\d+\.\d+\.\d+\.\d+|\d+\.\d+|\d+|)\"`)
 				result := re.FindStringSubmatch(strings.TrimSpace(r.Stdout))
 				if len(result) != 2 {
 					util.Log.Warn("Failed to parse SUSE Linux version: %s", r)

--- a/scan/suse.go
+++ b/scan/suse.go
@@ -59,7 +59,13 @@ func detectSUSE(c config.ServerInfo) (itsMe bool, suse osTypeInterface) {
 					util.Log.Warn("Failed to parse SUSE Linux version: %s", r)
 					return true, suse
 				}
-				suse.setDistro(name, result[1])
+				version := ""
+				if len(result[1]) <= 4 {
+					version = result[1]
+				} else {
+					version = result[1][0:4]
+				}
+				suse.setDistro(name, version)
 				return true, suse
 			}
 		}


### PR DESCRIPTION
## What did you implement:
add fix to support SLES variant OS for SAP applicance, whose OS is SLES_SAP and verion is 12.1.0.1. 
 

Closes #671

## How did you implement it:
add one condition for SLES_SAP, plus the verion checking for it 

## How can we verify it:
modify any SLES, edit file /etc/os-release, change two lines
```
NAME="SLES_SAP"
VERSION_ID="12.1.0.1"
```

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:***  YES
***Is it a breaking change?:*** NO
