### PR TITLE
Add ips flag to scan

### DIFF
--- a/commands/scan.go
+++ b/commands/scan.go
@@ -66,6 +66,8 @@ func (*ScanCmd) Usage() string {
 		[-debug]
 		[-pipe]
 		[-vvv]
+		[-detect-ips]
+
 
 		[SERVER]...
 `
@@ -112,6 +114,8 @@ func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 	)
 
 	f.BoolVar(&c.Conf.Pipe, "pipe", false, "Use stdin via PIPE")
+
+	f.BoolVar(&c.Conf.DetectIPS, "ips", false, "retrieve IPS information")
 	f.BoolVar(&c.Conf.Vvv, "vvv", false, "ssh -vvv")
 
 	f.IntVar(&p.timeoutSec, "timeout", 5*60,

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -66,7 +66,7 @@ func (*ScanCmd) Usage() string {
 		[-debug]
 		[-pipe]
 		[-vvv]
-		[-detect-ips]
+		[-ips]
 
 
 		[SERVER]...

--- a/config/config.go
+++ b/config/config.go
@@ -123,6 +123,7 @@ type Config struct {
 	CacheDBPath    string `json:"cacheDBPath,omitempty"`
 	Vvv            bool   `json:"vvv,omitempty"`
 	UUID           bool   `json:"uuid,omitempty"`
+	DetectIPS      bool   `json:"detectIps,omitempty"`
 
 	CveDict  GoCveDictConf `json:"cveDict,omitempty"`
 	OvalDict GovalDictConf `json:"ovalDict,omitempty"`

--- a/scan/base.go
+++ b/scan/base.go
@@ -356,6 +356,10 @@ func (l *base) detectDeepSecurity() (fingerprint string, err error) {
 }
 
 func (l *base) detectIPSs() {
+	if !config.Conf.DetectIPS {
+		return
+	}
+
 	ips := map[config.IPS]string{}
 
 	fingerprint, err := l.detectDeepSecurity()


### PR DESCRIPTION
# What did you implement:

Add `-ips` option to scan cmd. 
This option retrieve ips's server information.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

