### PR TITLE
report: simplify `x = x <op> y` to `x <op>= y`

### DIFF
--- a/report/azureblob.go
+++ b/report/azureblob.go
@@ -136,7 +136,7 @@ func createBlockBlob(cli storage.BlobStorageClient, k string, b []byte) error {
 		if b, err = gz(b); err != nil {
 			return err
 		}
-		k = k + ".gz"
+		k += ".gz"
 	}
 
 	ref := cli.GetContainerReference(c.Conf.Azure.ContainerName)

--- a/report/localfile.go
+++ b/report/localfile.go
@@ -129,7 +129,7 @@ func writeFile(path string, data []byte, perm os.FileMode) error {
 		if data, err = gz(data); err != nil {
 			return err
 		}
-		path = path + ".gz"
+		path += ".gz"
 	}
 	return ioutil.WriteFile(path, []byte(data), perm)
 }

--- a/report/s3.go
+++ b/report/s3.go
@@ -144,7 +144,7 @@ func putObject(svc *s3.S3, k string, b []byte) error {
 		if b, err = gz(b); err != nil {
 			return err
 		}
-		k = k + ".gz"
+		k += ".gz"
 	}
 
 	putObjectInput := &s3.PutObjectInput{


### PR DESCRIPTION
Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>


