### PR TITLE
Set ReportedAt as time.Now

### DIFF
--- a/scan/serverapi.go
+++ b/scan/serverapi.go
@@ -700,6 +700,7 @@ func ViaHTTP(header http.Header, body string) (models.ScanResult, error) {
 		Packages:    installedPackages,
 		SrcPackages: srcPackages,
 		ScannedCves: models.VulnInfos{},
+		ReportedAt: time.Now(),
 	}
 
 	return result, nil


### PR DESCRIPTION
This will fix the issue, because ReportedAt was not set.(https://github.com/future-architect/vuls/issues/928)

# What did you implement:
Results are stored, but can't be used with vulsrepo because "reportedAt" -timestamp is left initial value ("0001-01-01T00:00:00Z"). 

I set ReportedAt as time.Now()

Fixes https://github.com/future-architect/vuls/issues/928

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. start vuls-server with `-format-json -to-localfile" options (and provide vulnerability DB:s to it, too)
2. Run one-liner scan from e.g. Debian container (https://vuls.io/docs/en/usage-server.html#example-one-liner-scan)
3. Try to open it with vulsrepo. It will now work.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

