### PR TITLE
Updated config.toml reference url

### DIFF
--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -119,7 +119,7 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 		msg := []string{
 			fmt.Sprintf("Error loading %s", p.configPath),
 			"If you update Vuls and get this error, there may be incompatible changes in config.toml",
-			"Please check README: https://github.com/future-architect/vuls#configuration",
+			"Please check config.toml template : https://vuls.io/docs/en/usage-settings.html",
 		}
 		util.Log.Errorf("%s\n%+v", strings.Join(msg, "\n"), err)
 		return subcommands.ExitUsageError

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -145,7 +145,7 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 		msg := []string{
 			fmt.Sprintf("Error loading %s", p.configPath),
 			"If you update Vuls and get this error, there may be incompatible changes in config.toml",
-			"Please check README: https://github.com/future-architect/vuls#configuration",
+			"Please check config.toml template : https://vuls.io/docs/en/usage-settings.html",
 		}
 		util.Log.Errorf("%s\n%+v", strings.Join(msg, "\n"), err)
 		return subcommands.ExitUsageError


### PR DESCRIPTION
### What did I implement:

I have changed the config.toml reference URL to https://vuls.io/docs/en/usage-settings.html as the mentioned one - https://github.com/future-architect/vuls#configuration - doesnt exist in Readme file
