### PR TITLE
fix centos yum makecache --assumeyes

### DIFF
--- a/scan/redhatbase.go
+++ b/scan/redhatbase.go
@@ -351,9 +351,9 @@ func (o *redhatBase) parseInstalledPackagesLine(line string) (models.Package, er
 }
 
 func (o *redhatBase) yumMakeCache() error {
-	cmd := `yum makecache`
+	cmd := `yum makecache --assumeyes`
 	r := o.exec(util.PrependProxyEnv(cmd), o.sudo.yumMakeCache())
-	if !r.isSuccess() {
+	if !r.isSuccess(0, 1) {
 		return xerrors.Errorf("Failed to SSH: %s", r)
 	}
 	return nil


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

This patch fixed yum makecache gpg check to skip which unuse --nopgpcheck, use --assumeyes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Format your source code by `make fmt`

