### PR TITLE
Remove ThreadTimeStamp from message struct

### DIFF
--- a/report/slack.go
+++ b/report/slack.go
@@ -39,12 +39,11 @@ type field struct {
 }
 
 type message struct {
-	Text            string             `json:"text"`
-	Username        string             `json:"username"`
-	IconEmoji       string             `json:"icon_emoji"`
-	Channel         string             `json:"channel"`
-	ThreadTimeStamp string             `json:"thread_ts"`
-	Attachments     []slack.Attachment `json:"attachments"`
+	Text        string             `json:"text"`
+	Username    string             `json:"username"`
+	IconEmoji   string             `json:"icon_emoji"`
+	Channel     string             `json:"channel"`
+	Attachments []slack.Attachment `json:"attachments"`
 }
 
 // SlackWriter send report to slack


### PR DESCRIPTION
# What did you implement:

Remove ThreadTimeStamp from message struct on `report/slack.go`
- If `thread_ts` value sent as empty string ("") to Slack, it returns error `invalid_thread_ts`
- When API try to send, it use `slack.PostMessageParameters`, not use `message`
- Then, no need to send `thread_ts` to Slack.

Fixes #755

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

I have created new docker image, and tried to run it. (It succeed.)

1. Build image
```
$ docker build -t yahharo/vuls 'https://github.com/yahharo/vuls.git#fix-slack-notification'
$ docker push yahharo/vuls
```

2. Run my environment like these:

```bash
$ docker run --rm \
    -v $PWD:/vuls \
    -v $PWD/vuls-log:/var/log/vuls \
    -v /etc/localtime:/etc/localtime:ro \
    yahharo/vuls report \
    -cvedb-sqlite3-path /vuls/cve.sqlite3 \
    -to-slack \
    -diff \
    -config=./config.toml
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

