### PR TITLE
fix(scan): a bug of kernel Vulns detection on Ubuntu18

### DIFF
--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -562,7 +562,7 @@ func (v VulnInfo) AttackVector() string {
 	return ""
 }
 
-// PatchStatus returns attack vector string
+// PatchStatus returns fixed or unfixed string
 func (v VulnInfo) PatchStatus(packs Packages) string {
 	// Vuls don't know patch status of the CPE
 	if len(v.CpeURIs) != 0 {

--- a/oval/util.go
+++ b/oval/util.go
@@ -289,18 +289,28 @@ func isOvalDefAffected(def ovalmodels.Definition, req request, family string, ru
 			return true, true
 		}
 
+		// Compare between the installed version vs the version in OVAL
 		less, err := lessThan(family, req.versionRelease, ovalPack)
 		if err != nil {
 			util.Log.Debugf("Failed to parse versions: %s, Ver: %#v, OVAL: %#v, DefID: %s",
 				err, req.versionRelease, ovalPack, def.DefinitionID)
 			return false, false
 		}
-
 		if less {
-			if req.isSrcPack {
-				// Unable to judge whether fixed or not fixed of src package(Ubuntu, Debian)
+			// If the version of installed is less than in OVAL
+			switch family {
+			case config.RedHat,
+				config.Amazon,
+				config.SUSEEnterpriseServer,
+				config.Debian,
+				config.Ubuntu:
+				// Use fixed state in OVAL for these distros.
 				return true, false
 			}
+
+			// But CentOS can't judge whether fixed or unfixed.
+			// Because fixed state in RHEL's OVAL is different.
+			// So, it have to be judged version comparison.
 
 			// `offline` or `fast` scan mode can't get a updatable version.
 			// In these mode, the blow field was set empty.

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -285,7 +285,7 @@ func TestIsOvalDefAffected(t *testing.T) {
 				},
 			},
 			affected:    true,
-			notFixedYet: true,
+			notFixedYet: false,
 		},
 		// 4. Ubuntu
 		//   ovalpack.NotFixedYet == false
@@ -371,7 +371,7 @@ func TestIsOvalDefAffected(t *testing.T) {
 				},
 			},
 			affected:    true,
-			notFixedYet: true,
+			notFixedYet: false,
 		},
 		// 7 RedHat
 		{
@@ -450,7 +450,7 @@ func TestIsOvalDefAffected(t *testing.T) {
 				},
 			},
 			affected:    true,
-			notFixedYet: true,
+			notFixedYet: false,
 		},
 		// 10 RedHat
 		{


### PR DESCRIPTION
# What did you implement:

The key name of a kernel has been changed in OVAL for Ubuntu 18.
I fixed the detection logic.

`Not fixed yet` in a report is also fixed.
Use `not fixed yet` data in OVAL except for CentOS.
OVAL detection for CentOS uses RHEL's OVAL.
The patch provided status is different from CentOS and RHEL.
So,  the Version comparison(`new version` vs `fixed in version` in OVAL) is needed to judge `fixed` or `not fixed yet` for CentOS.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


# diff
```
 ~/w/u18  ls                                                                                                                                        Thu May 23 16:45:23 2019
localhost.json     localhost.json.new
 ~/w/u18  diff *                                                                                                                                    Thu May 23 16:45:23 2019
37c37
<     "reportedAt": "2019-05-23T16:44:53.78834+09:00",
---
>     "reportedAt": "2019-05-23T16:43:23.577594+09:00",
488c488
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
659c659
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
972c972
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
1466c1466
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
1572c1572
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
1678c1678
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
1764c1764
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
5974c5974
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
6433c6433
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
6539,6541c6539,6541
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
6659,6661c6659,6661
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
6779,6781c6779,6781
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
6899c6899
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
7000c7000
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
7106c7106
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
7207c7207
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
7308c7308
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
7439c7439
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
7540c7540
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
7641c7641
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
7768c7768
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
7895c7895
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
7991c7991
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
8132c8132
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
8465c8465
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
8591c8591
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
8713c8713
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
8834c8834
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
8965c8965
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
9086c9086
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
9197c9197
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
9288c9288
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
9409c9409
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
9535,9537c9535,9537
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
9777c9777
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
10110,10112c10110,10112
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
10261c10261
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
10352,10354c10352,10354
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
10548,10550c10548,10550
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
10936,10938c10936,10938
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
11122,11124c11122,11124
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
11263c11263
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
11495c11495
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
11888c11888
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
12004c12004
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
12221c12221
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
13187c13187
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
13591c13591
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
13651,13653c13651,13653
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
13932c13932
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
13987c13987
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
14072c14072
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
14142c14142
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
14207c14207
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
14277c14277
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
14337c14337
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
14769c14769
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
14819,14821c14819,14821
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
14975,14977c14975,14977
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
15126c15126
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
15262c15262
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
15836,15838c15836,15838
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
15972,15974c15972,15974
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
16072c16072
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
16228,16229c16228,16229
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "notFixedYet": false,
>                     "fixState": ""
16233,16234c16233,16234
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "notFixedYet": false,
>                     "fixState": ""
16238,16239c16238,16239
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "notFixedYet": false,
>                     "fixState": ""
16302c16302
<                     "name": "linux-image-virtual",
---
>                     "name": "linux-image-generic",
16821,16823c16821,16823
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
17468,17470c17468,17470
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
17674,17676c17674,17676
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
17860,17862c17860,17862
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
18066,18068c18066,18068
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
18847,18849c18847,18849
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
18978,18980c18978,18980
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
19129,19131c19129,19131
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
19355,19357c19355,19357
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""
19435,19437c19435,19437
<                     "name": "linux-image-virtual",
<                     "notFixedYet": true,
<                     "fixState": "Not fixed yet"
---
>                     "name": "linux-image-generic",
>                     "notFixedYet": false,
>                     "fixState": ""

```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

