### PR TITLE
Fix performance and bug

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -208,7 +208,26 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 		}
 	}
 
-	http.Handle("/vuls", server.VulsHandler{})
+	dbclient, locked, err := report.NewDBClient(report.DBClientConf{
+		CveDictCnf:  c.Conf.CveDict,
+		OvalDictCnf: c.Conf.OvalDict,
+		GostCnf:     c.Conf.Gost,
+		ExploitCnf:  c.Conf.Exploit,
+		DebugSQL:    c.Conf.DebugSQL,
+	})
+	if locked {
+		util.Log.Errorf("SQLite3 is locked. Close other DB connections and try again: %+v", err)
+		return subcommands.ExitFailure
+	}
+
+	if err != nil {
+		util.Log.Errorf("Failed to init DB Clients. err: %+v", err)
+		return subcommands.ExitFailure
+	}
+
+	defer dbclient.CloseDB()
+
+	http.Handle("/vuls", server.VulsHandler{DBclient: *dbclient})
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "ok")
 	})

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/knqyf263/trivy v0.1.4
 	github.com/kotakanbe/go-cve-dictionary v0.0.0-20190327053454-5fe52611f0b8
 	github.com/kotakanbe/go-pingscanner v0.1.0
-	github.com/kotakanbe/goval-dictionary v0.1.4
+	github.com/kotakanbe/goval-dictionary v0.2.0
 	github.com/kotakanbe/logrus-prefixed-formatter v0.0.0-20180123152602-928f7356cb96
 	github.com/lusis/go-slackbot v0.0.0-20180109053408-401027ccfef5 // indirect
 	github.com/lusis/slack-test v0.0.0-20190426140909-c40012f20018 // indirect

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,6 @@ github.com/kotakanbe/go-cve-dictionary v0.0.0-20190327053454-5fe52611f0b8 h1:0zo
 github.com/kotakanbe/go-cve-dictionary v0.0.0-20190327053454-5fe52611f0b8/go.mod h1:CNVaCVSeqjxCFQm93uCWPT8mR+a0514XHiiBJx9yrkQ=
 github.com/kotakanbe/go-pingscanner v0.1.0 h1:VG4/9l0i8WeToXclj7bIGoAZAu7a07Z3qmQiIfU0gT0=
 github.com/kotakanbe/go-pingscanner v0.1.0/go.mod h1:/761QZzuZFcfN8h/1QuawUA+pKukp3qcNj5mxJCOiAk=
-github.com/kotakanbe/goval-dictionary v0.1.4 h1:X0B9fCb9ogaVvHfJCvJwyOLNWiAHdkDD9tQA3GtuLGw=
-github.com/kotakanbe/goval-dictionary v0.1.4/go.mod h1:VupP39J8370MdBkmvQQVmuYf98VrcQzhiGo+UiNW4rs=
 github.com/kotakanbe/goval-dictionary v0.2.0 h1:Yq2F4ee+oLUWRGOzuptV1v5mIq43mahYPbVENocBlyI=
 github.com/kotakanbe/goval-dictionary v0.2.0/go.mod h1:VupP39J8370MdBkmvQQVmuYf98VrcQzhiGo+UiNW4rs=
 github.com/kotakanbe/logrus-prefixed-formatter v0.0.0-20180123152602-928f7356cb96 h1:xNVK0mQJdQjw+QYeaMM4G6fvucWr8rTGGIhlPakx1wU=

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/kotakanbe/go-pingscanner v0.1.0 h1:VG4/9l0i8WeToXclj7bIGoAZAu7a07Z3qm
 github.com/kotakanbe/go-pingscanner v0.1.0/go.mod h1:/761QZzuZFcfN8h/1QuawUA+pKukp3qcNj5mxJCOiAk=
 github.com/kotakanbe/goval-dictionary v0.1.4 h1:X0B9fCb9ogaVvHfJCvJwyOLNWiAHdkDD9tQA3GtuLGw=
 github.com/kotakanbe/goval-dictionary v0.1.4/go.mod h1:VupP39J8370MdBkmvQQVmuYf98VrcQzhiGo+UiNW4rs=
+github.com/kotakanbe/goval-dictionary v0.2.0 h1:Yq2F4ee+oLUWRGOzuptV1v5mIq43mahYPbVENocBlyI=
+github.com/kotakanbe/goval-dictionary v0.2.0/go.mod h1:VupP39J8370MdBkmvQQVmuYf98VrcQzhiGo+UiNW4rs=
 github.com/kotakanbe/logrus-prefixed-formatter v0.0.0-20180123152602-928f7356cb96 h1:xNVK0mQJdQjw+QYeaMM4G6fvucWr8rTGGIhlPakx1wU=
 github.com/kotakanbe/logrus-prefixed-formatter v0.0.0-20180123152602-928f7356cb96/go.mod h1:ljq48H1V+0Vh0u7ucA3LjR4AfkAeCpxrf7LaaCk8Vmo=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -152,7 +152,7 @@ func (o RedHatBase) update(r *models.ScanResult, defPacks defPacks) (nCVEs int) 
 
 func (o RedHatBase) convertToDistroAdvisory(def *ovalmodels.Definition) *models.DistroAdvisory {
 	advisoryID := def.Title
-	if o.family == config.RedHat || o.family == config.CentOS {
+	if (o.family == config.RedHat || o.family == config.CentOS) && len(advisoryID) > 0 {
 		ss := strings.Fields(def.Title)
 		advisoryID = strings.TrimSuffix(ss[0], ":")
 	}

--- a/oval/util.go
+++ b/oval/util.go
@@ -238,7 +238,7 @@ func getDefsByPackNameFromOvalDB(driver db.DB, r *models.ScanResult) (relatedDef
 	}
 
 	for _, req := range requests {
-		definitions, err := driver.GetByPackName(r.Release, req.packName, req.arch)
+		definitions, err := driver.GetByPackName(r.Family, r.Release, req.packName, req.arch)
 		if err != nil {
 			return relatedDefs, xerrors.Errorf("Failed to get %s OVAL info by package: %#v, err: %w", r.Family, req, err)
 		}


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

1. Fix performance. 

Fix the performance degradation introduced by this PR.
https://github.com/future-architect/vuls/pull/857

This PR needs to update go.mod after https://github.com/kotakanbe/goval-dictionary/pull/73/ is merged.

2. Fix bug

```
[Jul  9 19:24:18]  INFO [localhost] : 0 CVEs are detected with Library
[Jul  9 19:24:18]  INFO [localhost] OVAL is fresh: redhat 6.5-x86_64
2019/07/09 19:24:18 http: panic serving 127.0.0.1:55532: runtime error: index out of range
goroutine 154 [running]:
net/http.(*conn).serve.func1(0xc000860000)
	/usr/local/Cellar/go/1.12.4/libexec/src/net/http/server.go:1769 +0x139
panic(0x51c10e0, 0x64e2980)
	/usr/local/Cellar/go/1.12.4/libexec/src/runtime/panic.go:522 +0x1b5
github.com/future-architect/vuls/oval.RedHatBase.convertToDistroAdvisory(0x53b9ac4, 0x6, 0xc001072790, 0xc0008baf90)
	/Users/01025026/work/go/src/github.com/future-architect/vuls/oval/redhat.go:157 +0x29a
github.com/future-architect/vuls/oval.RedHatBase.update(0x53b9ac4, 0x6, 0xc000876000, 0x0, 0x0, 0xc000e920f0, 0x21, 0x0, 0x0, 0x0, ...)
	/Users/01025026/work/go/src/github.com/future-architect/vuls/oval/redhat.go:136 +0x75a
github.com/future-architect/vuls/oval.RedHatBase.FillWithOval(0x53b9ac4, 0x6, 0x57be840, 0xc0006557d0, 0xc000876000, 0x510f301, 0x0, 0x0)
	/Users/01025026/work/go/src/github.com/future-architect/vuls/oval/redhat.go:51 +0x17d
github.com/future-architect/vuls/report.FillWithOval(0x57be840, 0xc0006557d0, 0xc000876000, 0xc001074680, 0x2, 0x2)
	/Users/01025026/work/go/src/github.com/future-architect/vuls/report/report.go:336 +0x44c
github.com/future-architect/vuls/report.FillCveInfo(0x57c6660, 0xc00073e500, 0x57be840, 0xc0006557d0, 0x0, 0x0, 0x0, 0x0, 0xc000876000, 0x65332e0, ...)
	/Users/01025026/work/go/src/github.com/future-architect/vuls/report/report.go:175 +0x277
github.com/future-architect/vuls/server.VulsHandler.ServeHTTP(0x57a3b80, 0xc000714460, 0xc000864000)
	/Users/01025026/work/go/src/github.com/future-architect/vuls/server/server.go:91 +0x94e
net/http.(*ServeMux).ServeHTTP(0x6513a20, 0x57a3b80, 0xc000714460, 0xc000864000)
	/usr/local/Cellar/go/1.12.4/libexec/src/net/http/server.go:2375 +0x1d6
net/http.serverHandler.ServeHTTP(0xc0000f7790, 0x57a3b80, 0xc000714460, 0xc000864000)
	/usr/local/Cellar/go/1.12.4/libexec/src/net/http/server.go:2774 +0xa8
net/http.(*conn).serve(0xc000860000, 0x57ac800, 0xc00051d600)
	/usr/local/Cellar/go/1.12.4/libexec/src/net/http/server.go:1878 +0x851
created by net/http.(*Server).Serve
	/usr/local/Cellar/go/1.12.4/libexec/src/net/http/server.go:2884 +0x2f4
```

Inserting redhat's oval with --no-detail option to db will panic the Title because it does not exist.
https://github.com/future-architect/vuls/blob/master/oval/redhat.go#L155-L158

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

We have tested server mode.
OVAL used was redhat, ubuntu, oracle, amazon

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

