### PR TITLE
Added ReportedAt time for server mode reports - fixes #928

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -62,6 +62,12 @@ func (h VulsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// set ReportedAt to current time when it's set to the epoch, ensures that ReportedAt will be set
+	// properly for scans sent to vuls when running in server mode
+	if result.ReportedAt.IsZero() {
+		result.ReportedAt = time.Now()
+	}
+
 	// report
 	reports := []report.ResultWriter{
 		report.HTTPResponseWriter{Writer: w},


### PR DESCRIPTION
# What did you implement:

Added ReportedAt time for reports submitted from client while server is running in `server` mode. I know that there is already a PR (https://github.com/future-architect/vuls/pull/938) open for this, but it doesn't look like it's in progress and this is a fix that is impacting my use of Vuls. I can be active and make changes if requested, please let me know. 

Fixes #928 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Yes, see verification steps at the end of the PR

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
there is an open pull request, but it doesn't look active: https://github.com/future-architect/vuls/pull/938

- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
## To verify

- Create `data.json` file in your current directoy
```json
{
  "family": "centos",
  "release": "6.9",
  "runningKernel": {
    "release": "2.6.32-696.6.3.el6.x86_64",
    "version": "",
    "rebootRequired": false
  },
  "packages": {
    "ntp": {
      "name": "ntp",
      "version": "4.2.6p5",
      "release": "10.el6.centos.2",
      "arch": "x86_64"
    },
    "openssh": {
      "name": "openssh",
      "version": "5.3p1",
      "release": "122.el6",
      "arch": "x86_64"
    }
  }
}
```

- After starting vuls, run these two commands from your CLI, you should see that the time reported is the current time, not the epoch
```bash
# json
curl -s -X POST -H "Content-Type: application/json" -d ./data.json http://localhost:5515/vuls | jq '.[] | {reportedAt}'

# text
curl -X POST -H "Content-Type: text/plain" -H "X-Vuls-Server-Name: foo" -H "X-Vuls-OS-Family: centos" -H "X-Vuls-OS-Release: 6.9" -H "X-Vuls-Kernel-Release: 2.6.32-695.20.3.el6.x86_64" --data-binary "" http://localhost:5515/vuls |  jq '.[] | {reportedAt}'
```

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

