### PR TITLE
fix CentOS8 configtest always failed

### DIFF
--- a/scan/centos.go
+++ b/scan/centos.go
@@ -50,7 +50,7 @@ func (o *centos) depsFast() []string {
 
 	// repoquery
 	majorVersion, _ := o.Distro.MajorVersion()
-	if majorVersion < 8 {
+	if majorVersion <= 8 {
 		return []string{"yum-utils"}
 	}
 	return []string{"dnf-utils"}
@@ -63,7 +63,7 @@ func (o *centos) depsFastRoot() []string {
 
 	// repoquery
 	majorVersion, _ := o.Distro.MajorVersion()
-	if majorVersion < 8 {
+	if majorVersion <= 8 {
 		return []string{"yum-utils"}
 	}
 	return []string{"dnf-utils"}


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes #946 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
$ vuls configtest -ssh-config centos8
[Apr  2 12:34:56]  INFO [localhost] Validating config...
[Apr  2 12:34:56]  INFO [localhost] Detecting Server/Container OS... 
[Apr  2 12:34:56]  INFO [localhost] Detecting OS of servers... 
[Apr  2 12:34:56]  INFO [localhost] (1/1) Detected: centos8: centos 8.1.1911
[Apr  2 12:34:56]  INFO [localhost] Detecting OS of static containers... 
[Apr  2 12:34:56]  INFO [localhost] Detecting OS of containers... 
[Apr  2 12:34:56]  INFO [localhost] Checking Scan Modes...
[Apr  2 12:34:56]  INFO [localhost] Checking dependencies...
[Apr  2 12:34:56]  INFO [centos8] Dependencies ... Pass
[Apr  2 12:34:56]  INFO [localhost] Checking sudo settings...
[Apr  2 12:34:56]  INFO [centos8] Sudo... Pass
[Apr  2 12:34:56]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Apr  2 12:34:56]  INFO [localhost] Scannable servers are below...
centos8 
```
# Checklist:
You don't have to satisfy all of the following.

- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Enable "Allow edits from maintainers" for this PR


