### PR TITLE
fix(config): a DB URL error 'does not validate as url' #705

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -734,7 +734,7 @@ type GoCveDictConf struct {
 	Type string
 
 	// http://cve-dictionary.com:1323 or DB connection string
-	URL string `valid:"url" json:"-"`
+	URL string `json:"-"`
 
 	// /path/to/cve.sqlite3
 	SQLite3Path string `json:"-"`
@@ -788,7 +788,7 @@ type GovalDictConf struct {
 	Type string
 
 	// http://goval-dictionary.com:1324 or DB connection string
-	URL string `valid:"url" json:"-"`
+	URL string `json:"-"`
 
 	// /path/to/oval.sqlite3
 	SQLite3Path string `json:"-"`
@@ -841,7 +841,7 @@ type GostConf struct {
 	Type string
 
 	// http://gost-dictionary.com:1324 or DB connection string
-	URL string `valid:"url" json:"-"`
+	URL string `json:"-"`
 
 	// /path/to/gost.sqlite3
 	SQLite3Path string `json:"-"`


### PR DESCRIPTION
# What did you implement:

Remove URL validation of go-cve-dict, oval-dict, gost DB URL in config.toml

Fixes #705

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  
