### PR TITLE
feat(scan): get repository name of updatable pkgs for debian/ubuntu

### DIFF
--- a/scan/debian_test.go
+++ b/scan/debian_test.go
@@ -530,6 +530,7 @@ func TestParseAptCachePolicy(t *testing.T) {
 				Name:      "openssl",
 				Installed: "1.0.2f-2ubuntu1",
 				Candidate: "1.0.2g-1ubuntu2",
+				Repo:      "xenial/main",
 			},
 		},
 		{
@@ -550,6 +551,7 @@ func TestParseAptCachePolicy(t *testing.T) {
 				Name:      "openssl",
 				Installed: "1.0.1f-1ubuntu2.16",
 				Candidate: "1.0.1f-1ubuntu2.17",
+				Repo:      "trusty-updates/main",
 			},
 		},
 		{
@@ -570,6 +572,7 @@ func TestParseAptCachePolicy(t *testing.T) {
 				Name:      "openssl",
 				Installed: "1.0.1-4ubuntu5.33",
 				Candidate: "1.0.1-4ubuntu5.34",
+				Repo:      "precise-updates/main",
 			},
 		},
 	}


### PR DESCRIPTION
# What did you implement:

`apt policy` shows the repository name of updatable packages.
The repository name will be included to json result in -fast-root scan mode because it's necessary to refresh meta information by `apt-get update` with root privileges.

```
 apt policy zsh
zsh:
  Installed: 5.4.2-3ubuntu3
  Candidate: 5.4.2-3ubuntu3
  Version table:
 *** 5.4.2-3ubuntu3 500
        500 http://jp.archive.ubuntu.com/ubuntu bionic/main amd64 Packages
        100 /var/lib/dpkg/status
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on Ubuntu18, Debian 9.

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
