### PR TITLE
fix(config): fix double checking ResultsDir Path

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -177,13 +177,6 @@ func (c Config) ValidateOnConfigtest() bool {
 func (c Config) ValidateOnScan() bool {
 	errs := c.checkSSHKeyExist()
 
-	if len(c.ResultsDir) != 0 {
-		if ok, _ := valid.IsFilePath(c.ResultsDir); !ok {
-			errs = append(errs, xerrors.Errorf(
-				"JSON base directory must be a *Absolute* file path. -results-dir: %s", c.ResultsDir))
-		}
-	}
-
 	if runtime.GOOS == "windows" && !c.SSHNative {
 		errs = append(errs, xerrors.New("-ssh-native-insecure is needed on windows"))
 	}


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Vuls scan checks ResultsDir Path twice.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I execute vuls scan at latest version(v0.9.1 d6e74cc).
```
$ vuls -v
vuls v0.9.1 build-20191209_233537_d6e74cc
$ vuls scan -results-dir=vuls
[Dec  9 22:40:35]  INFO [localhost] Start scanning
[Dec  9 22:40:35]  INFO [localhost] config: /Users/vuls/config.toml
[Dec  9 22:40:35]  INFO [localhost] Validating config...
ERRO[0000] JSON base directory must be a *Absolute* file path. -results-dir: vuls 
ERRO[0000] JSON base directory must be a *Absolute* file path. -results-dir: vuls
$
```

I execute vuls scan at fixed version(2cdb7bf).
```
$ vuls -v
vuls v0.9.1 build-20191209_234102_2cdb7bf
$ vuls scan -results-dir=vuls
[Dec  9 23:09:37]  INFO [localhost] Start scanning
[Dec  9 23:09:37]  INFO [localhost] config: /Users/vuls/config.toml
[Dec  9 23:09:37]  INFO [localhost] Validating config...
ERRO[0000] JSON base directory must be a *Absolute* file path. -results-dir: vuls 
$ 
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** Yes

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

