### PR TITLE
Changes that don't require config.toml in server mode

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -94,8 +94,7 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.Conf.DebugSQL, "debug-sql", false, "SQL debug mode")
 
 	wd, _ := os.Getwd()
-	defaultConfPath := filepath.Join(wd, "config.toml")
-	f.StringVar(&p.configPath, "config", defaultConfPath, "/path/to/toml")
+	f.StringVar(&p.configPath, "config", "", "/path/to/toml")
 
 	defaultResultsDir := filepath.Join(wd, "results")
 	f.StringVar(&c.Conf.ResultsDir, "results-dir", defaultResultsDir, "/path/to/results")
@@ -151,9 +150,11 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	util.Log = util.NewCustomLogger(c.ServerInfo{})
 	cvelog.SetLogger(c.Conf.LogDir, false, c.Conf.Debug, false)
 
-	if err := c.Load(p.configPath, ""); err != nil {
-		util.Log.Errorf("Error loading %s. err: %+v", p.configPath, err)
-		return subcommands.ExitUsageError
+	if p.configPath != "" {
+		if err := c.Load(p.configPath, ""); err != nil {
+			util.Log.Errorf("Error loading %s. err: %+v", p.configPath, err)
+			return subcommands.ExitUsageError
+		}
 	}
 
 	c.Conf.CveDict.Overwrite(p.cveDict)


### PR DESCRIPTION
# What did you implement:

Changes that don't require config.toml in server mode.
Change default value of configPath to blank.

#### before
```
$ vuls server -ovaldb-type=redis -ovaldb-url=redis://localhost:6379 -cvedb-type=redis -cvedb-url=redis://localhost:6379
[Jun 26 14:34:37] ERROR [localhost] Error loading /vuls/config.toml. err: open /vuls/config.toml: no such file or directory
```

#### after
```
$ vuls server -ovaldb-type=redis -ovaldb-url=redis://localhost:6379 -cvedb-type=redis -cvedb-url=redis://localhost:6379
[Jun 26 14:35:32]  INFO [localhost] Validating config...
[Jun 26 14:35:32]  INFO [localhost] Validating db config...
INFO[0000] -cvedb-type: redis, -cvedb-url: redis://localhost:6379, -cvedb-path:
INFO[0000] -ovaldb-type: redis, -ovaldb-url: redis://localhost:6379, -ovaldb-path:
INFO[0000] -gostdb-type: sqlite3, -gostdb-url: , -gostdb-path: /vuls/gost.sqlite3
INFO[0000] -exploitdb-type: sqlite3, -exploitdb-url: , -exploitdb-path: /vuls/go-exploitdb.sqlite3
[Jun 26 14:35:32]  WARN [localhost] --gostdb-path=/vuls/gost.sqlite3 is not found. If the scan target server is Debian, RHEL or CentOS, it's recommended to use gost to improve scanning accuracy. To use gost database, see https://github.com/knqyf263/gost#fetch-redhat
[Jun 26 14:35:32]  WARN [localhost] --exploitdb-path=/vuls/go-exploitdb.sqlite3 is not found. It's recommended to use exploit to improve scanning accuracy. To use exploit db database, see https://github.com/mozqnet/go-exploitdb
[Jun 26 14:35:32]  INFO [localhost] Listening on localhost:551
```

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

```
$ ./vuls server -ovaldb-type=redis -ovaldb-url=redis://localhost:6379 -cvedb-type=redis -cvedb-url=redis://localhost:6379
$ cat amazon2.json | jq . 
{
  "Family": "amazon",
  "Release": "2 (Karoo)",
  "RunningKernel": {
    "Release": "4.14.121-109.96.amzn2.x86_64",
    "Version": ""
  },
  "Packages": {
    "kernel": {
      "Name": "kernel",
      "Version": "4.14.114",
      "Release": "105.126.amzn2",
      "Arch": "x86_64"
    },
    "dracut": {
      "Name": "dracut",
      "Version": "033",
      "Release": "535.amzn2.1.2",
      "Arch": "x86_64"
    }
  }
}

$ curl -X POST -H "Content-Type: application/json" -d @amazon2.json http://localhost:5515/vuls
```

```
$ ./vuls server -config ./config.toml
[Jun 26 15:05:06] ERROR Failed to create log directory. path: /var/log/vuls, err: mkdir /var/log/vuls: permission denied
EROR[06-26|15:05:06] Failed to create log directory           err="mkdir /var/log/vuls: permission denied"
[Jun 26 15:05:06]  INFO [localhost] Validating config...
[Jun 26 15:05:06]  INFO [localhost] Validating db config...
INFO[0000] -cvedb-type: redis, -cvedb-url: redis://localhost:6379, -cvedb-path:
INFO[0000] -ovaldb-type: redis, -ovaldb-url: redis://localhost:6379, -ovaldb-path:
INFO[0000] -gostdb-type: sqlite3, -gostdb-url: , -gostdb-path: /vuls/gost.sqlite3
INFO[0000] -exploitdb-type: sqlite3, -exploitdb-url: , -exploitdb-path: /vuls/go-exploitdb.sqlite3
[Jun 26 15:05:06]  WARN [localhost] --gostdb-path=/vuls/gost.sqlite3 is not found. If the scan target server is Debian, RHEL or CentOS, it's recommended to use gost to improve scanning accuracy. To use gost database, see https://github.com/knqyf263/gost#fetch-redhat
[Jun 26 15:05:06]  WARN [localhost] --exploitdb-path=/vuls/go-exploitdb.sqlite3 is not found. It's recommended to use exploit to improve scanning accuracy. To use exploit db database, see https://github.com/mozqnet/go-exploitdb
[Jun 26 15:05:06]  INFO [localhost] Listening on localhost:5515

$ curl -X POST -H "Content-Type: application/json" -d @amazon2.json http://localhost:5515/vuls
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
