### PR TITLE
fix(report): WordPress(WPVULNDB API) 429 Too Many Requests

### DIFF
--- a/wordpress/wordpress.go
+++ b/wordpress/wordpress.go
@@ -263,17 +263,17 @@ loop:
 		return "", err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 && resp.StatusCode != 404 && resp.StatusCode != 429 && (resp.StatusCode == 429 && retry > 3) {
-		return "", xerrors.Errorf("status: %s", resp.Status)
+	if resp.StatusCode == 200 {
+		return string(body), nil
 	} else if resp.StatusCode == 404 {
 		// This package is not in WPVulnDB
 		return "", nil
-	} else if resp.StatusCode == 429 {
+	} else if resp.StatusCode == 429 && retry <= 3 {
 		// 429 Too Many Requests
 		util.Log.Debugf("sleep %d min(s): %s", retry, resp.Status)
 		time.Sleep(time.Duration(retry) * time.Minute)
 		retry++
 		goto loop
 	}
-	return string(body), nil
+	return "", err
 }


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

WPVULNDB API often says "429 Too Many Requests".
If vuls report got 429, sleep 1 min and try again. vuls report give up over 3 times retry.

Fixes # (issue)

NO

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

I tested in HEAD of master branch.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

https://vuls-github.slack.com/archives/C0VTPKS3T/p1559186059012100
