### PR TITLE
add ScannedIPv4Addrs and ScannedIPv6Addrs

### DIFF
--- a/models/scanresults.go
+++ b/models/scanresults.go
@@ -51,6 +51,8 @@ type ScanResult struct {
 	ScannedVersion   string                 `json:"scannedVersion"`
 	ScannedRevision  string                 `json:"scannedRevision"`
 	ScannedBy        string                 `json:"scannedBy"`
+	ScannedIPv4Addrs []string               `json:"scannedIpv4Addrs"`
+	ScannedIPv6Addrs []string               `json:"scannedIpv6Addrs"`
 	ReportedAt       time.Time              `json:"reportedAt"`
 	ReportedVersion  string                 `json:"reportedVersion"`
 	ReportedRevision string                 `json:"reportedRevision"`


### PR DESCRIPTION
# What did you implement:

add Scanner's IPv4 and IPv6 to ScanResults.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run vuls scan locally, and I get following result:

```
...
"scannedAt":"2019-01-18T13:09:16.143774+09:00",
"scanMode":"fast mode",
"scannedVersion":"v0.6.1",
"scannedRevision":"4b49e11",
"scannedBy":"amachitomoyanoMacBook-puro.local",
"scannedIpv4Addrs":["192.168.1.12"],
"scannedIpv6Addrs":null,
...
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

