### PR TITLE
feat(server): support server mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.x
+  - "1.10"
 
 after_success:
   - test -n "$TRAVIS_TAG" && curl -sL https://git.io/goreleaser | bash

--- a/commands/report.go
+++ b/commands/report.go
@@ -67,6 +67,7 @@ type ReportCmd struct {
 	toLocalFile bool
 	toS3        bool
 	toAzureBlob bool
+	toHTTP      string
 
 	formatJSON        bool
 	formatXML         bool
@@ -118,6 +119,7 @@ func (*ReportCmd) Usage() string {
 		[-ignore-unscored-cves]
 		[-ignore-unfixed]
 		[-to-email]
+		[-to-http=http://vuls-server]
 		[-to-slack]
 		[-to-stride]
 		[-to-hipchat]
@@ -287,6 +289,11 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 		"to-s3",
 		false,
 		"Write report to S3 (bucket/yyyyMMdd_HHmm/servername.json/xml/txt)")
+	f.StringVar(&p.toHTTP,
+		"to-http",
+		"",
+		"http://vuls-server (default: empty)")
+
 	f.StringVar(&p.awsProfile, "aws-profile", "default", "AWS profile to use")
 	f.StringVar(&p.awsRegion, "aws-region", "us-east-1", "AWS region to use")
 	f.StringVar(&p.awsS3Bucket, "aws-s3-bucket", "", "S3 bucket name")
@@ -348,6 +355,7 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	c.Conf.ToHipChat = p.toHipChat
 	c.Conf.ToChatWork = p.toChatWork
 	c.Conf.ToEmail = p.toEMail
+	c.Conf.ToHTTP = p.toHTTP
 	c.Conf.ToSyslog = p.toSyslog
 	c.Conf.ToLocalFile = p.toLocalFile
 	c.Conf.ToS3 = p.toS3
@@ -404,6 +412,12 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 
 	if p.toSyslog {
 		reports = append(reports, report.SyslogWriter{})
+	}
+
+	if p.toHTTP != "" {
+		reports = append(reports, report.HTTPRequestWriter{
+			URL: p.toHTTP,
+		})
 	}
 
 	if p.toLocalFile {

--- a/commands/server.go
+++ b/commands/server.go
@@ -1,0 +1,308 @@
+/* Vuls - Vulnerability Scanner
+Copyright (C) 2016  Future Architect, Inc. Japan.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	// "github.com/future-architect/vuls/Server"
+
+	c "github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/models"
+	"github.com/future-architect/vuls/oval"
+	"github.com/future-architect/vuls/report"
+	"github.com/future-architect/vuls/scan"
+	"github.com/future-architect/vuls/util"
+	"github.com/google/subcommands"
+)
+
+// ServerCmd is subcommand for server
+type ServerCmd struct {
+	lang       string
+	debug      bool
+	debugSQL   bool
+	configPath string
+	logDir     string
+
+	cvssScoreOver      float64
+	ignoreUnscoredCves bool
+	ignoreUnfixed      bool
+
+	httpProxy string
+	listen    string
+
+	cveDBType string
+	cveDBPath string
+	cveDBURL  string
+
+	ovalDBType string
+	ovalDBPath string
+	ovalDBURL  string
+}
+
+// Name return subcommand name
+func (*ServerCmd) Name() string { return "server" }
+
+// Synopsis return synopsis
+func (*ServerCmd) Synopsis() string { return "Server" }
+
+// Usage return usage
+func (*ServerCmd) Usage() string {
+	return `Server:
+	Server
+		[-lang=en|ja]
+		[-config=/path/to/config.toml]
+		[-log-dir=/path/to/log]
+		[-cvedb-type=sqlite3|mysql|postgres]
+		[-cvedb-path=/path/to/cve.sqlite3]
+		[-cvedb-url=http://127.0.0.1:1323 or DB connection string]
+		[-ovaldb-type=sqlite3|mysql]
+		[-ovaldb-path=/path/to/oval.sqlite3]
+		[-ovaldb-url=http://127.0.0.1:1324 or DB connection string]
+		[-cvss-over=7]
+		[-diff]
+		[-ignore-unscored-cves]
+		[-ignore-unfixed]
+		[-to-email]
+		[-to-slack]
+		[-to-stride]
+		[-to-hipchat]
+		[-to-chatwork]
+		[-to-localfile]
+		[-to-s3]
+		[-to-azure-blob]
+		[-format-json]
+		[-format-xml]
+		[-format-one-email]
+		[-format-one-line-text]
+		[-format-short-text]
+		[-format-full-text]
+		[-http-proxy=http://192.168.0.1:8080]
+		[-debug]
+		[-debug-sql]
+		[-listen=localhost:5515]
+
+		[RFC3339 datetime format under results dir]
+`
+}
+
+// SetFlags set flag
+func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
+	f.StringVar(&p.lang, "lang", "en", "[en|ja]")
+	f.BoolVar(&p.debug, "debug", false, "debug mode")
+	f.BoolVar(&p.debugSQL, "debug-sql", false, "SQL debug mode")
+
+	wd, _ := os.Getwd()
+
+	defaultConfPath := filepath.Join(wd, "config.toml")
+	f.StringVar(&p.configPath, "config", defaultConfPath, "/path/to/toml")
+
+	defaultLogDir := util.GetDefaultLogDir()
+	f.StringVar(&p.logDir, "log-dir", defaultLogDir, "/path/to/log")
+
+	f.StringVar(
+		&p.cveDBType,
+		"cvedb-type",
+		"sqlite3",
+		"DB type for fetching CVE dictionary (sqlite3, mysql or postgres)")
+
+	defaultCveDBPath := filepath.Join(wd, "cve.sqlite3")
+	f.StringVar(
+		&p.cveDBPath,
+		"cvedb-path",
+		defaultCveDBPath,
+		"/path/to/sqlite3 (For get cve detail from cve.sqlite3)")
+
+	f.StringVar(
+		&p.cveDBURL,
+		"cvedb-url",
+		"",
+		"http://cve-dictionary.com:1323 or mysql connection string")
+
+	f.StringVar(
+		&p.ovalDBType,
+		"ovaldb-type",
+		"sqlite3",
+		"DB type for fetching OVAL dictionary (sqlite3 or mysql)")
+
+	defaultOvalDBPath := filepath.Join(wd, "oval.sqlite3")
+	f.StringVar(
+		&p.ovalDBPath,
+		"ovaldb-path",
+		defaultOvalDBPath,
+		"/path/to/sqlite3 (For get oval detail from oval.sqlite3)")
+
+	f.StringVar(
+		&p.ovalDBURL,
+		"ovaldb-url",
+		"",
+		"http://goval-dictionary.com:1324 or mysql connection string")
+
+	f.Float64Var(
+		&p.cvssScoreOver,
+		"cvss-over",
+		0,
+		"-cvss-over=6.5 means Servering CVSS Score 6.5 and over (default: 0 (means Server all))")
+
+	f.BoolVar(
+		&p.ignoreUnscoredCves,
+		"ignore-unscored-cves",
+		false,
+		"Don't Server the unscored CVEs")
+
+	f.BoolVar(
+		&p.ignoreUnfixed,
+		"ignore-unfixed",
+		false,
+		"Don't Server the unfixed CVEs")
+
+	f.StringVar(
+		&p.httpProxy,
+		"http-proxy",
+		"",
+		"http://proxy-url:port (default: empty)")
+	f.StringVar(
+		&p.listen,
+		"listen",
+		"localhost:5515",
+		"host:port (default: localhost:5515)")
+}
+
+// Execute execute
+func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+	c.Conf.Debug = p.debug
+	c.Conf.DebugSQL = p.debugSQL
+	c.Conf.LogDir = p.logDir
+	util.Log = util.NewCustomLogger(c.ServerInfo{})
+
+	c.Conf.Lang = p.lang
+	c.Conf.CveDBType = p.cveDBType
+	c.Conf.CveDBPath = p.cveDBPath
+	c.Conf.CveDBURL = p.cveDBURL
+	c.Conf.OvalDBType = p.ovalDBType
+	c.Conf.OvalDBPath = p.ovalDBPath
+	c.Conf.OvalDBURL = p.ovalDBURL
+	c.Conf.CvssScoreOver = p.cvssScoreOver
+	c.Conf.IgnoreUnscoredCves = p.ignoreUnscoredCves
+	c.Conf.IgnoreUnfixed = p.ignoreUnfixed
+	c.Conf.HTTPProxy = p.httpProxy
+
+	util.Log.Info("Validating config...")
+	if !c.Conf.ValidateOnReport() {
+		return subcommands.ExitUsageError
+	}
+	if err := report.CveClient.CheckHealth(); err != nil {
+		util.Log.Errorf("CVE HTTP server is not running. err: %s", err)
+		util.Log.Errorf("Run go-cve-dictionary as server mode before Servering or run with -cvedb-path option")
+		return subcommands.ExitFailure
+	}
+	if c.Conf.CveDBURL != "" {
+		util.Log.Infof("cve-dictionary: %s", c.Conf.CveDBURL)
+	} else {
+		if c.Conf.CveDBType == "sqlite3" {
+			util.Log.Infof("cve-dictionary: %s", c.Conf.CveDBPath)
+		}
+	}
+
+	if c.Conf.OvalDBURL != "" {
+		util.Log.Infof("oval-dictionary: %s", c.Conf.OvalDBURL)
+		err := oval.Base{}.CheckHTTPHealth()
+		if err != nil {
+			util.Log.Errorf("OVAL HTTP server is not running. err: %s", err)
+			util.Log.Errorf("Run goval-dictionary as server mode before Servering or run with -ovaldb-path option")
+			return subcommands.ExitFailure
+		}
+	} else {
+		if c.Conf.OvalDBType == "sqlite3" {
+			util.Log.Infof("oval-dictionary: %s", c.Conf.OvalDBPath)
+		}
+	}
+
+	var dbclient report.DBClient
+	var err error
+	if dbclient, err = report.NewDBClient(
+		c.Conf.CveDBType,
+		c.Conf.CveDBURL,
+		c.Conf.CveDBPath,
+		c.Conf.OvalDBType,
+		c.Conf.OvalDBURL,
+		c.Conf.OvalDBPath,
+		c.Conf.DebugSQL,
+	); err != nil {
+		util.Log.Errorf("Failed to New DB Clients: %s", err)
+		return subcommands.ExitFailure
+	}
+	defer dbclient.CloseDB()
+
+	http.Handle("/", vulsHandler{dbclient: dbclient})
+	util.Log.Infof("Listening on %s", p.listen)
+	if err := http.ListenAndServe(p.listen, nil); err != nil {
+		util.Log.Errorf("Failed to start server: %s", err)
+		return subcommands.ExitFailure
+	}
+	return subcommands.ExitSuccess
+}
+
+type vulsHandler struct {
+	dbclient report.DBClient
+}
+
+func (h vulsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var err error
+	result := models.ScanResult{ScannedCves: models.VulnInfos{}}
+
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "application/json" {
+		if err = json.NewDecoder(r.Body).Decode(&result); err != nil {
+			http.Error(w, "Invalid JSON", http.StatusBadRequest)
+			return
+		}
+	} else if contentType == "text/plain" {
+		buf := new(bytes.Buffer)
+		io.Copy(buf, r.Body)
+		if result, err = scan.ViaHTTP(r.Header, buf.String()); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	} else {
+		http.Error(w, fmt.Sprintf("Invalid Content-Type: %s", contentType), http.StatusUnsupportedMediaType)
+		return
+	}
+
+	if err := report.FillCveInfo(h.dbclient, &result, []string{}); err != nil {
+		util.Log.Error(err)
+		return
+	}
+
+	res, err := json.Marshal(result)
+	if err != nil {
+		util.Log.Error(err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(res)
+}

--- a/commands/server.go
+++ b/commands/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/future-architect/vuls/scan"
 	"github.com/future-architect/vuls/util"
 	"github.com/google/subcommands"
+	cvelog "github.com/kotakanbe/go-cve-dictionary/log"
 )
 
 // ServerCmd is subcommand for server
@@ -197,6 +198,7 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	c.Conf.DebugSQL = p.debugSQL
 	c.Conf.LogDir = p.logDir
 	util.Log = util.NewCustomLogger(c.ServerInfo{})
+	cvelog.SetLogger(p.logDir, false, c.Conf.Debug)
 
 	c.Conf.Lang = p.lang
 	c.Conf.CveDBType = p.cveDBType

--- a/config/config.go
+++ b/config/config.go
@@ -144,6 +144,7 @@ type Config struct {
 	ToLocalFile bool
 	ToS3        bool
 	ToAzureBlob bool
+	ToHTTP      string
 
 	FormatXML         bool
 	FormatJSON        bool

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ func main() {
 	subcommands.Register(&commands.HistoryCmd{}, "history")
 	subcommands.Register(&commands.ReportCmd{}, "report")
 	subcommands.Register(&commands.ConfigtestCmd{}, "configtest")
+	subcommands.Register(&commands.ServerCmd{}, "server")
 
 	var v = flag.Bool("v", false, "Show version")
 

--- a/report/http.go
+++ b/report/http.go
@@ -1,0 +1,43 @@
+/* Vuls - Vulnerability Scanner
+Copyright (C) 2016  Future Architect, Inc. Japan.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package report
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/future-architect/vuls/models"
+	"github.com/pkg/errors"
+)
+
+// HTTPWriter writes results to S3
+type HTTPWriter struct {
+	Writer http.ResponseWriter
+}
+
+// Write sends results as HTTP response
+func (w HTTPWriter) Write(rs ...models.ScanResult) (err error) {
+	res, err := json.Marshal(rs)
+	if err != nil {
+		return errors.Wrap(err, "Failed to marshal scah results")
+	}
+	w.Writer.Header().Set("Content-Type", "application/json")
+	_, err = w.Writer.Write(res)
+
+	return err
+}

--- a/scan/alpine.go
+++ b/scan/alpine.go
@@ -141,6 +141,11 @@ func (o *alpine) scanInstalledPackages() (models.Packages, error) {
 	return o.parseApkInfo(r.Stdout)
 }
 
+func (o *alpine) parseInstalledPackages(stdout string) (models.Packages, models.SrcPackages, error) {
+	installedPackages, err := o.parseApkInfo(stdout)
+	return installedPackages, nil, err
+}
+
 func (o *alpine) parseApkInfo(stdout string) (models.Packages, error) {
 	packs := models.Packages{}
 	scanner := bufio.NewScanner(strings.NewReader(stdout))

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -326,22 +326,61 @@ func (o *debian) rebootRequired() (bool, error) {
 const dpkgQuery = `dpkg-query -W -f="\${binary:Package},\${db:Status-Abbrev},\${Version},\${Source},\${source:Version}\n"`
 
 func (o *debian) scanInstalledPackages() (models.Packages, models.Packages, models.SrcPackages, error) {
-	installed, updatable, srcPacks := models.Packages{}, models.Packages{}, models.SrcPackages{}
+	updatable := models.Packages{}
 	r := o.exec(dpkgQuery, noSudo)
 	if !r.isSuccess() {
 		return nil, nil, nil, fmt.Errorf("Failed to SSH: %s", r)
 	}
 
+	installed, srcPacks, err := o.parseInstalledPackages(r.Stdout)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if o.getServerInfo().Mode.IsOffline() || o.getServerInfo().Mode.IsFast() {
+		return installed, updatable, srcPacks, nil
+	}
+
+	if err := o.aptGetUpdate(); err != nil {
+		return nil, nil, nil, err
+	}
+	updatableNames, err := o.getUpdatablePackNames()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	for _, name := range updatableNames {
+		for _, pack := range installed {
+			if pack.Name == name {
+				updatable[name] = pack
+				break
+			}
+		}
+	}
+
+	// Fill the candidate versions of upgradable packages
+	err = o.fillCandidateVersion(updatable)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to fill candidate versions. err: %s", err)
+	}
+	installed.MergeNewVersion(updatable)
+
+	return installed, updatable, srcPacks, nil
+}
+
+func (o *debian) parseInstalledPackages(stdout string) (models.Packages, models.SrcPackages, error) {
+	installed, srcPacks := models.Packages{}, models.SrcPackages{}
+
 	// e.g.
 	// curl,ii ,7.38.0-4+deb8u2,,7.38.0-4+deb8u2
 	// openssh-server,ii ,1:6.7p1-5+deb8u3,openssh,1:6.7p1-5+deb8u3
 	// tar,ii ,1.27.1-2+b1,tar (1.27.1-2),1.27.1-2
-	lines := strings.Split(r.Stdout, "\n")
+	lines := strings.Split(stdout, "\n")
+	fmt.Println(lines)
 	for _, line := range lines {
 		if trimmed := strings.TrimSpace(line); len(trimmed) != 0 {
 			name, status, version, srcName, srcVersion, err := o.parseScannedPackagesLine(trimmed)
-			if err != nil {
-				return nil, nil, nil, fmt.Errorf(
+			if err != nil || len(status) < 2 {
+				return nil, nil, fmt.Errorf(
 					"Debian: Failed to parse package line: %s", line)
 			}
 
@@ -387,35 +426,7 @@ func (o *debian) scanInstalledPackages() (models.Packages, models.Packages, mode
 	for name := range installed {
 		delete(srcPacks, name)
 	}
-
-	if o.getServerInfo().Mode.IsOffline() || o.getServerInfo().Mode.IsFast() {
-		return installed, updatable, srcPacks, nil
-	}
-
-	if err := o.aptGetUpdate(); err != nil {
-		return nil, nil, nil, err
-	}
-	updatableNames, err := o.getUpdatablePackNames()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	for _, name := range updatableNames {
-		for _, pack := range installed {
-			if pack.Name == name {
-				updatable[name] = pack
-				break
-			}
-		}
-	}
-
-	// Fill the candidate versions of upgradable packages
-	err = o.fillCandidateVersion(updatable)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("Failed to fill candidate versions. err: %s", err)
-	}
-	installed.MergeNewVersion(updatable)
-
-	return installed, updatable, srcPacks, nil
+	return installed, srcPacks, nil
 }
 
 func (o *debian) parseScannedPackagesLine(line string) (name, status, version, srcName, srcVersion string, err error) {

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -375,7 +375,6 @@ func (o *debian) parseInstalledPackages(stdout string) (models.Packages, models.
 	// openssh-server,ii ,1:6.7p1-5+deb8u3,openssh,1:6.7p1-5+deb8u3
 	// tar,ii ,1.27.1-2+b1,tar (1.27.1-2),1.27.1-2
 	lines := strings.Split(stdout, "\n")
-	fmt.Println(lines)
 	for _, line := range lines {
 		if trimmed := strings.TrimSpace(line); len(trimmed) != 0 {
 			name, status, version, srcName, srcVersion, err := o.parseScannedPackagesLine(trimmed)

--- a/scan/freebsd.go
+++ b/scan/freebsd.go
@@ -159,6 +159,10 @@ func (o *bsd) scanPackages() error {
 	return nil
 }
 
+func (o *bsd) parseInstalledPackages(string) (models.Packages, models.SrcPackages, error) {
+	return nil, nil, nil
+}
+
 func (o *bsd) rebootRequired() (bool, error) {
 	r := o.exec("freebsd-version -k", noSudo)
 	if !r.isSuccess() {

--- a/scan/pseudo.go
+++ b/scan/pseudo.go
@@ -68,6 +68,10 @@ func (o *pseudo) scanPackages() error {
 	return nil
 }
 
+func (o *pseudo) parseInstalledPackages(string) (models.Packages, models.SrcPackages, error) {
+	return nil, nil, nil
+}
+
 func (o *pseudo) detectPlatform() {
 	o.setPlatform(models.Platform{Name: "other"})
 	return

--- a/scan/redhatbase.go
+++ b/scan/redhatbase.go
@@ -305,7 +305,8 @@ func (o *redhatBase) parseInstalledPackages(stdout string) (models.Packages, mod
 			isKernel, running := isRunningKernel(pack, o.Distro.Family, o.Kernel)
 			if isKernel {
 				if o.Kernel.Release == "" {
-					// When the running kernel release is unknown, use the latest version
+					// When the running kernel release is unknown,
+					// use the latest release among the installed release
 					kernelRelease := ver.NewVersion(fmt.Sprintf("%s-%s", pack.Version, pack.Release))
 					if kernelRelease.LessThan(latestKernelRelease) {
 						continue

--- a/scan/serverapi.go
+++ b/scan/serverapi.go
@@ -32,6 +32,12 @@ import (
 	"github.com/future-architect/vuls/util"
 )
 
+var (
+	errOSFamilyHeader      = errors.New("X-Vuls-OS-Family header is required")
+	errOSReleaseHeader     = errors.New("X-Vuls-OS-Release header is required")
+	errKernelVersionHeader = errors.New("X-Vuls-Kernel-Version header is required")
+)
+
 var servers, errServers []osTypeInterface
 
 // Base Interface of redhat, debian, freebsd
@@ -439,12 +445,12 @@ func Scan(timeoutSec int) error {
 func ViaHTTP(header http.Header, body string) (models.ScanResult, error) {
 	family := header.Get("X-Vuls-OS-Family")
 	if family == "" {
-		return models.ScanResult{}, errors.New("X-Vuls-OS-Family header is required")
+		return models.ScanResult{}, errOSFamilyHeader
 	}
 
 	release := header.Get("X-Vuls-OS-Release")
 	if release == "" {
-		return models.ScanResult{}, errors.New("X-Vuls-OS-Release header is required")
+		return models.ScanResult{}, errOSReleaseHeader
 	}
 
 	kernelRelease := header.Get("X-Vuls-Kernel-Release")
@@ -454,7 +460,7 @@ func ViaHTTP(header http.Header, body string) (models.ScanResult, error) {
 
 	kernelVersion := header.Get("X-Vuls-Kernel-Version")
 	if family == config.Debian && kernelVersion == "" {
-		return models.ScanResult{}, errors.New("X-Vuls-Kernel-Version header is required")
+		return models.ScanResult{}, errKernelVersionHeader
 	}
 
 	distro := config.Distro{

--- a/scan/serverapi.go
+++ b/scan/serverapi.go
@@ -449,7 +449,7 @@ func ViaHTTP(header http.Header, body string) (models.ScanResult, error) {
 
 	kernelRelease := header.Get("X-Vuls-Kernel-Release")
 	if kernelRelease == "" {
-		return models.ScanResult{}, errors.New("X-Vuls-Kernel-Release header is required")
+		util.Log.Warn("If X-Vuls-Kernel-Release is not specified, there is a possibility of false detection")
 	}
 
 	kernelVersion := header.Get("X-Vuls-Kernel-Version")

--- a/scan/serverapi_test.go
+++ b/scan/serverapi_test.go
@@ -1,1 +1,138 @@
 package scan
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/models"
+)
+
+func TestViaHTTP(t *testing.T) {
+	r := newRHEL(config.ServerInfo{})
+	r.Distro = config.Distro{Family: config.RedHat}
+
+	var tests = []struct {
+		header         map[string]string
+		body           string
+		packages       models.Packages
+		expectedResult models.ScanResult
+		wantErr        error
+	}{
+		{
+			header: map[string]string{
+				"X-Vuls-OS-Release":     "6.9",
+				"X-Vuls-Kernel-Release": "2.6.32-695.20.3.el6.x86_64",
+			},
+			wantErr: errOSFamilyHeader,
+		},
+		{
+			header: map[string]string{
+				"X-Vuls-OS-Family":      "redhat",
+				"X-Vuls-Kernel-Release": "2.6.32-695.20.3.el6.x86_64",
+			},
+			wantErr: errOSReleaseHeader,
+		},
+		{
+			header: map[string]string{
+				"X-Vuls-OS-Family":      "debian",
+				"X-Vuls-OS-Release":     "8",
+				"X-Vuls-Kernel-Release": "2.6.32-695.20.3.el6.x86_64",
+			},
+			wantErr: errKernelVersionHeader,
+		},
+		{
+			header: map[string]string{
+				"X-Vuls-OS-Family":      "centos",
+				"X-Vuls-OS-Release":     "6.9",
+				"X-Vuls-Kernel-Release": "2.6.32-695.20.3.el6.x86_64",
+			},
+			body: `openssl	0	1.0.1e	30.el6.11 x86_64
+			Percona-Server-shared-56	1	5.6.19	rel67.0.el6 x84_64
+			kernel 0 2.6.32 696.20.1.el6 x86_64
+			kernel 0 2.6.32 696.20.3.el6 x86_64
+			kernel 0 2.6.32 695.20.3.el6 x86_64`,
+			expectedResult: models.ScanResult{
+				Family:  "centos",
+				Release: "6.9",
+				RunningKernel: models.Kernel{
+					Release: "2.6.32-695.20.3.el6.x86_64",
+				},
+				Packages: models.Packages{
+					"openssl": models.Package{
+						Name:    "openssl",
+						Version: "1.0.1e",
+						Release: "30.el6.11",
+					},
+					"Percona-Server-shared-56": models.Package{
+						Name:    "Percona-Server-shared-56",
+						Version: "1:5.6.19",
+						Release: "rel67.0.el6",
+					},
+					"kernel": models.Package{
+						Name:    "kernel",
+						Version: "2.6.32",
+						Release: "695.20.3.el6",
+					},
+				},
+			},
+		},
+		{
+			header: map[string]string{
+				"X-Vuls-OS-Family":      "debian",
+				"X-Vuls-OS-Release":     "8.10",
+				"X-Vuls-Kernel-Release": "3.16.0-4-amd64",
+				"X-Vuls-Kernel-Version": "3.16.51-2",
+			},
+			body: "",
+			expectedResult: models.ScanResult{
+				Family:  "debian",
+				Release: "8.10",
+				RunningKernel: models.Kernel{
+					Release: "3.16.0-4-amd64",
+					Version: "3.16.51-2",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		header := http.Header{}
+		for k, v := range tt.header {
+			header.Set(k, v)
+		}
+
+		result, err := ViaHTTP(header, tt.body)
+		if err != tt.wantErr {
+			t.Errorf("error: expected %s, actual: %s", tt.wantErr, err)
+		}
+
+		if result.Family != tt.expectedResult.Family {
+			t.Errorf("os family: expected %s, actual %s", tt.expectedResult.Family, result.Family)
+		}
+		if result.Release != tt.expectedResult.Release {
+			t.Errorf("os release: expected %s, actual %s", tt.expectedResult.Release, result.Release)
+		}
+		if result.RunningKernel.Release != tt.expectedResult.RunningKernel.Release {
+			t.Errorf("kernel release: expected %s, actual %s",
+				tt.expectedResult.RunningKernel.Release, result.RunningKernel.Release)
+		}
+		if result.RunningKernel.Version != tt.expectedResult.RunningKernel.Version {
+			t.Errorf("kernel version: expected %s, actual %s",
+				tt.expectedResult.RunningKernel.Version, result.RunningKernel.Version)
+		}
+
+		for name, expectedPack := range tt.expectedResult.Packages {
+			pack := result.Packages[name]
+			if pack.Name != expectedPack.Name {
+				t.Errorf("name: expected %s, actual %s", expectedPack.Name, pack.Name)
+			}
+			if pack.Version != expectedPack.Version {
+				t.Errorf("version: expected %s, actual %s", expectedPack.Version, pack.Version)
+			}
+			if pack.Release != expectedPack.Release {
+				t.Errorf("release: expected %s, actual %s", expectedPack.Release, pack.Release)
+			}
+		}
+	}
+}

--- a/scan/unknownDistro.go
+++ b/scan/unknownDistro.go
@@ -17,6 +17,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package scan
 
+import "github.com/future-architect/vuls/models"
+
 // inherit OsTypeInterface
 type unknown struct {
 	base
@@ -40,4 +42,8 @@ func (o *unknown) postScan() error {
 
 func (o *unknown) scanPackages() error {
 	return nil
+}
+
+func (o *unknown) parseInstalledPackages(string) (models.Packages, models.SrcPackages, error) {
+	return nil, nil, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,94 @@
+/* Vuls - Vulnerability Scanner
+Copyright (C) 2016  Future Architect, Inc. Japan.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	c "github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/models"
+	"github.com/future-architect/vuls/report"
+	"github.com/future-architect/vuls/scan"
+	"github.com/future-architect/vuls/util"
+)
+
+// VulsHandler is used for vuls server mode
+type VulsHandler struct {
+	DBclient report.DBClient
+}
+
+func (h VulsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var err error
+	result := models.ScanResult{ScannedCves: models.VulnInfos{}}
+
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "application/json" {
+		if err = json.NewDecoder(r.Body).Decode(&result); err != nil {
+			util.Log.Error(err)
+			http.Error(w, "Invalid JSON", http.StatusBadRequest)
+			return
+		}
+	} else if contentType == "text/plain" {
+		buf := new(bytes.Buffer)
+		io.Copy(buf, r.Body)
+		if result, err = scan.ViaHTTP(r.Header, buf.String()); err != nil {
+			util.Log.Error(err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	} else {
+		http.Error(w, fmt.Sprintf("Invalid Content-Type: %s", contentType), http.StatusUnsupportedMediaType)
+		return
+	}
+
+	if err := report.FillCveInfo(h.DBclient, &result, []string{}); err != nil {
+		util.Log.Error(err)
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	// report
+	reports := []report.ResultWriter{
+		report.HTTPWriter{Writer: w},
+	}
+	if c.Conf.ToLocalFile {
+		scannedAt := time.Now().Truncate(1 * time.Hour)
+		dir, err := scan.EnsureResultDir(scannedAt)
+		if err != nil {
+			util.Log.Errorf("Failed to ensure the result directory: %s", err)
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+
+		reports = append(reports, report.LocalFileWriter{
+			CurrentDir: dir,
+		})
+	}
+
+	for _, w := range reports {
+		if err := w.Write(result); err != nil {
+			util.Log.Errorf("Failed to report: %s", err)
+			return
+		}
+	}
+}


### PR DESCRIPTION
## What did you implement:

Support server mode

## How did you implement it:

Add server subcommand.

Support `application/json` and `text/plain`.
In the case of `text/plain`, `X-Vuls-OS-Family`, `X-Vuls-OS-Release` and `X-Vuls-Kernel-Release` headers are required.

Support OS: RHEL/CentOS/Debian/CentOS

## How can we verify it:
### Prepare Vuls server

```
$ vuls server -listen 0.0.0.0:5515
[Jul  5 22:32:46]  INFO [localhost] Validating config...
...
[Jul  5 22:32:46]  INFO [localhost] Listening on 0.0.0.0:5515
```


### CentOS

#### text/plain
```
$ ssh vuls@centos6
$ curl -X POST -H "Content-Type: text/plain" -H "X-Vuls-OS-Family: `awk '{print tolower($1)}' /etc/redhat-release`" -H "X-Vuls-OS-Release: `awk '{print $3}' /etc/r
edhat-release`" -H "X-Vuls-Kernel-Release: `uname -r`" --data-binary "`rpm -qa --queryformat "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH}\n"`" http://192.168.33.1:5515/
```

#### application/json
```
$ cat centos6.json
{
  "Family": "centos",
  "Release": "6.9",
  "RunningKernel": {
    "Release": "2.6.32-696.6.3.el6.x86_64",
    "Version": "",
    "RebootRequired": false
  },
  "Packages": {
    "ntp": {
      "Name": "ntp",
      "Version": "4.2.6p5"
    }
  }
}
$ curl -X POST -H "Content-Type: application/json" -d @centos.json http://localhost:5515
```

### Debian
#### text/plain
When Debian, `X-Vuls-Kernel-Release` is also required.

```
$ ssh vuls@debian8
$ curl -X POST -H "Content-Type: text/plain" -H "X-Vuls-OS-Family: debian" -H "X-Vuls-OS-Release: 8.10" -H "X-Vuls-Kernel-Release: `uname -r`" -H "X-Vuls-Kernel-Version: `uname -a | awk '{print $7}'`" --data-binary "$(dpkg-query -W -f="\${binary:Package},\${db:Status-Abbrev},\${Version},\${Source},\${source:Version}\n")" http://192.168.33.1:5515/
```

#### application/json
```
$ cat debian8.json
{
  "Family": "debian",
  "Release": "8.10",
  "RunningKernel": {
    "Release": "3.16.0-4-amd64",
    "Version": "3.16.51-2",
    "RebootRequired": false
  },
  "Packages": {
    "bind9-host": {
      "Name": "bind9-host",
      "Version": "1:9.9.5.dfsg-9+deb8u15"
    }
  },
  "SrcPackages": {
    "bind9": {
      "Name": "bind9",
      "Version": "1:9.9.5.dfsg-9+deb8u15",
      "BinaryNames": [
        "bind9-host"
      ]
    }
  }
}
$ curl -X POST -H "Content-Type: application/json" -d @debian8.json http://localhost:5515
```

### Ubuntu
#### text/plain

```
$ curl -X POST -H "Content-Type: text/plain" -H "X-Vuls-OS-Family: ubuntu" -H "X-Vuls-OS-Release: 16.04" -H "X-Vuls-Kernel-Release: `uname -r`" --data-binary "$(dpkg-query -W -f="\${binary:Package},\${db:Status-Abbrev},\${Version},\${Source},\${source:Version}\n")" http://192.168.33.1:5515/
```

#### application/json
Almost the same as Debian.  
No need for `RunningKernel.Version`.

```
$ cat ubuntu1604.json
{
  "Family": "ubuntu",
  "Release": "16.04",
  "RunningKernel": {
    "Release": "3.16.0-4-amd64",
    "RebootRequired": false
  },
  "Packages": {
    "bind9-host": {
      "Name": "bind9-host",
      "Version": "1:9.9.5.dfsg-9+deb8u15"
    }
  },
  "SrcPackages": {
    "bind9": {
      "Name": "bind9",
      "Version": "1:9.9.5.dfsg-9+deb8u15",
      "BinaryNames": [
        "bind9-host"
      ]
    }
  }
}
$ curl -X POST -H "Content-Type: application/json" http://localhost:5515 -d @ubuntu1604.json
```

## Todos:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** NO  
***Is it a breaking change?:*** NO
