### PR TITLE
Support SMTPS when using report -to-email 

### DIFF
--- a/report/email.go
+++ b/report/email.go
@@ -103,41 +103,41 @@ func smtps(emailConf config.SMTPConf, message string) (err error) {
 	//New TLS connection
 	con, err := tls.Dial("tcp", smtpServer, tlsConfig)
 	if err != nil {
-		return xerrors.Errorf("Can't create TLS connection: %w", err)
+		return xerrors.Errorf("Failed to create TLS connection: %w", err)
 	}
 	defer con.Close()
 
 	c, err := smtp.NewClient(con, emailConf.SMTPAddr)
 	if err != nil {
-		return xerrors.Errorf("Can't create new client: %w", err)
+		return xerrors.Errorf("Failed to create new client: %w", err)
 	}
 	if err = c.Auth(auth); err != nil {
-		return xerrors.Errorf("Auth error: %w", err)
+		return xerrors.Errorf("Failed to authenticate: %w", err)
 	}
 	if err = c.Mail(emailConf.From); err != nil {
-		return xerrors.Errorf("Mail command error: %w", err)
+		return xerrors.Errorf("Failed to send Mail command: %w", err)
 	}
 	for _, to := range emailConf.To {
 		if err = c.Rcpt(to); err != nil {
-			return xerrors.Errorf("Rcpt command error: %w", err)
+			return xerrors.Errorf("Failed to send Rcpt command: %w", err)
 		}
 	}
-	
+
 	w, err := c.Data()
 	if err != nil {
-		return xerrors.Errorf("Data command error: %w", err)
+		return xerrors.Errorf("Failed to send Data command: %w", err)
 	}
 	_, err = w.Write([]byte(message))
 	if err != nil {
-		return xerrors.Errorf("Can't write EMail message: %w", err)
+		return xerrors.Errorf("Failed to write EMail message: %w", err)
 	}
 	err = w.Close()
 	if err != nil {
-		return xerrors.Errorf("Writer Close error: %w", err)
+		return xerrors.Errorf("Failed to close Writer: %w", err)
 	}
 	err = c.Quit()
 	if err != nil {
-		return xerrors.Errorf("Connection close error: %w", err)
+		return xerrors.Errorf("Failed to close connection: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
# What did you implement:
The purpose of this pull request is to provide support for SMTPS when use ```report -to-email```.

Fixes #945 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Key points of changes
【report/email.go】
When ```vuls report -to-email``` using port465(SMTPS), smtp client use TLS connection.

# How to use SMTPS
Setting config.toml to use port465
```text
[email]
smtpAddr      = "smtp.xxx.xxx.com"
smtpPort      = "465"
user          = "xxxx"
password      = "xxxxxxx"
from          = "xxxx@xxxx.com"
to            = ["xxxx@xxxx.com"]
subjectPrefix = "[vuls]" 
```
 
# Reference
* https://golang.org/pkg/net/smtp/
* https://gist.github.com/chrisgillis/10888032

