### PR TITLE
Lint

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,7 +15,7 @@
 	clean
 
 SRCS = $(shell git ls-files '*.go')
-PKGS = ./. ./cache ./commands ./config ./models ./oval ./report ./scan ./util 
+PKGS = $(shell go list ./...)
 VERSION := $(shell git describe --tags --abbrev=0)
 REVISION := $(shell git rev-parse --short HEAD)
 LDFLAGS := -X 'main.version=$(VERSION)' \
@@ -40,11 +40,11 @@ install: main.go dep pretest
 
 lint:
 	@ go get -v github.com/golang/lint/golint
-	$(foreach file,$(SRCS),golint $(file) || exit;)
+	golint $(PKGS)
 
 vet:
 	#  @-go get -v golang.org/x/tools/cmd/vet
-	echo $(PKGS) | xargs go vet || exit;
+	go vet ./... || exit;
 
 fmt:
 	gofmt -s -w $(SRCS)
@@ -58,7 +58,7 @@ test: pretest
 	go install
 	echo $(PKGS) | xargs go test -cover -v || exit;
 
-unused :
+unused:
 	$(foreach pkg,$(PKGS),unused $(pkg);)
 
 cov:

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -94,8 +94,8 @@ var kernelRelatedPackNames = map[string]bool{
 	"kernel-tools":            true,
 	"kernel-tools-libs":       true,
 	"kernel-tools-libs-devel": true,
-	"perf":        true,
-	"python-perf": true,
+	"perf":                    true,
+	"python-perf":             true,
 }
 
 func (o RedHatBase) update(r *models.ScanResult, defPacks defPacks) {
@@ -114,7 +114,7 @@ func (o RedHatBase) update(r *models.ScanResult, defPacks defPacks) {
 			cveContents := vinfo.CveContents
 			if v, ok := vinfo.CveContents[ctype]; ok {
 				if v.LastModified.After(ovalContent.LastModified) {
-					util.Log.Debugf("%s, OvalID: %s ignroed: ",
+					util.Log.Debugf("%s, OvalID: %d ignroed: ",
 						cve.CveID, defPacks.def.ID)
 					continue
 				} else {

--- a/oval/util.go
+++ b/oval/util.go
@@ -68,7 +68,7 @@ func (e *ovalResult) upsert(def ovalmodels.Definition, packName string, notFixed
 		}
 	}
 	e.entries = append(e.entries, defPacks{
-		def: def,
+		def:                       def,
 		actuallyAffectedPackNames: map[string]bool{packName: notFixedYet},
 	})
 

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -760,7 +760,7 @@ func (o *debian) getCveIDsFromChangelog(
 
 	// Only logging the error.
 	o.log.Warnf("Failed to find the version in changelog: %s-%s", name, ver)
-	o.log.Debugf("Changelog of : %s-%s", name, ver, changelog)
+	o.log.Debugf("Changelog of : %s-%s-%s", name, ver, changelog)
 
 	// If the version is not in changelog, return entire changelog to put into cache
 	pack := o.Packages[name]

--- a/scan/freebsd.go
+++ b/scan/freebsd.go
@@ -279,7 +279,7 @@ func (o *bsd) parsePkgVersion(stdout string) models.Packages {
 				NewVersion: candidate,
 			}
 		case ">":
-			o.log.Warn("The installed version of the %s is newer than the current version. *This situation can arise with an out of date index file, or when testing new ports.*", name)
+			o.log.Warnf("The installed version of the %s is newer than the current version. *This situation can arise with an out of date index file, or when testing new ports.*", name)
 			packs[name] = models.Package{
 				Name:    name,
 				Version: ver,

--- a/scan/redhat.go
+++ b/scan/redhat.go
@@ -57,7 +57,7 @@ func detectRedhat(c config.ServerInfo) (itsMe bool, red osTypeInterface) {
 
 	if r := exec(c, "ls /etc/fedora-release", noSudo); r.isSuccess() {
 		red.setDistro(config.Fedora, "unknown")
-		util.Log.Warn("Fedora not tested yet: %s", r)
+		util.Log.Warnf("Fedora not tested yet: %s", r)
 		return true, red
 	}
 
@@ -68,7 +68,7 @@ func detectRedhat(c config.ServerInfo) (itsMe bool, red osTypeInterface) {
 			re := regexp.MustCompile(`(.*) release (\d[\d\.]*)`)
 			result := re.FindStringSubmatch(strings.TrimSpace(r.Stdout))
 			if len(result) != 3 {
-				util.Log.Warn("Failed to parse Oracle Linux version: %s", r)
+				util.Log.Warnf("Failed to parse Oracle Linux version: %s", r)
 				return true, red
 			}
 
@@ -85,7 +85,7 @@ func detectRedhat(c config.ServerInfo) (itsMe bool, red osTypeInterface) {
 			re := regexp.MustCompile(`(.*) release (\d[\d\.]*)`)
 			result := re.FindStringSubmatch(strings.TrimSpace(r.Stdout))
 			if len(result) != 3 {
-				util.Log.Warn("Failed to parse CentOS version: %s", r)
+				util.Log.Warnf("Failed to parse CentOS version: %s", r)
 				return true, red
 			}
 
@@ -95,7 +95,7 @@ func detectRedhat(c config.ServerInfo) (itsMe bool, red osTypeInterface) {
 				red.setDistro(config.CentOS, release)
 				return true, red
 			default:
-				util.Log.Warn("Failed to parse CentOS: %s", r)
+				util.Log.Warnf("Failed to parse CentOS: %s", r)
 			}
 		}
 	}
@@ -109,7 +109,7 @@ func detectRedhat(c config.ServerInfo) (itsMe bool, red osTypeInterface) {
 			re := regexp.MustCompile(`(.*) release (\d[\d\.]*)`)
 			result := re.FindStringSubmatch(strings.TrimSpace(r.Stdout))
 			if len(result) != 3 {
-				util.Log.Warn("Failed to parse RedHat/CentOS version: %s", r)
+				util.Log.Warnf("Failed to parse RedHat/CentOS version: %s", r)
 				return true, red
 			}
 

--- a/scan/suse.go
+++ b/scan/suse.go
@@ -67,7 +67,7 @@ func detectSUSE(c config.ServerInfo) (bool, osTypeInterface) {
 						return true, s
 					}
 				}
-				util.Log.Warn("Failed to parse SUSE Linux version: %s", r)
+				util.Log.Warnf("Failed to parse SUSE Linux version: %s", r)
 				return true, s
 			}
 		}
@@ -85,14 +85,14 @@ func (o *suse) parseOSRelease(content string) (name string, ver string) {
 	} else if strings.Contains(content, `NAME="SLES_SAP"`) {
 		name = config.SUSEEnterpriseServer
 	} else {
-		util.Log.Warn("Failed to parse SUSE edition: %s", content)
+		util.Log.Warnf("Failed to parse SUSE edition: %s", content)
 		return "unknown", "unknown"
 	}
 
 	re := regexp.MustCompile(`VERSION_ID=\"(.+)\"`)
 	result := re.FindStringSubmatch(strings.TrimSpace(content))
 	if len(result) != 2 {
-		util.Log.Warn("Failed to parse SUSE Linux version: %s", content)
+		util.Log.Warnf("Failed to parse SUSE Linux version: %s", content)
 		return "unknown", "unknown"
 	}
 	return name, result[1]

--- a/scan/utils.go
+++ b/scan/utils.go
@@ -46,7 +46,7 @@ func isRunningKernel(pack models.Package, family string, kernel models.Kernel) (
 		return false, false
 
 	default:
-		util.Log.Warnf("Reboot required is not implemented yet: %s, %s", family, kernel)
+		util.Log.Warnf("Reboot required is not implemented yet: %s, %v", family, kernel)
 	}
 	return false, false
 }

--- a/util/util.go
+++ b/util/util.go
@@ -34,7 +34,7 @@ func GenWorkers(num int) chan<- func() {
 			defer func() {
 				if p := recover(); p != nil {
 					log := NewCustomLogger(config.ServerInfo{})
-					log.Debugf("Panic: %s")
+					log.Debugf("Panic: %s", p)
 				}
 			}()
 			for f := range tasks {


### PR DESCRIPTION
# What did you implement:

The `go` command of Go1.9 or later excludes vendored packages from `...` wildcard.

ref. https://go-review.googlesource.com/c/go/+/38745

So, I adjust GNUmakefile by using `...` wildcard and found some linter warnings, so
fixed them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below