### PR TITLE
update goval-dictionary dependency to valid version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kotakanbe/go-cve-dictionary v0.0.0-20190327053454-5fe52611f0b8
 	github.com/kotakanbe/go-pingscanner v0.1.0
-	github.com/kotakanbe/goval-dictionary v0.1.3-0.20190613053258-8b98657de17d
+	github.com/kotakanbe/goval-dictionary v0.1.3-0.20190613053258-078b163b76ec
 	github.com/kotakanbe/logrus-prefixed-formatter v0.0.0-20180123152602-928f7356cb96
 	github.com/kr/pty v1.1.5 // indirect
 	github.com/labstack/echo v3.3.10+incompatible // indirect


### PR DESCRIPTION
# What did you implement:

Updated `go.mod` to use valid version of goval-dictionary -- v0.1.3-0.20190613053258-078b163b76ec

Fixes #838

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
make install
make test

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** Yes

