### PR TITLE
commands: simplify `s[:]` to s

### DIFF
--- a/commands/util.go
+++ b/commands/util.go
@@ -34,7 +34,7 @@ func getPasswd(prompt string) (string, error) {
 			return "", fmt.Errorf("Failed to read password")
 		}
 		if 0 < len(pass) {
-			return string(pass[:]), nil
+			return string(pass), nil
 		}
 	}
 


### PR DESCRIPTION
If s is a slice, then `s[:]` is identical to just `s`.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>
