### PR TITLE
fix(report): fix cvedb-url, add -cvedb-type=http

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,18 +10,18 @@
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:1679579905ae882f436a532ddec428bb91fecbcd93d683bf12b8689816b093f6"
+  digest = "1:386f6cd33248f04fc465df500e66d21892f0712e26c60d25b7ce3c678abaf2c0"
   name = "github.com/Azure/azure-sdk-for-go"
   packages = [
     "storage",
     "version",
   ]
   pruneopts = "UT"
-  revision = "9419692eb7ad7f923cca690cc5a6b2c6d22405e1"
-  version = "v22.1.1"
+  revision = "9699bdefa481d47c5c7638a1cc05d87ce53601fd"
+  version = "v22.2.2"
 
 [[projects]]
-  digest = "1:f3ce3f0a78d88ee5dd7dc024d4d3595538ac4d0ce5cbb6be19fcb15f4b59010a"
+  digest = "1:6b4743cf9d77747c1a772673333f8d6dfbfa93ffac858faae1333ffb7f0dfc4b"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
@@ -33,8 +33,8 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "4e5fffdf007df29ed0862f9e01fafabf4396e851"
-  version = "v11.2.6"
+  revision = "528b76fd0ebec0682f3e3da7c808cd472b999615"
+  version = "v11.2.7"
 
 [[projects]]
   digest = "1:9f3b30d9f8e0d7040f729b82dcbc8f0dead820a133b3147ce355fc451f32d761"
@@ -61,7 +61,7 @@
   version = "v9"
 
 [[projects]]
-  digest = "1:ad009afc10b82f2de510d000fad8472d13f2888716dc941c942f5cbb3a28cd57"
+  digest = "1:176bfeb168867283ee97848f5e2cf9a0b6c9f395ea8c6d547907dfba845e0249"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -99,8 +99,8 @@
     "service/sts",
   ]
   pruneopts = "UT"
-  revision = "cf00ea20983ce38df17ab0a0814463ab8838459f"
-  version = "v1.15.73"
+  revision = "64fc3d5c40fffc817c1cc1c1d89a6e482bf1120d"
+  version = "v1.15.77"
 
 [[projects]]
   digest = "1:0f98f59e9a2f4070d66f0c9c39561f68fcd1dc837b22a852d28d0003aebd1b1e"
@@ -181,12 +181,12 @@
   version = "v6.14.2"
 
 [[projects]]
-  digest = "1:adea5a94903eb4384abef30f3d878dc9ff6b6b5b0722da25b82e5169216dfb61"
+  digest = "1:ec6f9bf5e274c833c911923c9193867f3f18788c461f76f05f62bb1510e0ae65"
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d523deb1b23d913de5bdada721a6071e71283618"
-  version = "v1.4.0"
+  revision = "72cd26f257d44c1114970e19afddcd812016007e"
+  version = "v1.4.1"
 
 [[projects]]
   digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
@@ -393,7 +393,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:336333e5514fc6178cdb4245f64cc34f9c0212daa523a5267e357a7535d5470f"
+  digest = "1:cdd699c1d929e96f96846789e99d5f019c15f714102a1bb108575d36789d577b"
   name = "github.com/kotakanbe/go-cve-dictionary"
   packages = [
     "config",
@@ -402,7 +402,7 @@
     "models",
   ]
   pruneopts = "UT"
-  revision = "abc105b42ac1bd9f588884600ced6e2f3fcce0d7"
+  revision = "9549cd396c408c11f7d5cb6e4286dc8e7d9c6419"
 
 [[projects]]
   digest = "1:54d3c90db1164399906830313a6fce7770917d7e4a12da8f2d8693d18ff5ef27"
@@ -730,7 +730,7 @@
     "ssh/terminal",
   ]
   pruneopts = "UT"
-  revision = "e4dc69e5b2fd71dcaf8bd5d054eb936deb78d1fa"
+  revision = "3d3f9f413869b949e48070b5bc593aa22cc2b8f2"
 
 [[projects]]
   branch = "master"
@@ -747,7 +747,7 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "03003ca0c849e57b6ea29a4bab8d3cb6e4d568fe"
+  revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
 
 [[projects]]
   branch = "master"
@@ -797,7 +797,7 @@
   name = "google.golang.org/api"
   packages = ["support/bundler"]
   pruneopts = "UT"
-  revision = "cfbc873f6b93790282bed8e31e7f7df417caee1b"
+  revision = "83a9d304b1e613fc253e1e2710778642fe81af53"
 
 [[projects]]
   digest = "1:c25289f43ac4a68d88b02245742347c94f1e108c534dda442188015ff80669b3"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,6 +32,10 @@
   name = "github.com/kotakanbe/go-cve-dictionary"
   branch = "master"
 
+[[constraint]]
+  name = "github.com/mozqnet/go-exploitdb"
+  branch = "master"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/commands/report.go
+++ b/commands/report.go
@@ -97,7 +97,7 @@ func (*ReportCmd) Usage() string {
 		[-gostdb-url=http://127.0.0.1:1325 or DB connection string]
 		[-exploitdb-type=sqlite3|mysql|redis|http]
 		[-exploitdb-sqlite3-path=/path/to/exploitdb.sqlite3]
-		[-exploitdb-url=http://127.0.0.1:1325 or DB connection string]
+		[-exploitdb-url=http://127.0.0.1:1326 or DB connection string]
 		[-http="http://vuls-report-server"]
 
 		[RFC3339 datetime format under results dir]

--- a/commands/tui.go
+++ b/commands/tui.go
@@ -75,7 +75,7 @@ func (*TuiCmd) Usage() string {
 		[-gostdb-url=http://127.0.0.1:1325 or DB connection string]
 		[-exploitdb-type=sqlite3|mysql|redis|http]
 		[-exploitdb-sqlite3-path=/path/to/exploitdb.sqlite3]
-		[-exploitdb-url=http://127.0.0.1:1325 or DB connection string]
+		[-exploitdb-url=http://127.0.0.1:1326 or DB connection string]
 
 `
 }

--- a/commands/tui.go
+++ b/commands/tui.go
@@ -64,15 +64,18 @@ func (*TuiCmd) Usage() string {
 		[-debug]
 		[-debug-sql]
 		[-pipe]
-		[-cvedb-type=sqlite3|mysql|postgres|redis]
-		[-cvedb-path=/path/to/cve.sqlite3]
+		[-cvedb-type=sqlite3|mysql|postgres|redis|http]
+		[-cvedb-sqlite3-path=/path/to/cve.sqlite3]
 		[-cvedb-url=http://127.0.0.1:1323 or DB connection string]
-		[-ovaldb-type=sqlite3|mysql|redis]
-		[-ovaldb-path=/path/to/oval.sqlite3]
+		[-ovaldb-type=sqlite3|mysql|redis|http]
+		[-ovaldb-sqlite3-path=/path/to/oval.sqlite3]
 		[-ovaldb-url=http://127.0.0.1:1324 or DB connection string]
-		[-gostdb-type=sqlite3|mysql|redis]
-		[-gostdb-path=/path/to/gost.sqlite3]
+		[-gostdb-type=sqlite3|mysql|redis|http]
+		[-gostdb-sqlite3-path=/path/to/gost.sqlite3]
 		[-gostdb-url=http://127.0.0.1:1325 or DB connection string]
+		[-exploitdb-type=sqlite3|mysql|redis|http]
+		[-exploitdb-sqlite3-path=/path/to/exploitdb.sqlite3]
+		[-exploitdb-url=http://127.0.0.1:1325 or DB connection string]
 
 `
 }
@@ -130,7 +133,7 @@ func (p *TuiCmd) SetFlags(f *flag.FlagSet) {
 		"http://gost.com:1325 or DB connection string")
 
 	f.StringVar(&p.exploitConf.Type, "exploitdb-type", "",
-		"DB type of exploit (sqlite3, mysql, postgres or redis)")
+		"DB type of exploit (sqlite3, mysql, postgres, redis or http)")
 	f.StringVar(&p.exploitConf.SQLite3Path, "exploitdb-sqlite3-path", "", "/path/to/sqlite3")
 	f.StringVar(&p.exploitConf.URL, "exploitdb-url", "",
 		"http://exploit.com:1326 or DB connection string")
@@ -179,30 +182,25 @@ func (p *TuiCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 	}
 	util.Log.Infof("Loaded: %s", dir)
 
-	if err := report.CveClient.CheckHealth(); err != nil {
-		util.Log.Errorf("CVE HTTP server is not running. err: %s", err)
-		util.Log.Errorf("Run go-cve-dictionary as server mode before reporting or run with -cvedb-sqlite3-path option instead of -cvedb-url")
-		return subcommands.ExitFailure
+	util.Log.Info("Validating db config...")
+	if !c.Conf.ValidateOnReportDB() {
+		return subcommands.ExitUsageError
 	}
+
 	if c.Conf.CveDict.URL != "" {
-		util.Log.Infof("cve-dictionary: %s", c.Conf.CveDict.URL)
-	} else {
-		if c.Conf.CveDict.Type == "sqlite3" {
-			util.Log.Infof("cve-dictionary: %s", c.Conf.CveDict.SQLite3Path)
+		if err := report.CveClient.CheckHealth(); err != nil {
+			util.Log.Errorf("CVE HTTP server is not running. err: %s", err)
+			util.Log.Errorf("Run go-cve-dictionary as server mode before reporting or run with `-cvedb-type=sqlite3 -cvedb-sqlite3-path` option instead of -cvedb-url")
+			return subcommands.ExitFailure
 		}
 	}
 
 	if c.Conf.OvalDict.URL != "" {
-		util.Log.Infof("oval-dictionary: %s", c.Conf.OvalDict.URL)
 		err := oval.Base{}.CheckHTTPHealth()
 		if err != nil {
 			util.Log.Errorf("OVAL HTTP server is not running. err: %s", err)
-			util.Log.Errorf("Run goval-dictionary as server mode before reporting or run with -ovaldb-sqlite3-path option instead of -ovaldb-url")
+			util.Log.Errorf("Run goval-dictionary as server mode before reporting or run with `-ovaldb-type=sqlite3 -ovaldb-sqlite3-path` option instead of -ovaldb-url")
 			return subcommands.ExitFailure
-		}
-	} else {
-		if c.Conf.OvalDict.Type == "sqlite3" {
-			util.Log.Infof("oval-dictionary: %s", c.Conf.OvalDict.SQLite3Path)
 		}
 	}
 
@@ -211,26 +209,17 @@ func (p *TuiCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 		err := gost.Base{}.CheckHTTPHealth()
 		if err != nil {
 			util.Log.Errorf("gost HTTP server is not running. err: %s", err)
-			util.Log.Errorf("Run gost as server mode before reporting or run with -gostdb-sqlite3-path option instead of -gostdb-url")
+			util.Log.Errorf("Run gost as server mode before reporting or run with `-gostdb-type=sqlite3 -gostdb-sqlite3-path` option instead of -gostdb-url")
 			return subcommands.ExitFailure
-		}
-	} else {
-		if c.Conf.Gost.Type == "sqlite3" {
-			util.Log.Infof("gost: %s", c.Conf.Gost.SQLite3Path)
 		}
 	}
 
 	if c.Conf.Exploit.URL != "" {
-		util.Log.Infof("exploit: %s", c.Conf.Exploit.URL)
 		err := exploit.CheckHTTPHealth()
 		if err != nil {
 			util.Log.Errorf("exploit HTTP server is not running. err: %s", err)
-			util.Log.Errorf("Run exploit as server mode before reporting or run with -exploitdb-sqlite3-path option instead of -exploitdb-url")
+			util.Log.Errorf("Run go-exploitdb as server mode before reporting")
 			return subcommands.ExitFailure
-		}
-	} else {
-		if c.Conf.Exploit.Type == "sqlite3" {
-			util.Log.Infof("exploit: %s", c.Conf.Exploit.SQLite3Path)
 		}
 	}
 	dbclient, locked, err := report.NewDBClient(report.DBClientConf{

--- a/commands/tui.go
+++ b/commands/tui.go
@@ -37,7 +37,7 @@ import (
 // TuiCmd is Subcommand of host discovery mode
 type TuiCmd struct {
 	configPath  string
-	cvelDict    c.GoCveDictConf
+	cveDict     c.GoCveDictConf
 	ovalDict    c.GovalDictConf
 	gostConf    c.GostConf
 	exploitConf c.ExploitConf
@@ -114,10 +114,10 @@ func (p *TuiCmd) SetFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&c.Conf.Pipe, "pipe", false, "Use stdin via PIPE")
 
-	f.StringVar(&p.cvelDict.Type, "cvedb-type", "sqlite3",
+	f.StringVar(&p.cveDict.Type, "cvedb-type", "",
 		"DB type of go-cve-dictionary (sqlite3, mysql, postgres or redis)")
-	f.StringVar(&p.cvelDict.SQLite3Path, "cvedb-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.cvelDict.URL, "cvedb-url", "",
+	f.StringVar(&p.cveDict.SQLite3Path, "cvedb-path", "", "/path/to/sqlite3")
+	f.StringVar(&p.cveDict.URL, "cvedb-url", "",
 		"http://go-cve-dictionary.com:1323 or DB connection string")
 
 	f.StringVar(&p.ovalDict.Type, "ovaldb-type", "",
@@ -153,7 +153,7 @@ func (p *TuiCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 		return subcommands.ExitUsageError
 	}
 
-	c.Conf.CveDict.Overwrite(p.cvelDict)
+	c.Conf.CveDict.Overwrite(p.cveDict)
 	c.Conf.OvalDict.Overwrite(p.ovalDict)
 	c.Conf.Gost.Overwrite(p.gostConf)
 	c.Conf.Exploit.Overwrite(p.exploitConf)

--- a/exploit/exploit.go
+++ b/exploit/exploit.go
@@ -30,7 +30,7 @@ import (
 
 // FillWithExploit fills exploit information that has in Exploit
 func FillWithExploit(driver db.DB, r *models.ScanResult) (nExploitCve int, err error) {
-	if isFetchViaHTTP() {
+	if cnf.Conf.Exploit.IsFetchViaHTTP() {
 		// TODO
 		return 0, fmt.Errorf("We are not yet supporting data acquisition in exploitdb server mode")
 	}
@@ -84,7 +84,7 @@ func ConvertToModel(es []*exploitmodels.Exploit) (exploits []models.Exploit) {
 
 // CheckHTTPHealth do health check
 func CheckHTTPHealth() error {
-	if !isFetchViaHTTP() {
+	if !cnf.Conf.Exploit.IsFetchViaHTTP() {
 		return nil
 	}
 
@@ -111,9 +111,4 @@ func CheckIfExploitFetched(driver db.DB, osFamily string) (fetched bool, err err
 func CheckIfExploitFresh(driver db.DB, osFamily string) (ok bool, err error) {
 	//TODO
 	return true, nil
-}
-
-func isFetchViaHTTP() bool {
-	// Default value of OvalDBType is sqlite3
-	return cnf.Conf.Exploit.URL != "" && cnf.Conf.Exploit.Type == "sqlite3"
 }

--- a/exploit/exploit.go
+++ b/exploit/exploit.go
@@ -90,11 +90,10 @@ func convertToModels(es []*exploitmodels.Exploit) (exploits []models.Exploit) {
 			}
 		}
 		exploit := models.Exploit{
-			ExploitType: e.ExploitType,
-			ID:          e.ExploitUniqueID,
-			URL:         e.URL,
-			Description: e.Description,
-
+			ExploitType:  e.ExploitType,
+			ID:           e.ExploitUniqueID,
+			URL:          e.URL,
+			Description:  e.Description,
 			DocumentURL:  documentURL,
 			ShellCodeURL: shellURL,
 			PaperURL:     paperURL,

--- a/exploit/exploit.go
+++ b/exploit/exploit.go
@@ -18,11 +18,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package exploit
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
 	cnf "github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/models"
+	"github.com/future-architect/vuls/util"
 	"github.com/mozqnet/go-exploitdb/db"
 	exploitmodels "github.com/mozqnet/go-exploitdb/models"
 	"github.com/parnurzeal/gorequest"
@@ -31,28 +33,48 @@ import (
 // FillWithExploit fills exploit information that has in Exploit
 func FillWithExploit(driver db.DB, r *models.ScanResult) (nExploitCve int, err error) {
 	if cnf.Conf.Exploit.IsFetchViaHTTP() {
-		// TODO
-		return 0, fmt.Errorf("We are not yet supporting data acquisition in exploitdb server mode")
-	}
-
-	if driver == nil {
-		return 0, nil
-	}
-	for cveID, vuln := range r.ScannedCves {
-		es := driver.GetExploitByCveID(cveID)
-		if len(es) == 0 {
-			continue
+		var cveIDs []string
+		for cveID := range r.ScannedCves {
+			cveIDs = append(cveIDs, cveID)
 		}
-		exploits := ConvertToModel(es)
-		vuln.Exploits = exploits
-		r.ScannedCves[cveID] = vuln
-		nExploitCve++
+		prefix, _ := util.URLPathJoin(cnf.Conf.Exploit.URL, "cves")
+		responses, err := getCvesViaHTTP(cveIDs, prefix)
+		if err != nil {
+			return 0, err
+		}
+		for _, res := range responses {
+			exps := []*exploitmodels.Exploit{}
+			if err := json.Unmarshal([]byte(res.json), &exps); err != nil {
+				return 0, err
+			}
+			exploits := convertToModels(exps)
+			v, ok := r.ScannedCves[res.request.cveID]
+			if ok {
+				v.Exploits = exploits
+			}
+			r.ScannedCves[res.request.cveID] = v
+			nExploitCve++
+		}
+	} else {
+		if driver == nil {
+			return 0, nil
+		}
+		for cveID, vuln := range r.ScannedCves {
+			es := driver.GetExploitByCveID(cveID)
+			if len(es) == 0 {
+				continue
+			}
+			exploits := convertToModels(es)
+			vuln.Exploits = exploits
+			r.ScannedCves[cveID] = vuln
+			nExploitCve++
+		}
 	}
 	return nExploitCve, nil
 }
 
-// ConvertToModel converts gost model to vuls model
-func ConvertToModel(es []*exploitmodels.Exploit) (exploits []models.Exploit) {
+// convertToModels converts gost model to vuls model
+func convertToModels(es []*exploitmodels.Exploit) (exploits []models.Exploit) {
 	for _, e := range es {
 		var documentURL, paperURL, shellURL *string
 		if e.OffensiveSecurity != nil {

--- a/gost/debian.go
+++ b/gost/debian.go
@@ -55,7 +55,7 @@ func (deb Debian) FillWithGost(driver db.DB, r *models.ScanResult) (nCVEs int, e
 	}
 
 	packCvesList := []packCves{}
-	if deb.isFetchViaHTTP() {
+	if config.Conf.Gost.IsFetchViaHTTP() {
 		url, _ := util.URLPathJoin(config.Conf.Gost.URL, "debian", major(r.Release), "pkgs")
 		responses, err := getAllUnfixedCvesViaHTTP(r, url)
 		if err != nil {

--- a/gost/gost.go
+++ b/gost/gost.go
@@ -60,7 +60,7 @@ type Base struct {
 
 // CheckHTTPHealth do health check
 func (b Base) CheckHTTPHealth() error {
-	if !b.isFetchViaHTTP() {
+	if !cnf.Conf.Gost.IsFetchViaHTTP() {
 		return nil
 	}
 
@@ -87,11 +87,6 @@ func (b Base) CheckIfGostFetched(driver db.DB, osFamily string) (fetched bool, e
 func (b Base) CheckIfGostFresh(driver db.DB, osFamily string) (ok bool, err error) {
 	//TODO
 	return true, nil
-}
-
-func (b Base) isFetchViaHTTP() bool {
-	// Default value of OvalDBType is sqlite3
-	return cnf.Conf.Gost.URL != "" && cnf.Conf.Gost.Type == "sqlite3"
 }
 
 // Pseudo is Gost client except for RedHat family and Debian

--- a/gost/redhat.go
+++ b/gost/redhat.go
@@ -51,7 +51,7 @@ func (red RedHat) fillFixed(driver db.DB, r *models.ScanResult) error {
 		cveIDs = append(cveIDs, cveID)
 	}
 
-	if red.isFetchViaHTTP() {
+	if config.Conf.Gost.IsFetchViaHTTP() {
 		prefix, _ := util.URLPathJoin(config.Conf.Gost.URL,
 			"redhat", "cves")
 		responses, err := getCvesViaHTTP(cveIDs, prefix)
@@ -114,7 +114,7 @@ func (red RedHat) fillFixed(driver db.DB, r *models.ScanResult) error {
 }
 
 func (red RedHat) fillUnfixed(driver db.DB, r *models.ScanResult) (nCVEs int, err error) {
-	if red.isFetchViaHTTP() {
+	if config.Conf.Gost.IsFetchViaHTTP() {
 		prefix, _ := util.URLPathJoin(config.Conf.Gost.URL,
 			"redhat", major(r.Release), "pkgs")
 		responses, err := getAllUnfixedCvesViaHTTP(r, prefix)

--- a/models/scanresults.go
+++ b/models/scanresults.go
@@ -348,7 +348,7 @@ func (r ScanResult) FormatExploitCveSummary() string {
 			nExploitCve++
 		}
 	}
-	return fmt.Sprintf("%d cves with exploit", nExploitCve)
+	return fmt.Sprintf("%d exploits", nExploitCve)
 }
 
 func (r ScanResult) isDisplayUpdatableNum() bool {

--- a/oval/alpine.go
+++ b/oval/alpine.go
@@ -41,7 +41,7 @@ func NewAlpine() Alpine {
 // FillWithOval returns scan result after updating CVE info by OVAL
 func (o Alpine) FillWithOval(driver db.DB, r *models.ScanResult) (nCVEs int, err error) {
 	var relatedDefs ovalResult
-	if o.IsFetchViaHTTP() {
+	if config.Conf.OvalDict.IsFetchViaHTTP() {
 		if relatedDefs, err = getDefsByPackNameViaHTTP(r); err != nil {
 			return 0, err
 		}

--- a/oval/debian.go
+++ b/oval/debian.go
@@ -133,7 +133,7 @@ func (o Debian) FillWithOval(driver db.DB, r *models.ScanResult) (nCVEs int, err
 	}
 
 	var relatedDefs ovalResult
-	if o.IsFetchViaHTTP() {
+	if config.Conf.OvalDict.IsFetchViaHTTP() {
 		if relatedDefs, err = getDefsByPackNameViaHTTP(r); err != nil {
 			return 0, err
 		}
@@ -243,7 +243,7 @@ func (o Ubuntu) FillWithOval(driver db.DB, r *models.ScanResult) (nCVEs int, err
 	}
 
 	var relatedDefs ovalResult
-	if o.IsFetchViaHTTP() {
+	if config.Conf.OvalDict.IsFetchViaHTTP() {
 		if relatedDefs, err = getDefsByPackNameViaHTTP(r); err != nil {
 			return 0, err
 		}

--- a/oval/oval.go
+++ b/oval/oval.go
@@ -38,7 +38,6 @@ type Client interface {
 	// CheckIfOvalFetched checks if oval entries are in DB by family, release.
 	CheckIfOvalFetched(db.DB, string, string) (bool, error)
 	CheckIfOvalFresh(db.DB, string, string) (bool, error)
-	IsFetchViaHTTP() bool
 }
 
 // Base is a base struct
@@ -48,7 +47,7 @@ type Base struct {
 
 // CheckHTTPHealth do health check
 func (b Base) CheckHTTPHealth() error {
-	if !b.IsFetchViaHTTP() {
+	if !cnf.Conf.OvalDict.IsFetchViaHTTP() {
 		return nil
 	}
 
@@ -67,7 +66,7 @@ func (b Base) CheckHTTPHealth() error {
 
 // CheckIfOvalFetched checks if oval entries are in DB by family, release.
 func (b Base) CheckIfOvalFetched(driver db.DB, osFamily, release string) (fetched bool, err error) {
-	if !b.IsFetchViaHTTP() {
+	if !cnf.Conf.OvalDict.IsFetchViaHTTP() {
 		count, err := driver.CountDefs(osFamily, release)
 		if err != nil {
 			return false, fmt.Errorf("Failed to count OVAL defs: %s, %s, %v",
@@ -93,7 +92,7 @@ func (b Base) CheckIfOvalFetched(driver db.DB, osFamily, release string) (fetche
 // CheckIfOvalFresh checks if oval entries are fresh enough
 func (b Base) CheckIfOvalFresh(driver db.DB, osFamily, release string) (ok bool, err error) {
 	var lastModified time.Time
-	if !b.IsFetchViaHTTP() {
+	if !cnf.Conf.OvalDict.IsFetchViaHTTP() {
 		lastModified = driver.GetLastModified(osFamily, release)
 	} else {
 		url, _ := util.URLPathJoin(cnf.Conf.OvalDict.URL, "lastmodified", osFamily, release)
@@ -118,10 +117,4 @@ func (b Base) CheckIfOvalFresh(driver db.DB, osFamily, release string) (ok bool,
 	}
 	util.Log.Infof("OVAL is fresh: %s %s ", osFamily, release)
 	return true, nil
-}
-
-// IsFetchViaHTTP checks whether fetch via HTTP
-func (b Base) IsFetchViaHTTP() bool {
-	// Default value of OvalDBType is sqlite3
-	return cnf.Conf.OvalDict.URL != "" && cnf.Conf.OvalDict.Type == "sqlite3"
 }

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -37,7 +37,7 @@ type RedHatBase struct {
 // FillWithOval returns scan result after updating CVE info by OVAL
 func (o RedHatBase) FillWithOval(driver db.DB, r *models.ScanResult) (nCVEs int, err error) {
 	var relatedDefs ovalResult
-	if o.IsFetchViaHTTP() {
+	if config.Conf.OvalDict.IsFetchViaHTTP() {
 		if relatedDefs, err = getDefsByPackNameViaHTTP(r); err != nil {
 			return 0, err
 		}

--- a/oval/suse.go
+++ b/oval/suse.go
@@ -43,7 +43,7 @@ func NewSUSE() SUSE {
 // FillWithOval returns scan result after updating CVE info by OVAL
 func (o SUSE) FillWithOval(driver db.DB, r *models.ScanResult) (nCVEs int, err error) {
 	var relatedDefs ovalResult
-	if o.IsFetchViaHTTP() {
+	if config.Conf.OvalDict.IsFetchViaHTTP() {
 		if relatedDefs, err = getDefsByPackNameViaHTTP(r); err != nil {
 			return 0, err
 		}

--- a/report/cve_client.go
+++ b/report/cve_client.go
@@ -45,7 +45,7 @@ func (api *cvedictClient) initialize() {
 }
 
 func (api cvedictClient) CheckHealth() error {
-	if !api.isFetchViaHTTP() {
+	if !config.Conf.CveDict.IsFetchViaHTTP() {
 		util.Log.Debugf("get cve-dictionary from %s", config.Conf.CveDict.Type)
 		return nil
 	}
@@ -69,7 +69,7 @@ type response struct {
 }
 
 func (api cvedictClient) FetchCveDetails(driver cvedb.DB, cveIDs []string) (cveDetails []cve.CveDetail, err error) {
-	if !api.isFetchViaHTTP() {
+	if !config.Conf.CveDict.IsFetchViaHTTP() {
 		for _, cveID := range cveIDs {
 			cveDetail, err := driver.Get(cveID)
 			if err != nil {
@@ -176,16 +176,8 @@ func (api cvedictClient) httpGet(key, url string, resChan chan<- response, errCh
 	}
 }
 
-func (api cvedictClient) isFetchViaHTTP() bool {
-	// Default value of CveDBType is sqlite3
-	if config.Conf.CveDict.URL != "" && config.Conf.CveDict.Type == "sqlite3" {
-		return true
-	}
-	return false
-}
-
 func (api cvedictClient) FetchCveDetailsByCpeName(driver cvedb.DB, cpeName string) ([]cve.CveDetail, error) {
-	if api.isFetchViaHTTP() {
+	if config.Conf.CveDict.IsFetchViaHTTP() {
 		api.baseURL = config.Conf.CveDict.URL
 		url, err := util.URLPathJoin(api.baseURL, "cpes")
 		if err != nil {

--- a/report/report.go
+++ b/report/report.go
@@ -179,12 +179,12 @@ func FillCveInfo(dbclient DBClient, r *models.ScanResult, cpeURIs []string) erro
 		return fmt.Errorf("Failed to fill with CVE: %s", err)
 	}
 
-	util.Log.Infof("Fill Exploit information with Exploit-DB")
+	util.Log.Infof("Fill exploit information with Exploit-DB")
 	nExploitCve, err := FillWithExploit(dbclient.ExploitDB, r)
 	if err != nil {
 		return fmt.Errorf("Failed to fill with exploit: %s", err)
 	}
-	util.Log.Infof("%s: %d Exploits are detected with exploit",
+	util.Log.Infof("%s: %d exploits are detected",
 		r.FormatServerName(), nExploitCve)
 
 	fillCweDict(r)


### PR DESCRIPTION
# What did you implement:

If you use go-cve-dictionary, goval-dictionary, gost, go-exploitdb as http server mode, type of each dictionary have to be defined `http`

config.toml
```
[cveDict]
type = "http"
url = "http://localhost:1323"

[ovalDict]
type = "http"
url = "http://localhost:1324"

[gost]
type = "http"
url = "http://localhost:1325"

[exploit]
type = "http"
url = "http://localhost:1326"
```
also add `http` to command line args.

Fixes #721

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
