### PR TITLE
Fix race condition in server-mode

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -208,26 +208,7 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 		}
 	}
 
-	dbclient, locked, err := report.NewDBClient(report.DBClientConf{
-		CveDictCnf:  c.Conf.CveDict,
-		OvalDictCnf: c.Conf.OvalDict,
-		GostCnf:     c.Conf.Gost,
-		ExploitCnf:  c.Conf.Exploit,
-		DebugSQL:    c.Conf.DebugSQL,
-	})
-	if locked {
-		util.Log.Errorf("SQLite3 is locked. Close other DB connections and try again: %+v", err)
-		return subcommands.ExitFailure
-	}
-
-	if err != nil {
-		util.Log.Errorf("Failed to init DB Clients. err: %+v", err)
-		return subcommands.ExitFailure
-	}
-
-	defer dbclient.CloseDB()
-
-	http.Handle("/vuls", server.VulsHandler{DBclient: *dbclient})
+	http.Handle("/vuls", server.VulsHandler{})
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "ok")
 	})


### PR DESCRIPTION
# What did you implement:

I fixed the bug of race condition in vuls server-mode.

The server-mode runs report.NewDBClient only once the first time.
NewDBClient returns multiple DBs.

At this time, internally execute github.com/kotakanbe/go-cve-dictionary/db.NewDB which returns driver.
After this, The server-mode always execute functions such as NewOvalDB for the same driver .

This driver has the family property (e.g. d. Ovaldb).
After that, server-mode always executes functions like NewOvalDB for the same driver.
So, when a request from different OS is made asynchronously, ovaldb is rewritten.

I added below log in goval-dictionary/db/redis.go. 
```
func (d *RedisDriver) NewOvalDB(family string) error {
        fmt.Println("Call NewOvalDB")
        fmt.Printf("Pre NewOvalDB: %s\n", family)
        switch family {
        case c.CentOS:
                d.ovaldb = c.RedHat
        case c.Debian, c.Ubuntu, c.RedHat, c.Oracle,
                c.OpenSUSE, c.OpenSUSELeap, c.SUSEEnterpriseServer,
                c.SUSEEnterpriseDesktop, c.SUSEOpenstackCloud,
                c.Alpine, c.Amazon:

                d.ovaldb = family
        default:
                if strings.Contains(family, "suse") {
                        suses := []string{
                                c.OpenSUSE,
                                c.OpenSUSELeap,
                                c.SUSEEnterpriseServer,
                                c.SUSEEnterpriseDesktop,
                                c.SUSEOpenstackCloud,
                        }
                        return fmt.Errorf("Unknown SUSE. Specify from %s: %s", suses, family)
                }
                return fmt.Errorf("Unknown OS Type: %s", family)
        }
        fmt.Printf("Pro NewOvalDB: %s\n", family)
        return nil
}
```

Below execute log.

```
# First request after run the server-mode
Call NewOvalDB
Pre NewOvalDB: 
Pro NewOvalDB: redhat
・
・
・
# Second and subsequent requests after running server mode
Call NewOvalDB
Pre NewOvalDB: redhat
Pro NewOvalDB: ubuntu
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

I wrote PoC. 
https://github.com/masahiro331/vuls_racecondition

I checked using PoC before and after the pull request.
Using DBs: Redis, Sqlite3 and postgresql.

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:***  Yes

