### PR TITLE
fix(report): ignore exploits of no-cve-id vulns

### DIFF
--- a/exploit/exploit.go
+++ b/exploit/exploit.go
@@ -44,6 +44,9 @@ func FillWithExploit(driver db.DB, r *models.ScanResult) (nExploitCve int, err e
 			return 0, nil
 		}
 		for cveID, vuln := range r.ScannedCves {
+			if cveID == "" {
+				continue
+			}
 			es := driver.GetExploitByCveID(cveID)
 			if len(es) == 0 {
 				continue

--- a/report/tui.go
+++ b/report/tui.go
@@ -624,7 +624,7 @@ func summaryLines(r models.ScanResult) string {
 
 		exploits := ""
 		if 0 < len(vinfo.Exploits) {
-			exploits = " POC"
+			exploits = "POC"
 		}
 
 		var cols []string


### PR DESCRIPTION
# What did you implement:

In the current implementation, `vuls report` fills `All exploits with no CVE-ID` for the detected no-cve-id vulns. (The query is `select * from exploits where cve_id = ""`)
This is a bug. So, don't fill exploits of no-cve-id vulns.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

./vuls report and then check the attack code is not included in the vulnerability without `CVE-ID`

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
