### PR TITLE
fix(scan): ignore wp-cli stderr messages (#825)

### DIFF
--- a/scan/base.go
+++ b/scan/base.go
@@ -670,7 +670,7 @@ func (l *base) detectWpCore() (string, error) {
 }
 
 func (l *base) detectWpThemes() ([]models.WpPackage, error) {
-	cmd := fmt.Sprintf("sudo -u %s -i -- %s theme list --path=%s --format=json --allow-root",
+	cmd := fmt.Sprintf("sudo -u %s -i -- %s theme list --path=%s --format=json --allow-root 2>/dev/null",
 		l.ServerInfo.WordPress.OSUser,
 		l.ServerInfo.WordPress.CmdPath,
 		l.ServerInfo.WordPress.DocRoot)
@@ -691,7 +691,7 @@ func (l *base) detectWpThemes() ([]models.WpPackage, error) {
 }
 
 func (l *base) detectWpPlugins() ([]models.WpPackage, error) {
-	cmd := fmt.Sprintf("sudo -u %s -i -- %s plugin list --path=%s --format=json --allow-root",
+	cmd := fmt.Sprintf("sudo -u %s -i -- %s plugin list --path=%s --format=json --allow-root 2>/dev/null",
 		l.ServerInfo.WordPress.OSUser,
 		l.ServerInfo.WordPress.CmdPath,
 		l.ServerInfo.WordPress.DocRoot)


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

vuls scan failed that wordpress site includes poor theme/plugin.
when wp-cli output stderr, vuls scan can't get only json messages. 

Fixes #825 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I checked to ignore the following messages.

```
Unable to open /SITE1/wordpress/wp-content/wflogs/ips.php for reading and writing.
PHP Warning:  call_user_func_array() expects parameter 1 to be a valid callback, function 'goyahso_change_post_object' not found or invalid function name in /SITE1/wordpress/wp-includes/class-wp-hook.php on line 286
Warning: call_user_func_array() expects parameter 1 to be a valid callback, function 'goyahso_change_post_object' not found or invalid function name in /SITE1/wordpress/wp-includes/class-wp-hook.php on line 286
```

```
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /SITE2/wordpress/wp-includes/pomo/plural-forms.php on line 210
Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /SITE2/wordpress/wp-includes/pomo/plural-forms.php on line 210
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

