### PR TITLE
Add quiet option to remove warning messages to output file

### DIFF
--- a/commands/report.go
+++ b/commands/report.go
@@ -87,6 +87,7 @@ func (*ReportCmd) Usage() string {
 		[-http-proxy=http://192.168.0.1:8080]
 		[-debug]
 		[-debug-sql]
+		[-quiet]
 		[-pipe]
 		[-cvedb-type=sqlite3|mysql|postgres|redis|http]
 		[-cvedb-sqlite3-path=/path/to/cve.sqlite3]
@@ -111,6 +112,8 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&c.Conf.Lang, "lang", "en", "[en|ja]")
 	f.BoolVar(&c.Conf.Debug, "debug", false, "debug mode")
 	f.BoolVar(&c.Conf.DebugSQL, "debug-sql", false, "SQL debug mode")
+
+	f.BoolVar(&c.Conf.Quiet, "quiet", false, "Log only to file")
 
 	wd, _ := os.Getwd()
 	defaultConfPath := filepath.Join(wd, "config.toml")

--- a/config/config.go
+++ b/config/config.go
@@ -106,6 +106,7 @@ type Config struct {
 	LogDir     string `json:"logDir,omitempty"`
 	ResultsDir string `json:"resultsDir,omitempty"`
 	Pipe       bool   `json:"pipe,omitempty"`
+	Quiet      bool   `json:"quiet,omitempty"`
 
 	Default       ServerInfo            `json:"default,omitempty"`
 	Servers       map[string]ServerInfo `json:"servers,omitempty"`

--- a/report/util.go
+++ b/report/util.go
@@ -69,8 +69,14 @@ func formatScanSummary(rs ...models.ScanResult) string {
 				r.FormatServerName(), r.Warnings))
 		}
 	}
-	return fmt.Sprintf("%s\n\n%s", table, strings.Join(
+
+	// We don't want warning message to the summary file
+	if config.Conf.Quiet {
+		return fmt.Sprintf("%s\n", table)
+	} else {
+		return fmt.Sprintf("%s\n\n%s", table, strings.Join(
 		warnMsgs, "\n\n"))
+	}
 }
 
 func formatOneLineSummary(rs ...models.ScanResult) string {

--- a/report/util.go
+++ b/report/util.go
@@ -75,7 +75,7 @@ func formatScanSummary(rs ...models.ScanResult) string {
 		return fmt.Sprintf("%s\n", table)
 	} else {
 		return fmt.Sprintf("%s\n\n%s", table, strings.Join(
-		warnMsgs, "\n\n"))
+			warnMsgs, "\n\n"))
 	}
 }
 

--- a/scan/base.go
+++ b/scan/base.go
@@ -729,7 +729,7 @@ func (l *base) detectWpPlugins() ([]models.WpPackage, error) {
 }
 
 func (l *base) ps() (stdout string, err error) {
-	cmd := `LANGUAGE=en_US.UTF-8 ps --no-headers --ppid 2 -p 2 --deselect -o pid,comm | awk '{print $1,$2}'`
+	cmd := `LANGUAGE=en_US.UTF-8 ps --no-headers --ppid 2 -p 2 --deselect -o pid,comm`
 	r := l.exec(util.PrependProxyEnv(cmd), noSudo)
 	if !r.isSuccess() {
 		return "", xerrors.Errorf("Failed to SSH: %s", r)

--- a/util/logutil.go
+++ b/util/logutil.go
@@ -44,7 +44,6 @@ func init() {
 func NewCustomLogger(c config.ServerInfo) *logrus.Entry {
 	log := logrus.New()
 	log.Formatter = &formatter.TextFormatter{MsgAnsiColor: c.LogMsgAnsiColor}
-	log.Out = os.Stderr
 	log.Level = logrus.InfoLevel
 	if config.Conf.Debug {
 		log.Level = logrus.DebugLevel
@@ -60,6 +59,18 @@ func NewCustomLogger(c config.ServerInfo) *logrus.Entry {
 		if err := os.Mkdir(logDir, 0700); err != nil {
 			log.Errorf("Failed to create log directory. path: %s, err: %s", logDir, err)
 		}
+	}
+
+	// Only log to a file if quiet mode enabled
+	if config.Conf.Quiet {
+		logFile := logDir+"/vuls.log"
+		if file, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err == nil {
+			log.Out = file
+		} else {
+			log.Errorf("Failed to create log file. path: %s, err: %s", logFile, err)
+		}
+	} else {
+		log.Out = os.Stderr
 	}
 
 	whereami := "localhost"

--- a/util/logutil.go
+++ b/util/logutil.go
@@ -63,7 +63,7 @@ func NewCustomLogger(c config.ServerInfo) *logrus.Entry {
 
 	// Only log to a file if quiet mode enabled
 	if config.Conf.Quiet {
-		logFile := logDir+"/vuls.log"
+		logFile := logDir + "/vuls.log"
 		if file, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err == nil {
 			log.Out = file
 		} else {


### PR DESCRIPTION
# What did you implement:

When there are one or more warnings during the scan, they appear in the report especially in the file "summary.txt" (with the option "-to-localfile").
I want to parse the content of this file to process the results of the scan. With warnings the parsing is more complicated. Furthermore errors and warnings appear in the logs. So, we don't need warning in this file.

We keep track of the errors and warnings with the command scan, but we could remove them from the command report.

So I added an option -quiet to force logging to a file instead of stdout.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

In my case, warnings appear when I scan a Debian container because checkrestart ins't available (for example). Use -quiet option when there are warnings during your scan, with the option -to-localfile and you would see that there aren't warnings in the file (juste results of the scan).

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
