### PR TITLE
Support ProxyJump option when using ssh command 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1035,6 +1035,7 @@ type ServerInfo struct {
 	ServerName             string                      `toml:"-" json:"serverName,omitempty"`
 	User                   string                      `toml:"user,omitempty" json:"user,omitempty"`
 	Host                   string                      `toml:"host,omitempty" json:"host,omitempty"`
+	JumpServer             []string                    `toml:"jumpServer,omitempty" json:"jumpServer,omitempty"`
 	Port                   string                      `toml:"port,omitempty" json:"port,omitempty"`
 	KeyPath                string                      `toml:"keyPath,omitempty" json:"keyPath,omitempty"`
 	KeyPassword            string                      `json:"-,omitempty" toml:"-"`

--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -56,6 +56,11 @@ func (c TOMLLoader) Load(pathToToml, keyPass string) error {
 			if len(s.Host) == 0 {
 				return xerrors.Errorf("%s is invalid. host is empty", serverName)
 			}
+			
+			s.JumpServer = v.JumpServer
+			if len(s.JumpServer) == 0 {
+				s.JumpServer = d.JumpServer
+			}
 
 			switch {
 			case v.Port != "":

--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -56,7 +56,7 @@ func (c TOMLLoader) Load(pathToToml, keyPass string) error {
 			if len(s.Host) == 0 {
 				return xerrors.Errorf("%s is invalid. host is empty", serverName)
 			}
-			
+
 			s.JumpServer = v.JumpServer
 			if len(s.JumpServer) == 0 {
 				s.JumpServer = d.JumpServer

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/boltdb/bolt v1.3.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/d4l3k/messagediff v1.2.2-0.20190829033028-7e0a312ae40b
-	github.com/docker/docker-credential-helpers v0.6.3
 	github.com/google/subcommands v1.2.0
 	github.com/gosuri/uitable v0.0.4
 	github.com/hashicorp/go-uuid v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/boltdb/bolt v1.3.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/d4l3k/messagediff v1.2.2-0.20190829033028-7e0a312ae40b
+	github.com/docker/docker-credential-helpers v0.6.3
 	github.com/google/subcommands v1.2.0
 	github.com/gosuri/uitable v0.0.4
 	github.com/hashicorp/go-uuid v1.0.2

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -285,6 +285,10 @@ func sshExecExternal(c conf.ServerInfo, cmd string, sudo bool) (result execResul
 		defaultSSHArgs = append(defaultSSHArgs, "-vvv")
 	}
 
+	if len(c.JumpServer) != 0 { 
+		defaultSSHArgs = append(defaultSSHArgs, "-J", strings.Join(c.JumpServer, ","))
+	}
+
 	args := append(defaultSSHArgs, fmt.Sprintf("%s@%s", c.User, c.Host))
 	args = append(args, "-p", c.Port)
 	if 0 < len(c.KeyPath) {

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -285,7 +285,7 @@ func sshExecExternal(c conf.ServerInfo, cmd string, sudo bool) (result execResul
 		defaultSSHArgs = append(defaultSSHArgs, "-vvv")
 	}
 
-	if len(c.JumpServer) != 0 { 
+	if len(c.JumpServer) != 0 {
 		defaultSSHArgs = append(defaultSSHArgs, "-J", strings.Join(c.JumpServer, ","))
 	}
 


### PR DESCRIPTION
# What did you implement:
The purpose of this pull request is to provide support for ProxyJump option.

Fixes #987 

## Type of change
- [*] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
When running ```vuls scan --debug -vvv```, I can confirm output ```ssh -J test@test.com:22,test@test1.com:2222 targetmachine```.
![image](https://user-images.githubusercontent.com/39241071/84480410-789d3d80-accf-11ea-9735-572c4be1d6e4.png)

# How to use ProxyJump
Add ProxyJump setting to the Severs section of config.toml.
For example, ```ProxyJump=["user@(hostname or IPaddress):port"]```
【config.toml】
```text
[servers]

[servers.ubuntu]
host         = ""
port        = ""
user        = ""
keyPath     = ""
# Add this line
jumpServer = ["test@test.com:22", "test@test1.com:2222"]
```
If we don't run ProxyJump option, please check **.vuls** directory.
The control master may be the cause.