### PR TITLE
feat(report): display "fixed" when updatable even in fast mode

### DIFF
--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -567,6 +567,13 @@ func (v VulnInfo) PatchStatus(packs Packages) string {
 			return "unfixed"
 		}
 
+		// Fast and offline mode can not get the candidate version.
+		// Vuls can be considered as 'fixed' if not-fixed-yet==true and
+		// the fixed-in-version (information in the oval) is not an empty.
+		if p.FixedIn != "" {
+			continue
+		}
+
 		// fast, offline mode doesn't have new version
 		if pack, ok := packs[p.Name]; ok {
 			if pack.NewVersion == "" {


### PR DESCRIPTION
# What did you implement:

Fixes #820

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## Ubuntu18 (fast scan mode)

- before
![u18-before](https://user-images.githubusercontent.com/534611/79107155-d59f7480-7dae-11ea-92ea-4b324949c67f.png)

- after
![u18-after](https://user-images.githubusercontent.com/534611/79107171-dfc17300-7dae-11ea-9259-6b9bf8b93413.png)

## Debian9 (fast scan mode)
- before

![コメント](https://user-images.githubusercontent.com/534611/79108576-9b83a200-7db1-11ea-92c6-2df1adcf3eed.png)


-after

![after](https://user-images.githubusercontent.com/534611/79108552-89a1ff00-7db1-11ea-90ff-11c92a37838e.png)


# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES