### PR TITLE
feat(scan): add -wordpress-only and -libs-only flag

### DIFF
--- a/commands/scan.go
+++ b/commands/scan.go
@@ -58,6 +58,9 @@ func (*ScanCmd) Usage() string {
 		[-ssh-native-insecure]
 		[-ssh-config]
 		[-containers-only]
+		[-images-only]
+		[-libs-only]
+		[-wordpress-only]
 		[-skip-broken]
 		[-http-proxy=http://192.168.0.1:8080]
 		[-ask-key-password]
@@ -102,6 +105,12 @@ func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&c.Conf.ImagesOnly, "images-only", false,
 		"Scan container images only. Default: Scan both of hosts and images")
+
+	f.BoolVar(&c.Conf.LibsOnly, "libs-only", false,
+		"Scan libraries (lock files) specified in config.toml only.")
+
+	f.BoolVar(&c.Conf.WordPressOnly, "wordpress-only", false,
+		"Scan WordPress only.")
 
 	f.BoolVar(&c.Conf.SkipBroken, "skip-broken", false,
 		"[For CentOS] yum update changelog with --skip-broken option")

--- a/config/config.go
+++ b/config/config.go
@@ -27,8 +27,8 @@ import (
 	"strings"
 
 	syslog "github.com/RackSec/srslog"
-	valid "github.com/asaskevich/govalidator"
 	"github.com/aquasecurity/fanal/types"
+	valid "github.com/asaskevich/govalidator"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
 )
@@ -116,15 +116,19 @@ type Config struct {
 	IgnoreUnfixed         bool `json:"ignoreUnfixed,omitempty"`
 	IgnoreGitHubDismissed bool `json:"ignore_git_hub_dismissed,omitempty"`
 
-	SSHNative      bool   `json:"sshNative,omitempty"`
-	SSHConfig      bool   `json:"sshConfig,omitempty"`
-	ContainersOnly bool   `json:"containersOnly,omitempty"`
-	ImagesOnly     bool   `json:"imagesOnly,omitempty"`
-	SkipBroken     bool   `json:"skipBroken,omitempty"`
-	CacheDBPath    string `json:"cacheDBPath,omitempty"`
-	Vvv            bool   `json:"vvv,omitempty"`
-	UUID           bool   `json:"uuid,omitempty"`
-	DetectIPS      bool   `json:"detectIps,omitempty"`
+	SSHNative bool `json:"sshNative,omitempty"`
+	SSHConfig bool `json:"sshConfig,omitempty"`
+
+	ContainersOnly bool `json:"containersOnly,omitempty"`
+	ImagesOnly     bool `json:"imagesOnly,omitempty"`
+	LibsOnly       bool `json:"libsOnly,omitempty"`
+	WordPressOnly  bool `json:"wordpressOnly,omitempty"`
+
+	SkipBroken  bool   `json:"skipBroken,omitempty"`
+	CacheDBPath string `json:"cacheDBPath,omitempty"`
+	Vvv         bool   `json:"vvv,omitempty"`
+	UUID        bool   `json:"uuid,omitempty"`
+	DetectIPS   bool   `json:"detectIps,omitempty"`
 
 	CveDict  GoCveDictConf `json:"cveDict,omitempty"`
 	OvalDict GovalDictConf `json:"ovalDict,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/hashicorp/uuid v0.0.0-20160311170451-ebb0a03e909c
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c
 	github.com/jroimartin/gocui v0.4.0
+	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/k0kubun/pp v3.0.1+incompatible
 	github.com/knqyf263/go-cpe v0.0.0-20180327054844-659663f6eca2
 	github.com/knqyf263/go-deb-version v0.0.0-20190517075300-09fca494f03d

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,7 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
 github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
@@ -189,6 +190,8 @@ github.com/jroimartin/gocui v0.4.0 h1:52jnalstgmc25FmtGcWqa0tcbMEWS6RpFLsOIO+I+E
 github.com/jroimartin/gocui v0.4.0/go.mod h1:7i7bbj99OgFHzo7kB2zPb8pXLqMBSQegY7azfqXMkyY=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 h1:uC1QfSlInpQF+M0ao65imhwqKnz3Q2z/d8PWZRMQvDM=
+github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/k0kubun/pp v3.0.1+incompatible h1:3tqvf7QgUnZ5tXO6pNAZlrvHgl6DvifjDrd9g2S9Z40=
 github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e h1:RgQk53JHp/Cjunrr1WlsXSZpqXn+uREuHvUVcK82CV8=
@@ -292,6 +295,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
@@ -344,6 +348,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tealeg/xlsx v1.0.3/go.mod h1:uxu5UY2ovkuRPWKQ8Q7JG0JbSivrISjdPzZQKeo74mA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/models/library.go
+++ b/models/library.go
@@ -3,9 +3,9 @@ package models
 import (
 	"path/filepath"
 
-	"github.com/future-architect/vuls/util"
 	"github.com/aquasecurity/trivy/pkg/scanner/library"
 	"github.com/aquasecurity/trivy/pkg/vulnsrc/vulnerability"
+	"github.com/future-architect/vuls/util"
 	"golang.org/x/xerrors"
 
 	"github.com/aquasecurity/go-dep-parser/pkg/types"

--- a/report/slack.go
+++ b/report/slack.go
@@ -106,8 +106,8 @@ func (w SlackWriter) Write(rs ...models.ScanResult) (err error) {
 					ThreadTimestamp: ts,
 				}
 				if _, _, err = api.PostMessage(
-					channel, 
-					slack.MsgOptionText("", false), 
+					channel,
+					slack.MsgOptionText("", false),
 					slack.MsgOptionPostMessageParameters(params),
 					slack.MsgOptionAttachments(m[k]...),
 				); err != nil {

--- a/scan/base_test.go
+++ b/scan/base_test.go
@@ -21,14 +21,14 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/future-architect/vuls/config"
 	_ "github.com/aquasecurity/fanal/analyzer/library/bundler"
 	_ "github.com/aquasecurity/fanal/analyzer/library/cargo"
-	_ "github.com/aquasecurity/fanal/analyzer/library/composer" 
+	_ "github.com/aquasecurity/fanal/analyzer/library/composer"
 	_ "github.com/aquasecurity/fanal/analyzer/library/npm"
 	_ "github.com/aquasecurity/fanal/analyzer/library/pipenv"
 	_ "github.com/aquasecurity/fanal/analyzer/library/poetry"
 	_ "github.com/aquasecurity/fanal/analyzer/library/yarn"
+	"github.com/future-architect/vuls/config"
 )
 
 func TestParseDockerPs(t *testing.T) {

--- a/scan/container.go
+++ b/scan/container.go
@@ -25,11 +25,11 @@ import (
 	"github.com/aquasecurity/fanal/analyzer"
 	"golang.org/x/xerrors"
 
+	fanalos "github.com/aquasecurity/fanal/analyzer/os"
+	godeptypes "github.com/aquasecurity/go-dep-parser/pkg/types"
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/models"
 	"github.com/future-architect/vuls/util"
-	fanalos "github.com/aquasecurity/fanal/analyzer/os"
-	godeptypes "github.com/aquasecurity/go-dep-parser/pkg/types"
 
 	// Register library analyzers
 	_ "github.com/aquasecurity/fanal/analyzer/library/bundler"

--- a/scan/serverapi.go
+++ b/scan/serverapi.go
@@ -748,11 +748,16 @@ func setupChangelogCache() error {
 // GetScanResults returns ScanResults from
 func GetScanResults(scannedAt time.Time, timeoutSec int) (results models.ScanResults, err error) {
 	parallelExec(func(o osTypeInterface) (err error) {
-		if err = o.preCure(); err != nil {
-			return err
-		}
-		if err = o.scanPackages(); err != nil {
-			return err
+		if !(config.Conf.LibsOnly || config.Conf.WordPressOnly) {
+			if err = o.preCure(); err != nil {
+				return err
+			}
+			if err = o.scanPackages(); err != nil {
+				return err
+			}
+			if err = o.postScan(); err != nil {
+				return err
+			}
 		}
 		if err = o.scanWordPress(); err != nil {
 			return xerrors.Errorf("Failed to scan WordPress: %w", err)
@@ -760,7 +765,7 @@ func GetScanResults(scannedAt time.Time, timeoutSec int) (results models.ScanRes
 		if err = o.scanLibraries(); err != nil {
 			return xerrors.Errorf("Failed to scan Library: %w", err)
 		}
-		return o.postScan()
+		return nil
 	}, timeoutSec)
 
 	hostname, _ := os.Hostname()


### PR DESCRIPTION
# What did you implement:

# Add -libs-only flag that doesn't detect OS packages Vulns to the scan command. 
https://vuls.io/docs/en/usage-scan-non-os-packages.html#options

# Add -wordpress-only flag that doesn't detect OS packages Vulns to the scan command. 
https://vuls.io/docs/en/usage-scan-wordpress.html#scan-wordpress-core-plugin-theme

```
$ ./vuls scan -h
scan:
        scan
                [-config=/path/to/config.toml]
                [-results-dir=/path/to/results]
                [-log-dir=/path/to/log]
                [-cachedb-path=/path/to/cache.db]
                [-ssh-native-insecure]
                [-ssh-config]
                [-containers-only]
                [-images-only]
                [-libs-only]
                [-skip-broken]
                [-http-proxy=http://192.168.0.1:8080]
                [-ask-key-password]
                [-timeout=300]
                [-timeout-scan=7200]
                [-debug]
                [-pipe]
                [-vvv]
                [-ips]


                [SERVER]...
  -ask-key-password
        Ask ssh privatekey password before scanning
  -cachedb-path string
        /path/to/cache.db (local cache of changelog for Ubuntu/Debian) (default "/home/ubuntu/go/src/github.com/future-architect/vuls/cache.db")
  -config string
        /path/to/toml (default "/home/ubuntu/go/src/github.com/future-architect/vuls/config.toml")
  -containers-only
        Scan running containers only. Default: Scan both of hosts and running containers
  -debug
        debug mode
  -http-proxy string
        http://proxy-url:port (default: empty)
  -images-only
        Scan container images only. Default: Scan both of hosts and images
  -ips
        retrieve IPS information
  -libs-only
        Scan libraries (lock files) specified in config.toml only.
  -log-dir string
        /path/to/log (default "/var/log/vuls")
  -pipe
        Use stdin via PIPE
  -results-dir string
        /path/to/results (default "/home/ubuntu/go/src/github.com/future-architect/vuls/results")
  -skip-broken
        [For CentOS] yum update changelog with --skip-broken option
  -ssh-config
        Use SSH options specified in ssh_config preferentially
  -ssh-native-insecure
        Use Native Go implementation of SSH. Default: Use the external command
  -timeout int
        Number of seconds for processing other than scan (default 300)
  -timeout-scan int
        Number of seconds for scanning vulnerabilities for all servers (default 7200)
  -vvv
        ssh -vvv
```
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

$ ./vuls scan -libs-only
$ ./vuls scan -wordpress-only

and reporting

# Checklist:
- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES