### PR TITLE
fix(report): return both scores of gost and oval

### DIFF
--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -275,7 +275,7 @@ func (v VulnInfo) Mitigations(myFamily string) (values []CveContentStr) {
 
 // Cvss2Scores returns CVSS V2 Scores
 func (v VulnInfo) Cvss2Scores(myFamily string) (values []CveContentCvss) {
-	order := []CveContentType{Nvd, NvdXML, RedHat, Jvn}
+	order := []CveContentType{Nvd, NvdXML, RedHatAPI, RedHat, Jvn}
 	if myFamily != config.RedHat && myFamily != config.CentOS {
 		order = append(order, NewCveContentType(myFamily))
 	}
@@ -295,26 +295,6 @@ func (v VulnInfo) Cvss2Scores(myFamily string) (values []CveContentCvss) {
 				},
 			})
 		}
-	}
-
-	for _, v := range values {
-		if v.Type == RedHat {
-			return
-		}
-	}
-	// Set the CVSS v2 score of vuln that exists only in gost.
-	// Unfixed vulnerabilities detected by gost are not in OVAL, because
-	// OVAL data has only vulnerabilities for already fixed.
-	if cont, found := v.CveContents[RedHatAPI]; found {
-		values = append(values, CveContentCvss{
-			Type: RedHatAPI,
-			Value: Cvss{
-				Type:     CVSS2,
-				Score:    cont.Cvss2Score,
-				Vector:   cont.Cvss2Vector,
-				Severity: strings.ToUpper(cont.Cvss2Severity),
-			},
-		})
 	}
 
 	for _, adv := range v.DistroAdvisories {
@@ -359,7 +339,7 @@ func (v VulnInfo) Cvss2Scores(myFamily string) (values []CveContentCvss) {
 
 // Cvss3Scores returns CVSS V3 Score
 func (v VulnInfo) Cvss3Scores() (values []CveContentCvss) {
-	order := []CveContentType{Nvd, RedHat, Jvn}
+	order := []CveContentType{Nvd, RedHatAPI, RedHat, Jvn}
 	for _, ctype := range order {
 		if cont, found := v.CveContents[ctype]; found {
 			// https://nvd.nist.gov/vuln-metrics/cvss
@@ -373,27 +353,6 @@ func (v VulnInfo) Cvss3Scores() (values []CveContentCvss) {
 				},
 			})
 		}
-	}
-
-	for _, v := range values {
-		if v.Type == RedHat {
-			return
-		}
-	}
-
-	// Set the CVSS v3 score of vuln that exists only in gost.
-	// Unfixed vulnerabilities detected by gost are not in OVAL, because
-	// OVAL data has only vulnerabilities for already fixed.
-	if cont, found := v.CveContents[RedHatAPI]; found {
-		values = append(values, CveContentCvss{
-			Type: RedHatAPI,
-			Value: Cvss{
-				Type:     CVSS3,
-				Score:    cont.Cvss3Score,
-				Vector:   cont.Cvss3Vector,
-				Severity: strings.ToUpper(cont.Cvss3Severity),
-			},
-		})
 	}
 	return
 }


### PR DESCRIPTION
# What did you implement:

fix(report): return both scores of gost and oval

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`./vuls report` shows both CVSS scores of oval and gost.

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES