### PR TITLE
Workaround vuls ignoring `-listen` flag.

### DIFF
--- a/commands/server.go
+++ b/commands/server.go
@@ -100,8 +100,8 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.Conf.FormatJSON, "format-json", false, "JSON format")
 
 	f.BoolVar(&c.Conf.ToLocalFile, "to-localfile", false, "Write report to localfile")
-	f.StringVar(&p.listen, "listen", "localhost:5515",
-		"host:port (default: localhost:5515)")
+	f.StringVar(&p.listen, "listen", "0.0.0.0:5515",
+		"host:port (default: 0.0.0.0:5515)")
 
 	f.StringVar(&p.cveDict.Type, "cvedb-type", "",
 		"DB type of go-cve-dictionary (sqlite3, mysql, postgres, redis or http)")


### PR DESCRIPTION
After reviewing the logs, the flag to set the address and port from which
the vuls daemon listens is never properly applied, even when expressly
set. This is hard-coding for now, while I file I try to debug further and
review with upstream developers.


If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

