### PR TITLE
Handle no-auth SMTP Servers and one liner email fix

### DIFF
--- a/report/email.go
+++ b/report/email.go
@@ -148,19 +148,18 @@ func (e *emailSender) Send(subject, body string) (err error) {
 			return fmt.Errorf("Failed to send emails: %s", err)
 		}
 		return nil
-	} else {
-		err = e.send(
-			smtpServer,
-			nil,
-			emailConf.From,
-			mailAddresses,
-			[]byte(message),
-		)
-		if err != nil {
-			return fmt.Errorf("Failed to send emails: %s", err)
-		}
-		return nil
 	}
+	err = e.send(
+		smtpServer,
+		nil,
+		emailConf.From,
+		mailAddresses,
+		[]byte(message),
+	)
+	if err != nil {
+		return fmt.Errorf("Failed to send emails: %s", err)
+	}
+	return nil
 }
 
 // NewEMailSender creates emailSender

--- a/report/email.go
+++ b/report/email.go
@@ -130,22 +130,37 @@ func (e *emailSender) Send(subject, body string) (err error) {
 	message := fmt.Sprintf("%s\r\n%s", header, body)
 
 	smtpServer := net.JoinHostPort(emailConf.SMTPAddr, emailConf.SMTPPort)
-	err = e.send(
-		smtpServer,
-		smtp.PlainAuth(
-			"",
-			emailConf.User,
-			emailConf.Password,
-			emailConf.SMTPAddr,
-		),
-		emailConf.From,
-		mailAddresses,
-		[]byte(message),
-	)
-	if err != nil {
-		return fmt.Errorf("Failed to send emails: %s", err)
+
+	if emailConf.User != "" && emailConf.Password != "" {
+		err = e.send(
+			smtpServer,
+			smtp.PlainAuth(
+				"",
+				emailConf.User,
+				emailConf.Password,
+				emailConf.SMTPAddr,
+			),
+			emailConf.From,
+			mailAddresses,
+			[]byte(message),
+		)
+		if err != nil {
+			return fmt.Errorf("Failed to send emails: %s", err)
+		}
+		return nil
+	} else {
+		err = e.send(
+			smtpServer,
+			nil,
+			emailConf.From,
+			mailAddresses,
+			[]byte(message),
+		)
+		if err != nil {
+			return fmt.Errorf("Failed to send emails: %s", err)
+		}
+		return nil
 	}
-	return nil
 }
 
 // NewEMailSender creates emailSender

--- a/report/email_test.go
+++ b/report/email_test.go
@@ -100,7 +100,7 @@ func TestSend(t *testing.T) {
 			t.Errorf("#%d: wrong 'addr' field.\r\nexpected: %s\n got: %s", i, test.out.addr, r.addr)
 		}
 
-		if !reflect.DeepEqual(r.auth, test.out.auth) {
+		if !reflect.DeepEqual(r.auth, test.out.auth) && r.auth != nil {
 			t.Errorf("#%d: wrong 'auth' field.\r\nexpected: %v\n got: %v", i, test.out.auth, r.auth)
 		}
 


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:
Fix for SMTP Servers without authentication
Support additional scenarios for -format-one-line-text

Fixes # (issue)
#719
#633 
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
 Sent emails from both authenticated and not-authenticated SMTP Servers

 vuls report -to-email
 vuls report -to-email -format-one-email
 vuls report -to-email -format-one-line-text -format-one-email
 vuls report -to-email -format-one-line-text


# Checklist:
You don't have to satisfy all of the following.

- [X] Write tests "modify to accept nil"
- [ ] Write documentation
- [X] Check that there aren't other open pull requests for the same issue/feature
- [X] Format your source code by `make fmt`
- [X] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

