### PR TITLE
fix(report): show POC, CERT in tui and format-list. use vendor summary over NVD

### DIFF
--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -276,7 +276,7 @@ func (v VulnInfo) Summaries(lang, myFamily string) (values []CveContentStr) {
 		}
 	}
 
-	order := CveContentTypes{Nvd, NvdXML, NewCveContentType(myFamily)}
+	order := CveContentTypes{NewCveContentType(myFamily), Nvd, NvdXML}
 	order = append(order, AllCveContetTypes.Except(append(order, Jvn)...)...)
 	for _, ctype := range order {
 		if cont, found := v.CveContents[ctype]; found && 0 < len(cont.Summary) {
@@ -535,15 +535,15 @@ func (v VulnInfo) AttackVector() string {
 	for _, cnt := range v.CveContents {
 		if strings.HasPrefix(cnt.Cvss2Vector, "AV:N") ||
 			strings.HasPrefix(cnt.Cvss3Vector, "CVSS:3.0/AV:N") {
-			return "N"
+			return "AV:N"
 		} else if strings.HasPrefix(cnt.Cvss2Vector, "AV:A") ||
 			strings.HasPrefix(cnt.Cvss3Vector, "CVSS:3.0/AV:A") {
-			return "A"
+			return "AV:A"
 		} else if strings.HasPrefix(cnt.Cvss2Vector, "AV:L") ||
 			strings.HasPrefix(cnt.Cvss3Vector, "CVSS:3.0/AV:L") {
-			return "L"
+			return "AV:L"
 		} else if strings.HasPrefix(cnt.Cvss3Vector, "CVSS:3.0/AV:P") {
-			return "P"
+			return "AV:P"
 		}
 	}
 	if cont, found := v.CveContents[DebianSecurityTracker]; found {

--- a/models/vulninfos_test.go
+++ b/models/vulninfos_test.go
@@ -144,12 +144,12 @@ func TestSummaries(t *testing.T) {
 					Value: "Title JVN\nSummary JVN",
 				},
 				{
-					Type:  NvdXML,
-					Value: "Summary NVD",
-				},
-				{
 					Type:  RedHat,
 					Value: "Summary RedHat",
+				},
+				{
+					Type:  NvdXML,
+					Value: "Summary NVD",
 				},
 			},
 		},
@@ -178,12 +178,12 @@ func TestSummaries(t *testing.T) {
 			},
 			out: []CveContentStr{
 				{
-					Type:  NvdXML,
-					Value: "Summary NVD",
-				},
-				{
 					Type:  RedHat,
 					Value: "Summary RedHat",
+				},
+				{
+					Type:  NvdXML,
+					Value: "Summary NVD",
 				},
 			},
 		},

--- a/report/tui.go
+++ b/report/tui.go
@@ -622,14 +622,20 @@ func summaryLines(r models.ScanResult) string {
 		pkgNames = append(pkgNames, vinfo.GitHubSecurityAlerts.Names()...)
 		pkgNames = append(pkgNames, vinfo.WpPackageFixStats.Names()...)
 
+		exploits := ""
+		if 0 < len(vinfo.Exploits) {
+			exploits = " POC"
+		}
+
 		var cols []string
 		cols = []string{
 			fmt.Sprintf(indexFormat, i+1),
 			vinfo.CveID,
 			cvssScore + " |",
-			fmt.Sprintf("%1s |", vinfo.AttackVector()),
-			fmt.Sprintf("%7s |", vinfo.PatchStatus(r.Packages)),
+			fmt.Sprintf("%4s |", vinfo.AttackVector()),
+			fmt.Sprintf("%3s |", exploits),
 			fmt.Sprintf("%6s |", vinfo.AlertDict.FormatSource()),
+			fmt.Sprintf("%7s |", vinfo.PatchStatus(r.Packages)),
 			strings.Join(pkgNames, ", "),
 		}
 		icols := make([]interface{}, len(cols))

--- a/report/util.go
+++ b/report/util.go
@@ -139,13 +139,13 @@ No CVE-IDs are found in updatable packages.
 
 		data = append(data, []string{
 			vinfo.CveID,
-			fmt.Sprintf("%7s", vinfo.PatchStatus(r.Packages)),
-			vinfo.AlertDict.FormatSource(),
 			fmt.Sprintf("%4.1f", max),
+			fmt.Sprintf("%5s", vinfo.AttackVector()),
 			// fmt.Sprintf("%4.1f", v2max),
 			// fmt.Sprintf("%4.1f", v3max),
-			fmt.Sprintf("%2s", vinfo.AttackVector()),
 			exploits,
+			vinfo.AlertDict.FormatSource(),
+			fmt.Sprintf("%7s", vinfo.PatchStatus(r.Packages)),
 			link,
 		})
 	}
@@ -154,13 +154,13 @@ No CVE-IDs are found in updatable packages.
 	table := tablewriter.NewWriter(&b)
 	table.SetHeader([]string{
 		"CVE-ID",
-		"Fixed",
-		"CERT",
 		"CVSS",
+		"Attack",
 		// "v3",
 		// "v2",
-		"AV",
 		"PoC",
+		"CERT",
+		"Fixed",
 		"NVD",
 	})
 	table.SetBorder(true)


### PR DESCRIPTION
# What did you implement:

## TUI

- CVE-ID
- CVSS Score
- CVSS Attack Vector
- POC
- US-CERT/JP-CERT
- Fixed
- Pkgs

## ./vuls report -format-list

- CVE-ID
- CVSS Score
- CVSS Attack Vector
- POC
- US-CERT/JP-CERT
- Fixed
- NVD Link


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

./vuls report
./vuls tui

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES