### PR TITLE
Specify VOLUME using json syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --no-cache \
 
 COPY --from=builder /go/bin/vuls /usr/local/bin/
 
-VOLUME [$WORKDIR, $LOGDIR]
+VOLUME ["$WORKDIR", "$LOGDIR"]
 WORKDIR $WORKDIR
 ENV PWD $WORKDIR
 


### PR DESCRIPTION
When using a json array for VOLUME, values must be quoted. Else it's interpreted as a string, eg /[vuls

Relates to https://github.com/kotakanbe/goval-dictionary/issues/58

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`ls` in the resulting docker image. You should see the mount point `/vuls` and _not_ `/[vuls`