### PR TITLE
composer.lock instaad of composer.json

### DIFF
--- a/models/library.go
+++ b/models/library.go
@@ -122,7 +122,7 @@ var LibraryMap = map[string]string{
 	"yarn.lock":         "node",
 	"Gemfile.lock":      "ruby",
 	"Cargo.lock":        "rust",
-	"composer.json":     "php",
+	"composer.lock":     "php",
 	"Pipfile.lock":      "python",
 	"poetry.lock":       "python",
 }


### PR DESCRIPTION
# What did you implement:
find composer.lock files instead of composer.json as the trivy analyzer expects

Fixes # (issue)
https://github.com/future-architect/vuls/issues/972

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Add composer.lock file with phpwhois 4.2.2 and verify we see CVE-2015-5243 in the output
