### PR TITLE
fix(gost): a bug of parseCwe

### DIFF
--- a/gost/redhat.go
+++ b/gost/redhat.go
@@ -208,18 +208,23 @@ func (red RedHat) mergePackageStates(v models.VulnInfo, ps []gostmodels.RedhatPa
 	return
 }
 
-// ConvertToModel converts gost model to vuls model
-func (red RedHat) ConvertToModel(cve *gostmodels.RedhatCVE) *models.CveContent {
-	cwes := []string{}
-	if cve.Cwe != "" {
-		s := strings.TrimPrefix(cve.Cwe, "(")
-		s = strings.TrimSuffix(s, ")")
-		if strings.Contains(cve.Cwe, "|") {
-			cwes = strings.Split(cve.Cwe, "|")
-		} else {
-			cwes = strings.Split(s, "->")
+func (red RedHat) parseCwe(str string) (cwes []string) {
+	if str != "" {
+		s := strings.Replace(str, "(", "|", -1)
+		s = strings.Replace(s, ")", "|", -1)
+		s = strings.Replace(s, "->", "|", -1)
+		for _, s := range strings.Split(s, "|") {
+			if s != "" {
+				cwes = append(cwes, s)
+			}
 		}
 	}
+	return
+}
+
+// ConvertToModel converts gost model to vuls model
+func (red RedHat) ConvertToModel(cve *gostmodels.RedhatCVE) *models.CveContent {
+	cwes := red.parseCwe(cve.Cwe)
 
 	details := []string{}
 	for _, detail := range cve.Details {

--- a/gost/redhat_test.go
+++ b/gost/redhat_test.go
@@ -1,0 +1,37 @@
+package gost
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestParseCwe(t *testing.T) {
+	var tests = []struct {
+		in  string
+		out []string
+	}{
+		{
+			in:  "CWE-665->(CWE-200|CWE-89)",
+			out: []string{"CWE-665", "CWE-200", "CWE-89"},
+		},
+		{
+			in:  "CWE-841->CWE-770->CWE-454",
+			out: []string{"CWE-841", "CWE-770", "CWE-454"},
+		},
+		{
+			in:  "(CWE-122|CWE-125)",
+			out: []string{"CWE-122", "CWE-125"},
+		},
+	}
+
+	r := RedHat{}
+	for i, tt := range tests {
+		out := r.parseCwe(tt.in)
+		sort.Strings(out)
+		sort.Strings(tt.out)
+		if !reflect.DeepEqual(tt.out, out) {
+			t.Errorf("[%d]expected: %s, actual: %s", i, tt.out, out)
+		}
+	}
+}


### PR DESCRIPTION
# What did you implement:

When CWE in gost is `CWE-665->(CWE-200|CWE-89)`
Vuls shows `cweID: "CWE-665->(CWE-200"` , `cweID: "CWE-89)"`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:***YES  
