### PR TITLE
Support email one-line format

### DIFF
--- a/report/email.go
+++ b/report/email.go
@@ -40,8 +40,12 @@ func (w EMailWriter) Write(rs ...models.ScanResult) (err error) {
 	m := map[string]int{}
 	for _, r := range rs {
 		if conf.FormatOneEMail {
-			message += formatFullPlainText(r) + "\r\n\r\n"
-
+			if conf.formatOneLineSummary{
+				message += formatOneLineSummary(r) + "\r\n\r\n"
+			}
+			else{
+				message += formatFullPlainText(r) + "\r\n\r\n"
+			}
 			mm := r.ScannedCves.CountGroupBySeverity()
 			keys := []string{"High", "Medium", "Low", "Unknown"}
 			for _, k := range keys {


### PR DESCRIPTION
## What did you implement:

Closes #633 

## How did you implement it:
Added logic to consider additional flag

## How can we verify it:
run with `vuls report -to-email -format-one-line-text -format-one-email` and get short email

## Todos:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
