### PR TITLE
Changing the scannedAt time in the original result

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -84,6 +84,7 @@ func (h VulsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		scannedAt := result.ScannedAt
 		if scannedAt.IsZero() {
 			scannedAt = time.Now().Truncate(1 * time.Hour)
+			result.ScannedAt = scannedAt
 		}
 		dir, err := scan.EnsureResultDir(scannedAt)
 		if err != nil {


### PR DESCRIPTION
# What did I implement:

The report of vuls server (running with `-to-localfile -format-json`) will always have the `scannedAt` attribute as `0001-01-01T00:00:00Z`. There is an explicit check for the value in the parameter before creation of directory - if the value equals `time.IsZero()` then the directory name is set to the current time. However, the `scannedAt` time in the report stays the same as before. 

https://github.com/future-architect/vuls/blob/master/server/server.go#L83-L98

When parsing the local json files of scanned hosts, the timestamp of all the servers remains as `0001-01-01T00:00:00Z`. 

In the PR, I have changed the `scannedAt` attribute in the report to current time so that the json files contain the correct time of scan. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`make test`

```
?   	github.com/future-architect/vuls	[no test files]
?   	github.com/future-architect/vuls/alert	[no test files]
=== RUN   TestSetupBolt
--- PASS: TestSetupBolt (0.01s)
=== RUN   TestEnsureBuckets
--- PASS: TestEnsureBuckets (0.01s)
=== RUN   TestPutGetChangelog
--- PASS: TestPutGetChangelog (0.01s)
PASS
coverage: 54.9% of statements
ok  	github.com/future-architect/vuls/cache	0.045s	coverage: 54.9% of statements
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/future-architect/vuls/commands	0.016s	coverage: 0.0% of statements [no tests to run]
=== RUN   TestSyslogConfValidate
--- PASS: TestSyslogConfValidate (0.00s)
=== RUN   TestMajorVersion
--- PASS: TestMajorVersion (0.00s)
=== RUN   TestToCpeURI
--- PASS: TestToCpeURI (0.00s)
PASS
coverage: 7.5% of statements
ok  	github.com/future-architect/vuls/config	0.005s	coverage: 7.5% of statements
?   	github.com/future-architect/vuls/contrib/owasp-dependency-check/parser	[no test files]
?   	github.com/future-architect/vuls/cwe	[no test files]
=== RUN   TestSetPackageStates
--- PASS: TestSetPackageStates (0.00s)
PASS
coverage: 0.0% of statements
ok  	github.com/future-architect/vuls/exploit	0.008s	coverage: 0.0% of statements
?   	github.com/future-architect/vuls/github	[no test files]
=== RUN   TestSetPackageStates
--- PASS: TestSetPackageStates (0.00s)
=== RUN   TestParseCwe
--- PASS: TestParseCwe (0.00s)
PASS
coverage: 6.7% of statements
ok  	github.com/future-architect/vuls/gost	0.009s	coverage: 6.7% of statements
=== RUN   TestExcept
--- PASS: TestExcept (0.00s)
=== RUN   TestSourceLinks
--- PASS: TestSourceLinks (0.00s)
=== RUN   TestVendorLink
--- PASS: TestVendorLink (0.00s)
=== RUN   TestMergeNewVersion
--- PASS: TestMergeNewVersion (0.00s)
=== RUN   TestMerge
--- PASS: TestMerge (0.00s)
=== RUN   TestAddBinaryName
--- PASS: TestAddBinaryName (0.00s)
=== RUN   TestFindByBinName
--- PASS: TestFindByBinName (0.00s)
=== RUN   TestFilterByCvssOver
--- PASS: TestFilterByCvssOver (0.00s)
=== RUN   TestFilterIgnoreCveIDs
--- PASS: TestFilterIgnoreCveIDs (0.00s)
=== RUN   TestFilterIgnoreCveIDsContainer
--- PASS: TestFilterIgnoreCveIDsContainer (0.00s)
=== RUN   TestFilterUnfixed
--- PASS: TestFilterUnfixed (0.00s)
=== RUN   TestFilterIgnorePkgs
--- PASS: TestFilterIgnorePkgs (0.00s)
=== RUN   TestFilterIgnorePkgsContainer
--- PASS: TestFilterIgnorePkgsContainer (0.00s)
=== RUN   TestIsDisplayUpdatableNum
--- PASS: TestIsDisplayUpdatableNum (0.00s)
=== RUN   TestTitles
--- PASS: TestTitles (0.00s)
=== RUN   TestSummaries
--- PASS: TestSummaries (0.00s)
=== RUN   TestCountGroupBySeverity
--- PASS: TestCountGroupBySeverity (0.00s)
=== RUN   TestToSortedSlice
--- PASS: TestToSortedSlice (0.00s)
=== RUN   TestCvss2Scores
--- PASS: TestCvss2Scores (0.00s)
=== RUN   TestMaxCvss2Scores
--- PASS: TestMaxCvss2Scores (0.00s)
=== RUN   TestCvss3Scores
--- PASS: TestCvss3Scores (0.00s)
=== RUN   TestMaxCvss3Scores
--- PASS: TestMaxCvss3Scores (0.00s)
=== RUN   TestMaxCvssScores
--- PASS: TestMaxCvssScores (0.00s)
=== RUN   TestFormatMaxCvssScore
--- PASS: TestFormatMaxCvssScore (0.00s)
=== RUN   TestSortPackageStatues
--- PASS: TestSortPackageStatues (0.00s)
=== RUN   TestStorePackageStatueses
--- PASS: TestStorePackageStatueses (0.00s)
=== RUN   TestAppendIfMissing
--- PASS: TestAppendIfMissing (0.00s)
=== RUN   TestSortByConfiden
--- PASS: TestSortByConfiden (0.00s)
PASS
coverage: 42.2% of statements
ok  	github.com/future-architect/vuls/models	0.016s	coverage: 42.2% of statements
=== RUN   TestPackNamesOfUpdateDebian
--- PASS: TestPackNamesOfUpdateDebian (0.00s)
=== RUN   TestParseCvss2
--- PASS: TestParseCvss2 (0.00s)
=== RUN   TestParseCvss3
--- PASS: TestParseCvss3 (0.00s)
=== RUN   TestPackNamesOfUpdate
--- PASS: TestPackNamesOfUpdate (0.00s)
=== RUN   TestUpsert
--- PASS: TestUpsert (0.00s)
=== RUN   TestDefpacksToPackStatuses
--- PASS: TestDefpacksToPackStatuses (0.00s)
=== RUN   TestIsOvalDefAffected
--- PASS: TestIsOvalDefAffected (0.00s)
=== RUN   TestMajor
--- PASS: TestMajor (0.00s)
PASS
coverage: 27.8% of statements
ok  	github.com/future-architect/vuls/oval	0.014s	coverage: 27.8% of statements
=== RUN   TestSend
--- PASS: TestSend (0.00s)
=== RUN   TestGetNotifyUsers
--- PASS: TestGetNotifyUsers (0.00s)
=== RUN   TestSyslogWriterEncodeSyslog
--- PASS: TestSyslogWriterEncodeSyslog (0.00s)
=== RUN   TestIsCveInfoUpdated
--- PASS: TestIsCveInfoUpdated (0.00s)
=== RUN   TestDiff
--- PASS: TestDiff (0.00s)
=== RUN   TestIsCveFixed
--- PASS: TestIsCveFixed (0.00s)
PASS
coverage: 6.2% of statements
ok  	github.com/future-architect/vuls/report	0.017s	coverage: 6.2% of statements
=== RUN   TestParseApkInfo
--- PASS: TestParseApkInfo (0.00s)
=== RUN   TestParseApkVersion
--- PASS: TestParseApkVersion (0.00s)
=== RUN   TestParseDockerPs
--- PASS: TestParseDockerPs (0.00s)
=== RUN   TestParseLxdPs
--- PASS: TestParseLxdPs (0.00s)
=== RUN   TestParseIp
--- PASS: TestParseIp (0.00s)
=== RUN   TestIsAwsInstanceID
--- PASS: TestIsAwsInstanceID (0.00s)
=== RUN   TestParseSystemctlStatus
--- PASS: TestParseSystemctlStatus (0.00s)
=== RUN   TestGetCveIDsFromChangelog
--- PASS: TestGetCveIDsFromChangelog (0.00s)
=== RUN   TestGetUpdatablePackNames
--- PASS: TestGetUpdatablePackNames (0.00s)
=== RUN   TestGetChangelogCache
--- PASS: TestGetChangelogCache (0.01s)
=== RUN   TestSplitAptCachePolicy
--- PASS: TestSplitAptCachePolicy (0.00s)
=== RUN   TestParseAptCachePolicy
--- PASS: TestParseAptCachePolicy (0.00s)
=== RUN   TestParseCheckRestart
--- PASS: TestParseCheckRestart (0.00s)
=== RUN   TestDecorateCmd
--- PASS: TestDecorateCmd (0.00s)
=== RUN   TestParseIfconfig
--- PASS: TestParseIfconfig (0.00s)
=== RUN   TestParsePkgVersion
time="May 27 12:36:45" level=warning msg="The installed version of the ntp is newer than the current version. *This situation can arise with an out of date index file, or when testing new ports.*"
--- PASS: TestParsePkgVersion (0.00s)
=== RUN   TestSplitIntoBlocks
--- PASS: TestSplitIntoBlocks (0.00s)
=== RUN   TestParseBlock
--- PASS: TestParseBlock (0.00s)
=== RUN   TestParseInstalledPackagesLinesRedhat
--- PASS: TestParseInstalledPackagesLinesRedhat (0.00s)
=== RUN   TestParseScanedPackagesLineRedhat
--- PASS: TestParseScanedPackagesLineRedhat (0.00s)
=== RUN   TestChangeSectionState
--- PASS: TestChangeSectionState (0.00s)
=== RUN   TestParseYumUpdateinfoLineToGetCveIDs
--- PASS: TestParseYumUpdateinfoLineToGetCveIDs (0.00s)
=== RUN   TestParseYumUpdateinfoToGetAdvisoryID
--- PASS: TestParseYumUpdateinfoToGetAdvisoryID (0.00s)
=== RUN   TestParseYumUpdateinfoLineToGetIssued
--- PASS: TestParseYumUpdateinfoLineToGetIssued (0.00s)
=== RUN   TestParseYumUpdateinfoLineToGetUpdated
--- PASS: TestParseYumUpdateinfoLineToGetUpdated (0.00s)
=== RUN   TestIsDescriptionLine
--- PASS: TestIsDescriptionLine (0.00s)
=== RUN   TestParseYumUpdateinfoToGetSeverity
--- PASS: TestParseYumUpdateinfoToGetSeverity (0.00s)
=== RUN   TestParseYumUpdateinfoOL
--- PASS: TestParseYumUpdateinfoOL (0.00s)
=== RUN   TestParseYumUpdateinfoRHEL
--- PASS: TestParseYumUpdateinfoRHEL (0.00s)
=== RUN   TestParseYumUpdateinfoAmazon
--- PASS: TestParseYumUpdateinfoAmazon (0.00s)
=== RUN   TestParseYumCheckUpdateLine
--- PASS: TestParseYumCheckUpdateLine (0.00s)
=== RUN   TestParseYumCheckUpdateLines
--- PASS: TestParseYumCheckUpdateLines (0.00s)
=== RUN   TestParseYumCheckUpdateLinesAmazon
--- PASS: TestParseYumCheckUpdateLinesAmazon (0.00s)
=== RUN   TestParseYumUpdateinfoListAvailable
--- PASS: TestParseYumUpdateinfoListAvailable (0.00s)
=== RUN   TestExtractPackNameVerRel
--- PASS: TestExtractPackNameVerRel (0.00s)
=== RUN   TestGetDiffChangelog
--- PASS: TestGetDiffChangelog (0.00s)
=== RUN   TestDivideChangelogsIntoEachPackages
--- PASS: TestDivideChangelogsIntoEachPackages (0.00s)
=== RUN   TestCheckYumPsInstalled
--- PASS: TestCheckYumPsInstalled (0.00s)
=== RUN   TestParseYumPS
--- PASS: TestParseYumPS (0.00s)
=== RUN   TestParseNeedsRestarting
--- PASS: TestParseNeedsRestarting (0.00s)
=== RUN   TestIsExecScanUsingYum
--- PASS: TestIsExecScanUsingYum (0.00s)
=== RUN   TestIsExecFillChangelogs
--- PASS: TestIsExecFillChangelogs (0.00s)
=== RUN   TestIsScanChangelogs
--- PASS: TestIsScanChangelogs (0.00s)
=== RUN   TestViaHTTP
--- PASS: TestViaHTTP (0.00s)
=== RUN   TestScanUpdatablePackages
--- PASS: TestScanUpdatablePackages (0.00s)
=== RUN   TestScanUpdatablePackage
--- PASS: TestScanUpdatablePackage (0.00s)
=== RUN   TestParseOSRelease
--- PASS: TestParseOSRelease (0.00s)
=== RUN   TestIsRunningKernelSUSE
--- PASS: TestIsRunningKernelSUSE (0.00s)
=== RUN   TestIsRunningKernelRedHatLikeLinux
--- PASS: TestIsRunningKernelRedHatLikeLinux (0.00s)
PASS
coverage: 25.2% of statements
ok  	github.com/future-architect/vuls/scan	0.040s	coverage: 25.2% of statements
?   	github.com/future-architect/vuls/server	[no test files]
=== RUN   TestUrlJoin
--- PASS: TestUrlJoin (0.00s)
=== RUN   TestPrependHTTPProxyEnv
--- PASS: TestPrependHTTPProxyEnv (0.00s)
=== RUN   TestTruncate
--- PASS: TestTruncate (0.00s)
PASS
coverage: 28.0% of statements
ok  	github.com/future-architect/vuls/util	0.005s	coverage: 28.0% of statements
testing: warning: no tests to run
PASS
coverage: 0.0% of statements
ok  	github.com/future-architect/vuls/wordpress	0.008s	coverage: 0.0% of statements [no tests to run]
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Enable "Allow edits from maintainers" for this PR

***Is this ready for review?:*** YES