### PR TITLE
Delete tab from output in case of No CVE-IDs

### DIFF
--- a/report/util.go
+++ b/report/util.go
@@ -104,7 +104,7 @@ func formatList(r models.ScanResult) string {
 %s
 No CVE-IDs are found in updatable packages.
 %s
-	 `, header, r.FormatUpdatablePacksSummary())
+`, header, r.FormatUpdatablePacksSummary())
 	}
 
 	data := [][]string{}
@@ -168,7 +168,7 @@ func formatFullPlainText(r models.ScanResult) (lines string) {
 %s
 No CVE-IDs are found in updatable packages.
 %s
-	 `, header, r.FormatUpdatablePacksSummary())
+`, header, r.FormatUpdatablePacksSummary())
 	}
 
 	lines = header + "\n"


### PR DESCRIPTION
# What did you implement:

I deleted tab from output message of "No CVE-IDs are found in updatable packages.".
The reason for deleting is to include the output result of Vuls in JSON and become a parse error when registering to GitHub Issues.
If you need a tab, would you tell me the reason.

```
$ vuls report -ignore-unfixed -format-list -config=config.toml -cvss-over=8 | od -c
[Jan 24 14:46:16]  INFO [localhost] Validating config...
[Jan 24 14:46:16]  INFO [localhost] Loaded: /home/centos/work/vuls/results/2019-01-24T14:43:18Z
[Jan 24 14:46:16]  INFO [localhost] Validating db config...
INFO[0000] -cvedb-type: sqlite3, -cvedb-url: , -cvedb-path: /home/centos/cve.sqlite3 
INFO[0000] -ovaldb-type: sqlite3, -ovaldb-url: , -ovaldb-path: /home/centos/go/src/github.com/kotakanbe/goval-dictionary/oval.sqlite3 
INFO[0000] -gostdb-type: sqlite3, -gostdb-url: , -gostdb-path: /home/centos/go/src/github.com/knqyf263/gost/gost.sqlite3 
INFO[0000] -exploitdb-type: sqlite3, -exploitdb-url: , -exploitdb-path: /home/centos/go/src/github.com/mozqnet/go-exploitdb/go-exploitdb.sqlite3 
INFO[01-24|14:46:16] Opening DB.                              db=sqlite3
INFO[01-24|14:46:16] Migrating DB.                            db=sqlite3
INFO[01-24|14:46:16] Opening Database.                        db=sqlite3
0000000  \n   h   t   t   p   d   @   l   o   c   a   l   h   o   s   t
0000020       (   d   e   b   i   a   n   9   .   6   )       o   n    
0000040   l   o   c   a   l   h   o   s   t  \n   =   =   =   =   =   =
0000060   =   =   =   =   =   =   =   =   =   =   =   =   =   =   =   =
*
0000120   =   =  \n   T   o   t   a   l   :       0       (   H   i   g
0000140   h   :   0       M   e   d   i   u   m   :   0       L   o   w
0000160   :   0       ?   :   0   )   ,       0   /   0       F   i   x
0000200   e   d   ,       1   0   9       i   n   s   t   a   l   l   e
0000220   d   ,       0       e   x   p   l   o   i   t   s   ,       e
0000240   n   :       0   ,       j   a   :       0       a   l   e   r
0000260   t   s  \n  \n   N   o       C   V   E   -   I   D   s       a
0000300   r   e       f   o   u   n   d       i   n       u   p   d   a
0000320   t   a   b   l   e       p   a   c   k   a   g   e   s   .  \n
0000340   1   0   9       i   n   s   t   a   l   l   e   d  \n  \t    
0000360  \n
0000361
$ 
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Scan for httpd container on CentOS

```
$ vuls report -ignore-unfixed -format-list -config=config.toml -cvss-over=8 | od -c
[Jan 24 14:51:09]  INFO [localhost] Validating config...
[Jan 24 14:51:09]  INFO [localhost] Loaded: /home/centos/work/vuls/results/2019-01-24T14:43:18Z
[Jan 24 14:51:09]  INFO [localhost] Validating db config...
INFO[0000] -cvedb-type: sqlite3, -cvedb-url: , -cvedb-path: /home/centos/cve.sqlite3 
INFO[0000] -ovaldb-type: sqlite3, -ovaldb-url: , -ovaldb-path: /home/centos/go/src/github.com/kotakanbe/goval-dictionary/oval.sqlite3 
INFO[0000] -gostdb-type: sqlite3, -gostdb-url: , -gostdb-path: /home/centos/go/src/github.com/knqyf263/gost/gost.sqlite3 
INFO[0000] -exploitdb-type: sqlite3, -exploitdb-url: , -exploitdb-path: /home/centos/go/src/github.com/mozqnet/go-exploitdb/go-exploitdb.sqlite3 
INFO[01-24|14:51:09] Opening DB.                              db=sqlite3
INFO[01-24|14:51:09] Migrating DB.                            db=sqlite3
INFO[01-24|14:51:09] Opening Database.                        db=sqlite3
0000000  \n   h   t   t   p   d   @   l   o   c   a   l   h   o   s   t
0000020       (   d   e   b   i   a   n   9   .   6   )       o   n    
0000040   l   o   c   a   l   h   o   s   t  \n   =   =   =   =   =   =
0000060   =   =   =   =   =   =   =   =   =   =   =   =   =   =   =   =
*
0000120   =   =  \n   T   o   t   a   l   :       0       (   H   i   g
0000140   h   :   0       M   e   d   i   u   m   :   0       L   o   w
0000160   :   0       ?   :   0   )   ,       0   /   0       F   i   x
0000200   e   d   ,       1   0   9       i   n   s   t   a   l   l   e
0000220   d   ,       0       e   x   p   l   o   i   t   s   ,       e
0000240   n   :       0   ,       j   a   :       0       a   l   e   r
0000260   t   s  \n  \n   N   o       C   V   E   -   I   D   s       a
0000300   r   e       f   o   u   n   d       i   n       u   p   d   a
0000320   t   a   b   l   e       p   a   c   k   a   g   e   s   .  \n
0000340   1   0   9       i   n   s   t   a   l   l   e   d  \n  \n
0000357
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES 

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/