### PR TITLE
fix(scan): allow exit 1 for no match `lsof | grep`

### DIFF
--- a/scan/base.go
+++ b/scan/base.go
@@ -789,7 +789,7 @@ func (l *base) parseGrepProcMap(stdout string) (soPaths []string) {
 func (l *base) lsOfListen() (stdout string, err error) {
 	cmd := `lsof -i -P -n | grep LISTEN`
 	r := l.exec(util.PrependProxyEnv(cmd), sudo)
-	if !r.isSuccess() {
+	if !r.isSuccess(0, 1) {
 		return "", xerrors.Errorf("Failed to SSH: %s", r)
 	}
 	return r.Stdout, nil


### PR DESCRIPTION
#What did you implement:

Avoid warning
```
[Jul  6 10:10:13]  WARN [localhost] Warning: Some warnings occurred while scanning on localhost: [Failed to dpkg-ps:
    github.com/future-architect/vuls/scan.(*debian).postScan
        /root/go/src/github.com/future-architect/vuls/scan/debian.go:270
  - Failed to ls of:
    github.com/future-architect/vuls/scan.(*debian).dpkgPs
        /root/go/src/github.com/future-architect/vuls/scan/debian.go:1159
  - Failed to SSH: execResult: servername: 
      cmd: lsof -i -P -n | grep LISTEN
      exitstatus: 1
      stdout: 
      stderr: 
      err: exit status 1:
    github.com/future-architect/vuls/scan.(*base).lsOfListen
        /root/go/src/github.com/future-architect/vuls/scan/base.go:793 Failed to scan need-restarting processes:
    github.com/future-architect/vuls/scan.(*debian).postScan
        /root/go/src/github.com/future-architect/vuls/scan/debian.go:279
  - Failed to LANGUAGE=en_US.UTF-8 checkrestart. status: 127, stdout: , stderr: /bin/sh: 1: checkrestart: not found:
    github.com/future-architect/vuls/scan.(*debian).checkrestart
        /root/go/src/github.com/future-architect/vuls/scan/debian.go:993]
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
