### PR TITLE
Fill Red Hat CVE data for all distros

### DIFF
--- a/gost/base.go
+++ b/gost/base.go
@@ -1,0 +1,46 @@
+package gost
+
+import (
+	"golang.org/x/xerrors"
+	"github.com/parnurzeal/gorequest"
+	"net/http"
+	"fmt"
+	cnf "github.com/future-architect/vuls/config"
+	"github.com/knqyf263/gost/db"
+)
+
+
+// Base is a base struct
+type Base struct {
+	family string
+}
+
+// CheckHTTPHealth do health check
+func (b Base) CheckHTTPHealth() error {
+	if !cnf.Conf.Gost.IsFetchViaHTTP() {
+		return nil
+	}
+
+	url := fmt.Sprintf("%s/health", cnf.Conf.Gost.URL)
+	var errs []error
+	var resp *http.Response
+	resp, _, errs = gorequest.New().Get(url).End()
+	//  resp, _, errs = gorequest.New().SetDebug(config.Conf.Debug).Get(url).End()
+	//  resp, _, errs = gorequest.New().Proxy(api.httpProxy).Get(url).End()
+	if 0 < len(errs) || resp == nil || resp.StatusCode != 200 {
+		return xerrors.Errorf("Failed to connect to gost server. url: %s, errs: %w", url, errs)
+	}
+	return nil
+}
+
+// CheckIfGostFetched checks if oval entries are in DB by family, release.
+func (b Base) CheckIfGostFetched(driver db.DB, osFamily string) (fetched bool, err error) {
+	//TODO
+	return true, nil
+}
+
+// CheckIfGostFresh checks if oval entries are fresh enough
+func (b Base) CheckIfGostFresh(driver db.DB, osFamily string) (ok bool, err error) {
+	//TODO
+	return true, nil
+}

--- a/gost/base.go
+++ b/gost/base.go
@@ -1,18 +1,23 @@
 package gost
 
 import (
-	"golang.org/x/xerrors"
-	"github.com/parnurzeal/gorequest"
-	"net/http"
 	"fmt"
 	cnf "github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/models"
 	"github.com/knqyf263/gost/db"
+	"github.com/parnurzeal/gorequest"
+	"golang.org/x/xerrors"
+	"net/http"
 )
-
 
 // Base is a base struct
 type Base struct {
 	family string
+}
+
+// FillCVEsWithRedHat fills cve information that has in Gost
+func (b Base) FillCVEsWithRedHat(driver db.DB, r *models.ScanResult) error {
+	return RedHat{}.fillFixed(driver, r)
 }
 
 // CheckHTTPHealth do health check

--- a/gost/base.go
+++ b/gost/base.go
@@ -12,7 +12,6 @@ import (
 
 // Base is a base struct
 type Base struct {
-	family string
 }
 
 // FillCVEsWithRedHat fills cve information that has in Gost

--- a/gost/base.go
+++ b/gost/base.go
@@ -2,12 +2,13 @@ package gost
 
 import (
 	"fmt"
+	"net/http"
+
 	cnf "github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/models"
 	"github.com/knqyf263/gost/db"
 	"github.com/parnurzeal/gorequest"
 	"golang.org/x/xerrors"
-	"net/http"
 )
 
 // Base is a base struct

--- a/gost/debian.go
+++ b/gost/debian.go
@@ -21,8 +21,8 @@ type packCves struct {
 	cves      []models.CveContent
 }
 
-// FillWithGost fills cve information that has in Gost
-func (deb Debian) FillWithGost(driver db.DB, r *models.ScanResult, _ bool) (nCVEs int, err error) {
+// DetectUnfixed fills cve information that has in Gost
+func (deb Debian) DetectUnfixed(driver db.DB, r *models.ScanResult, _ bool) (nCVEs int, err error) {
 	linuxImage := "linux-image-" + r.RunningKernel.Release
 	// Add linux and set the version of running kernel to search OVAL.
 	if r.Container.ContainerID == "" {

--- a/gost/gost.go
+++ b/gost/gost.go
@@ -8,7 +8,8 @@ import (
 
 // Client is the interface of OVAL client.
 type Client interface {
-	FillWithGost(db.DB, *models.ScanResult, bool) (int, error)
+	DetectUnfixed(db.DB, *models.ScanResult, bool) (int, error)
+	FillCVEsWithRedHat(db.DB, *models.ScanResult) error
 
 	//TODO implement
 	// CheckHTTPHealth() error

--- a/gost/gost.go
+++ b/gost/gost.go
@@ -1,15 +1,9 @@
 package gost
 
 import (
-	"fmt"
-	"net/http"
-	"strings"
-
 	cnf "github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/models"
 	"github.com/knqyf263/gost/db"
-	"github.com/parnurzeal/gorequest"
-	"golang.org/x/xerrors"
 )
 
 // Client is the interface of OVAL client.
@@ -35,53 +29,4 @@ func NewClient(family string) Client {
 	default:
 		return Pseudo{}
 	}
-}
-
-// Base is a base struct
-type Base struct {
-	family string
-}
-
-// CheckHTTPHealth do health check
-func (b Base) CheckHTTPHealth() error {
-	if !cnf.Conf.Gost.IsFetchViaHTTP() {
-		return nil
-	}
-
-	url := fmt.Sprintf("%s/health", cnf.Conf.Gost.URL)
-	var errs []error
-	var resp *http.Response
-	resp, _, errs = gorequest.New().Get(url).End()
-	//  resp, _, errs = gorequest.New().SetDebug(config.Conf.Debug).Get(url).End()
-	//  resp, _, errs = gorequest.New().Proxy(api.httpProxy).Get(url).End()
-	if 0 < len(errs) || resp == nil || resp.StatusCode != 200 {
-		return xerrors.Errorf("Failed to connect to gost server. url: %s, errs: %w", url, errs)
-	}
-	return nil
-}
-
-// CheckIfGostFetched checks if oval entries are in DB by family, release.
-func (b Base) CheckIfGostFetched(driver db.DB, osFamily string) (fetched bool, err error) {
-	//TODO
-	return true, nil
-}
-
-// CheckIfGostFresh checks if oval entries are fresh enough
-func (b Base) CheckIfGostFresh(driver db.DB, osFamily string) (ok bool, err error) {
-	//TODO
-	return true, nil
-}
-
-// Pseudo is Gost client except for RedHat family and Debian
-type Pseudo struct {
-	Base
-}
-
-// FillWithGost fills cve information that has in Gost
-func (pse Pseudo) FillWithGost(driver db.DB, r *models.ScanResult, _ bool) (int, error) {
-	return 0, nil
-}
-
-func major(osVer string) (majorVersion string) {
-	return strings.Split(osVer, ".")[0]
 }

--- a/gost/microsoft.go
+++ b/gost/microsoft.go
@@ -13,8 +13,8 @@ type Microsoft struct {
 	Base
 }
 
-// FillWithGost fills cve information that has in Gost
-func (ms Microsoft) FillWithGost(driver db.DB, r *models.ScanResult, _ bool) (nCVEs int, err error) {
+// DetectUnfixed fills cve information that has in Gost
+func (ms Microsoft) DetectUnfixed(driver db.DB, r *models.ScanResult, _ bool) (nCVEs int, err error) {
 	if driver == nil {
 		return 0, nil
 	}

--- a/gost/pseudo.go
+++ b/gost/pseudo.go
@@ -1,9 +1,9 @@
 package gost
 
 import (
-	"strings"
 	"github.com/future-architect/vuls/models"
 	"github.com/knqyf263/gost/db"
+	"strings"
 )
 
 // Pseudo is Gost client except for RedHat family and Debian
@@ -11,8 +11,8 @@ type Pseudo struct {
 	Base
 }
 
-// FillWithGost fills cve information that has in Gost
-func (pse Pseudo) FillWithGost(driver db.DB, r *models.ScanResult, _ bool) (int, error) {
+// DetectUnfixed fills cve information that has in Gost
+func (pse Pseudo) DetectUnfixed(driver db.DB, r *models.ScanResult, _ bool) (int, error) {
 	return 0, nil
 }
 

--- a/gost/pseudo.go
+++ b/gost/pseudo.go
@@ -1,0 +1,21 @@
+package gost
+
+import (
+	"strings"
+	"github.com/future-architect/vuls/models"
+	"github.com/knqyf263/gost/db"
+)
+
+// Pseudo is Gost client except for RedHat family and Debian
+type Pseudo struct {
+	Base
+}
+
+// FillWithGost fills cve information that has in Gost
+func (pse Pseudo) FillWithGost(driver db.DB, r *models.ScanResult, _ bool) (int, error) {
+	return 0, nil
+}
+
+func major(osVer string) (majorVersion string) {
+	return strings.Split(osVer, ".")[0]
+}

--- a/gost/redhat.go
+++ b/gost/redhat.go
@@ -17,12 +17,9 @@ type RedHat struct {
 	Base
 }
 
-// FillWithGost fills cve information that has in Gost
-func (red RedHat) FillWithGost(driver db.DB, r *models.ScanResult, ignoreWillNotFix bool) (nCVEs int, err error) {
-	if nCVEs, err = red.fillUnfixed(driver, r, ignoreWillNotFix); err != nil {
-		return 0, err
-	}
-	return nCVEs, red.fillFixed(driver, r)
+// DetectUnfixed fills cve information that has in Gost
+func (red RedHat) DetectUnfixed(driver db.DB, r *models.ScanResult, ignoreWillNotFix bool) (nCVEs int, err error) {
+	return red.fillUnfixed(driver, r, ignoreWillNotFix)
 }
 
 func (red RedHat) fillFixed(driver db.DB, r *models.ScanResult) error {

--- a/gost/redhat.go
+++ b/gost/redhat.go
@@ -68,7 +68,7 @@ func (red RedHat) fillFixed(driver db.DB, r *models.ScanResult) error {
 			return nil
 		}
 		for cveID, redCve := range driver.GetRedhatMulti(cveIDs) {
-			if redCve.ID == 0 {
+			if len(redCve.Name) == 0 {
 				continue
 			}
 			cveCont := red.ConvertToModel(&redCve)

--- a/report/report.go
+++ b/report/report.go
@@ -346,7 +346,10 @@ func FillWithGost(driver gostdb.DB, r *models.ScanResult, ignoreWillNotFix bool)
 	gostClient := gost.NewClient(r.Family)
 	// TODO chekc if fetched
 	// TODO chekc if fresh enough
-	return gostClient.FillWithGost(driver, r, ignoreWillNotFix)
+	if nCVEs, err = gostClient.DetectUnfixed(driver, r, ignoreWillNotFix); err != nil {
+		return
+	}
+	return nCVEs, gostClient.FillCVEsWithRedHat(driver, r)
 }
 
 // FillWithExploit fills Exploits with exploit dataabase

--- a/scan/base.go
+++ b/scan/base.go
@@ -670,7 +670,7 @@ func (l *base) detectWpCore() (string, error) {
 }
 
 func (l *base) detectWpThemes() ([]models.WpPackage, error) {
-	cmd := fmt.Sprintf("sudo -u %s -i -- %s theme list --path=%s --format=json --allow-root",
+	cmd := fmt.Sprintf("sudo -u %s -i -- %s theme list --path=%s --format=json --allow-root 2>/dev/null",
 		l.ServerInfo.WordPress.OSUser,
 		l.ServerInfo.WordPress.CmdPath,
 		l.ServerInfo.WordPress.DocRoot)
@@ -691,7 +691,7 @@ func (l *base) detectWpThemes() ([]models.WpPackage, error) {
 }
 
 func (l *base) detectWpPlugins() ([]models.WpPackage, error) {
-	cmd := fmt.Sprintf("sudo -u %s -i -- %s plugin list --path=%s --format=json --allow-root",
+	cmd := fmt.Sprintf("sudo -u %s -i -- %s plugin list --path=%s --format=json --allow-root 2>/dev/null",
 		l.ServerInfo.WordPress.OSUser,
 		l.ServerInfo.WordPress.CmdPath,
 		l.ServerInfo.WordPress.DocRoot)


### PR DESCRIPTION
# What did you implement:

In the current implementation, Vuls fills Red Hat CVE data when the scan target server is RHEL or CentOS. But Red Hat CVE Data is useful for other distros, This P/R fills it on all distros. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
 
tested on Amazon Linux, CentOS.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
