### PR TITLE
add build time

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,8 +18,9 @@ SRCS = $(shell git ls-files '*.go')
 PKGS = $(shell go list ./...)
 VERSION := $(shell git describe --tags --abbrev=0)
 REVISION := $(shell git rev-parse --short HEAD)
+BUILDTIME := $(shell date "+%Y%m%d_%H%M%S")
 LDFLAGS := -X 'github.com/future-architect/vuls/config.Version=$(VERSION)' \
-	-X 'github.com/future-architect/vuls/config.Revision=$(REVISION)'
+    -X 'github.com/future-architect/vuls/config.Revision=$(BUILDTIME)_$(REVISION)'
 
 all: dep build
 


### PR DESCRIPTION
# What did you implement:

The build time is now output when version is displayed with -v

# How Has This Been Tested?

I confirmed that it was built and displayed

```
$ ./vuls -v
vuls v0.6.1 20190118_040151_4b49e11
```
vuls <version> <build day> <build time> <commit hash>