### PR TITLE
fix(tui): enable to exec tui mode without cve.sqlite3

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -315,11 +315,6 @@ func (c Config) ValidateOnTui() bool {
 	if err := validateDB("cvedb", c.CveDict.Type, c.CveDict.SQLite3Path, c.CveDict.URL); err != nil {
 		errs = append(errs, err)
 	}
-	if c.CveDict.Type == "sqlite3" {
-		if _, err := os.Stat(c.CveDict.SQLite3Path); os.IsNotExist(err) {
-			errs = append(errs, xerrors.Errorf("SQLite3 DB path (%s) is not exist: %s", "cvedb", c.CveDict.SQLite3Path))
-		}
-	}
 
 	for _, err := range errs {
 		log.Error(err)


### PR DESCRIPTION
# What did you implement:

fix(tui): enable to exec tui mode without cve.sqlite3

related https://github.com/future-architect/vuls/pull/900

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

./vuls tui with no cve.sqlite3

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES