### PR TITLE
modify build time

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,7 +20,7 @@ VERSION := $(shell git describe --tags --abbrev=0)
 REVISION := $(shell git rev-parse --short HEAD)
 BUILDTIME := $(shell date "+%Y%m%d_%H%M%S")
 LDFLAGS := -X 'github.com/future-architect/vuls/config.Version=$(VERSION)' \
-    -X 'github.com/future-architect/vuls/config.Revision=$(BUILDTIME)_$(REVISION)'
+    -X 'github.com/future-architect/vuls/config.Revision=build-$(BUILDTIME)_$(REVISION)'
 
 all: dep build
 


### PR DESCRIPTION
# What did you implement:

The build time is now output when version is displayed with -v


## How Has This Been Tested?

I confirmed that it was built and displayed

```
$ ./vuls -v
vuls v0.6.2 build-20190124_061720_9b8a323

```