### PR TITLE
feat(wordpress): Cache WpVulnDB

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -56,7 +56,7 @@ func (h VulsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := report.FillCveInfo(h.DBclient, &result, []string{}, true, &map[string]string{}); err != nil {
+	if err := report.FillCveInfo(h.DBclient, &result, []string{}, true); err != nil {
 		util.Log.Error(err)
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -56,7 +56,7 @@ func (h VulsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := report.FillCveInfo(h.DBclient, &result, []string{}, true); err != nil {
+	if err := report.FillCveInfo(h.DBclient, &result, []string{}, true, &map[string]string{}); err != nil {
 		util.Log.Error(err)
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return

--- a/wordpress/wordpress.go
+++ b/wordpress/wordpress.go
@@ -58,7 +58,8 @@ func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]
 	body, ok := searchCache(ver, wpVulnCaches)
 	if !ok {
 		url := fmt.Sprintf("https://wpvulndb.com/api/v3/wordpresses/%s", ver)
-		body, err := httpRequest(url, token)
+		var err error
+		body, err = httpRequest(url, token)
 		if err != nil {
 			return 0, err
 		}
@@ -87,7 +88,8 @@ func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]
 		body, ok := searchCache(p.Name, wpVulnCaches)
 		if !ok {
 			url := fmt.Sprintf("https://wpvulndb.com/api/v3/themes/%s", p.Name)
-			body, err := httpRequest(url, token)
+			var err error
+			body, err = httpRequest(url, token)
 			if err != nil {
 				return 0, err
 			}
@@ -127,7 +129,8 @@ func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]
 		body, ok := searchCache(p.Name, wpVulnCaches)
 		if !ok {
 			url := fmt.Sprintf("https://wpvulndb.com/api/v3/plugins/%s", p.Name)
-			body, err := httpRequest(url, token)
+			var err error
+			body, err = httpRequest(url, token)
 			if err != nil {
 				return 0, err
 			}

--- a/wordpress/wordpress.go
+++ b/wordpress/wordpress.go
@@ -94,9 +94,10 @@ func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]
 				return 0, err
 			}
 			(*wpVulnCaches)[p.Name] = body
-			if body == "" {
-				continue
-			}
+		}
+
+		if body == "" {
+			continue
 		}
 
 		templateVinfos, err := convertToVinfos(p.Name, body)
@@ -135,9 +136,10 @@ func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]
 				return 0, err
 			}
 			(*wpVulnCaches)[p.Name] = body
-			if body == "" {
-				continue
-			}
+		}
+
+		if body == "" {
+			continue
 		}
 
 		pluginVinfos, err := convertToVinfos(p.Name, body)

--- a/wordpress/wordpress_test.go
+++ b/wordpress/wordpress_test.go
@@ -123,7 +123,7 @@ func TestSearchCache(t *testing.T) {
 
 	for i, tt := range tests {
 		value, ok := searchCache(tt.name, &tt.wpVulnCache)
-		if value != tt.value || ok != ok {
+		if value != tt.value || ok != tt.ok {
 			t.Errorf("[%d] searchCache error ", i)
 		}
 	}

--- a/wordpress/wordpress_test.go
+++ b/wordpress/wordpress_test.go
@@ -99,8 +99,8 @@ func TestSearchCache(t *testing.T) {
 		{
 			name: "akismet",
 			wpVulnCache: map[string]string{
-				"BackWPup" : "body",
-				"akismet": "body",
+				"BackWPup": "body",
+				"akismet":  "body",
 			},
 			value: "body",
 			ok:    true,
@@ -108,16 +108,16 @@ func TestSearchCache(t *testing.T) {
 		{
 			name: "akismet",
 			wpVulnCache: map[string]string{
-				"BackWPup" : "body",
+				"BackWPup": "body",
 			},
 			value: "",
 			ok:    false,
 		},
 		{
-			name: "akismet",
+			name:        "akismet",
 			wpVulnCache: nil,
-			value: "",
-			ok:    false,
+			value:       "",
+			ok:          false,
 		},
 	}
 

--- a/wordpress/wordpress_test.go
+++ b/wordpress/wordpress_test.go
@@ -79,3 +79,52 @@ func TestRemoveInactive(t *testing.T) {
 		}
 	}
 }
+
+func TestSearchCache(t *testing.T) {
+
+	var tests = []struct {
+		name        string
+		wpVulnCache map[string]string
+		value       string
+		ok          bool
+	}{
+		{
+			name: "akismet",
+			wpVulnCache: map[string]string{
+				"akismet": "body",
+			},
+			value: "body",
+			ok:    true,
+		},
+		{
+			name: "akismet",
+			wpVulnCache: map[string]string{
+				"BackWPup" : "body",
+				"akismet": "body",
+			},
+			value: "body",
+			ok:    true,
+		},
+		{
+			name: "akismet",
+			wpVulnCache: map[string]string{
+				"BackWPup" : "body",
+			},
+			value: "",
+			ok:    false,
+		},
+		{
+			name: "akismet",
+			wpVulnCache: nil,
+			value: "",
+			ok:    false,
+		},
+	}
+
+	for i, tt := range tests {
+		value, ok := searchCache(tt.name, &tt.wpVulnCache)
+		if value != tt.value || ok != ok {
+			t.Errorf("[%d] searchCache error ", i)
+		}
+	}
+}


### PR DESCRIPTION
## What did you implement:
I implemented Cache WpVulnDB.
It reduces access to wpvulndb by caching .

What makes we happy when I add this.
If you use multiple WordPress scans, you can reduce API calls by the same core, plugins and themes.




I tested wordpresses in action.
The request for one server result was the same as the request for two replicated servers results.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

