### PR TITLE
Fix SSH failure due to .ssh/config owner

### DIFF
--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -69,7 +69,7 @@ func (p *ConfigtestCmd) SetFlags(f *flag.FlagSet) {
 		"Use Native Go implementation of SSH. Default: Use the external command")
 
 	f.BoolVar(&c.Conf.SSHConfig, "ssh-config", false,
-		"Use SSH options specified in ssh_config preferentially")
+		"[Deprecated] Use SSH options specified in ssh_config preferentially")
 
 	f.BoolVar(&c.Conf.ContainersOnly, "containers-only", false,
 		"Test containers only. Default: Test both of hosts and containers")
@@ -105,6 +105,16 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 			"Please check config.toml template : https://vuls.io/docs/en/usage-settings.html",
 		}
 		util.Log.Errorf("%s\n%+v", strings.Join(msg, "\n"), err)
+		return subcommands.ExitUsageError
+	}
+
+	if c.Conf.SSHConfig {
+		msg := []string{
+			"-ssh-config is deprecated",
+			"If you update Vuls and get this error, there may be incompatible changes in config.toml",
+			"Please check config.toml template : https://vuls.io/docs/en/usage-settings.html",
+		}
+		util.Log.Errorf("%s", strings.Join(msg, "\n"))
 		return subcommands.ExitUsageError
 	}
 

--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -36,7 +36,7 @@ func (*ConfigtestCmd) Usage() string {
 			[-log-dir=/path/to/log]
 			[-ask-key-password]
 			[-timeout=300]
-			[-ssh-external]
+			[-ssh-config]
 			[-containers-only]
 			[-http-proxy=http://192.168.0.1:8080]
 			[-debug]

--- a/commands/discover.go
+++ b/commands/discover.go
@@ -187,6 +187,7 @@ sqlite3Path = "/path/to/go-exploitdb.sqlite3"
 host                = "{{$ip}}"
 #port               = "22"
 #user               = "root"
+#sshConfigPath		= "/home/username/.ssh/config"
 #keyPath            = "/home/username/.ssh/id_rsa"
 #scanMode           = ["fast", "fast-root", "deep", "offline"]
 #type               = "pseudo"

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -80,7 +80,7 @@ func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 		"Use Native Go implementation of SSH. Default: Use the external command")
 
 	f.BoolVar(&c.Conf.SSHConfig, "ssh-config", false,
-		"Use SSH options specified in ssh_config preferentially")
+		"[Deprecated] Use SSH options specified in ssh_config preferentially")
 
 	f.BoolVar(&c.Conf.ContainersOnly, "containers-only", false,
 		"Scan running containers only. Default: Scan both of hosts and running containers")
@@ -143,6 +143,16 @@ func (p *ScanCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 			"Please check config.toml template : https://vuls.io/docs/en/usage-settings.html",
 		}
 		util.Log.Errorf("%s\n%+v", strings.Join(msg, "\n"), err)
+		return subcommands.ExitUsageError
+	}
+
+	if c.Conf.SSHConfig {
+		msg := []string{
+			"-ssh-config is deprecated",
+			"If you update Vuls and get this error, there may be incompatible changes in config.toml",
+			"Please check config.toml template : https://vuls.io/docs/en/usage-settings.html",
+		}
+		util.Log.Errorf("%s", strings.Join(msg, "\n"))
 		return subcommands.ExitUsageError
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1036,6 +1036,7 @@ type ServerInfo struct {
 	User                   string                      `toml:"user,omitempty" json:"user,omitempty"`
 	Host                   string                      `toml:"host,omitempty" json:"host,omitempty"`
 	Port                   string                      `toml:"port,omitempty" json:"port,omitempty"`
+	SSHConfigPath          string                      `toml:"sshConfigPath,omitempty" json:"sshConfigPath,omitempty"`
 	KeyPath                string                      `toml:"keyPath,omitempty" json:"keyPath,omitempty"`
 	KeyPassword            string                      `json:"-,omitempty" toml:"-"`
 	CpeNames               []string                    `toml:"cpeNames,omitempty" json:"cpeNames,omitempty"`

--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -77,6 +77,11 @@ func (c TOMLLoader) Load(pathToToml, keyPass string) error {
 				}
 			}
 
+			s.SSHConfigPath = v.SSHConfigPath
+			if len(s.SSHConfigPath) == 0 {
+				s.SSHConfigPath = d.SSHConfigPath
+			}
+
 			s.KeyPath = v.KeyPath
 			if len(s.KeyPath) == 0 {
 				s.KeyPath = d.KeyPath

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -260,7 +260,9 @@ func sshExecExternal(c conf.ServerInfo, cmd string, sudo bool) (result execResul
 
 	defaultSSHArgs := []string{"-tt"}
 
-	if !conf.Conf.SSHConfig {
+	if 0 < len(c.SSHConfigPath) {
+		defaultSSHArgs = append(defaultSSHArgs, "-F", c.SSHConfigPath)
+	} else {
 		home, err := homedir.Dir()
 		if err != nil {
 			msg := fmt.Sprintf("Failed to get HOME directory: %s", err)
@@ -291,8 +293,6 @@ func sshExecExternal(c conf.ServerInfo, cmd string, sudo bool) (result execResul
 		args = append(args, "-i", c.KeyPath)
 		args = append(args, "-o", "PasswordAuthentication=no")
 	}
-
-	args = append(args, "-F", "/home/mainek00n/.ssh/config")
 
 	cmd = decorateCmd(c, cmd, sudo)
 	cmd = fmt.Sprintf("stty cols 1000; %s", cmd)

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -292,6 +292,8 @@ func sshExecExternal(c conf.ServerInfo, cmd string, sudo bool) (result execResul
 		args = append(args, "-o", "PasswordAuthentication=no")
 	}
 
+	args = append(args, "-F", "/home/mainek00n/.ssh/config")
+
 	cmd = decorateCmd(c, cmd, sudo)
 	cmd = fmt.Sprintf("stty cols 1000; %s", cmd)
 


### PR DESCRIPTION
# What did you implement:

Use the SSH `-F` option to avoid the bug that `.ssh/config` causes an error depending on the owner setting. Also, the command line option: `-ssh-config` has been deprecated.

Fixes #986 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

As stated in the issue, I confirmed by executing `scan.sh` of vulsctl.
I used a docker container as the scan destination.

- vulsctl → Docker (Ubuntu20.04)
```terminal
vulsctl on master
❯ cat config.toml
[servers]

[servers.ubuntu]
host = "172.17.0.2"
port = "22"
user = "root"
sshConfigPath = "/root/.ssh/config"
keyPath = "/root/.ssh/id_rsa"

vulsctl on master
❯ ./scan.sh
[Jun 14 16:07:53]  INFO [localhost] Validating config...
[Jun 14 16:07:53]  INFO [localhost] Detecting Server/Container OS...
[Jun 14 16:07:53]  INFO [localhost] Detecting OS of servers...
[Jun 14 16:07:53]  INFO [localhost] (1/1) Detected: ubuntu: ubuntu 20.04
[Jun 14 16:07:53]  INFO [localhost] Detecting OS of containers...
[Jun 14 16:07:53]  INFO [localhost] Checking Scan Modes...
[Jun 14 16:07:53]  INFO [localhost] Checking dependencies...
[Jun 14 16:07:53]  INFO [ubuntu] Dependencies... Pass
[Jun 14 16:07:53]  INFO [localhost] Checking sudo settings...
[Jun 14 16:07:53]  INFO [ubuntu] sudo ... No need
[Jun 14 16:07:53]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Jun 14 16:07:53]  INFO [localhost] Scannable servers are below...
ubuntu
[Jun 14 16:07:54]  INFO [localhost] Start scanning
[Jun 14 16:07:54]  INFO [localhost] config: /vuls/config.toml
[Jun 14 16:07:54]  INFO [localhost] Validating config...
[Jun 14 16:07:54]  INFO [localhost] Detecting Server/Container OS...
[Jun 14 16:07:54]  INFO [localhost] Detecting OS of servers...
[Jun 14 16:07:55]  INFO [localhost] (1/1) Detected: ubuntu: ubuntu 20.04
[Jun 14 16:07:55]  INFO [localhost] Detecting OS of containers...
[Jun 14 16:07:55]  INFO [localhost] Checking Scan Modes...
[Jun 14 16:07:55]  INFO [localhost] Detecting Platforms...
[Jun 14 16:07:55]  INFO [localhost] (1/1) ubuntu is running on other
[Jun 14 16:07:55]  INFO [localhost] Detecting IPS identifiers...
[Jun 14 16:07:55]  INFO [localhost] (1/1) ubuntu has 0 IPS integration
[Jun 14 16:07:55]  INFO [localhost] Scanning vulnerabilities...
[Jun 14 16:07:55]  INFO [localhost] Scanning vulnerable OS packages...
[Jun 14 16:07:55]  INFO [ubuntu] Scanning in fast mode


One Line Summary
================
ubuntu  ubuntu20.04     186 installed





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

This problem occurs when the owner of .ssh/config is different. Therefore, it can be reproduced locally. So I created a test user and tested it.

- local(Ubuntu20.04)→Docker(Ubuntu20.04)
```terminal
$ ls -l ~/.ssh
-rw-r--r-- 1 test      test       472 Jun 15 01:01 config
-rw------- 1 mainek00n mainek00n 2.6K Jun 15 01:01 id_rsa
-rw-r--r-- 1 mainek00n mainek00n  570 Jun 15 01:01 id_rsa.pub

$ cat config.toml
[cveDict]
type = "sqlite3"
SQLite3Path = "/usr/share/vuls-data/cve.sqlite3"

[ovalDict]
type = "sqlite3"
SQLite3Path = "/usr/share/vuls-data/oval.sqlite3"

[gost]
type = "sqlite3"
SQLite3Path = "/usr/share/vuls-data/gost.sqlite3"

[servers]

[servers.ubuntu]
host = "localhost"
port = "32772"
sshConfigPath = "/home/mainek00n/.ssh/config"
user = "root"
keyPath = "/home/mainek00n/.ssh/id_rsa"
scanMode = [ "fast" ]
#scanMode = ["fast", "fast-root", "deep", "offline"]

$ ./vuls configtest
[Jun 15 01:24:18]  INFO [localhost] Validating config...
[Jun 15 01:24:18]  INFO [localhost] Detecting Server/Container OS...
[Jun 15 01:24:18]  INFO [localhost] Detecting OS of servers...
[Jun 15 01:24:19]  INFO [localhost] (1/1) Detected: ubuntu: ubuntu 20.04
[Jun 15 01:24:19]  INFO [localhost] Detecting OS of containers...
[Jun 15 01:24:19]  INFO [localhost] Checking Scan Modes...
[Jun 15 01:24:19]  INFO [localhost] Checking dependencies...
[Jun 15 01:24:19]  INFO [ubuntu] Dependencies... Pass
[Jun 15 01:24:19]  INFO [localhost] Checking sudo settings...
[Jun 15 01:24:19]  INFO [ubuntu] sudo ... No need
[Jun 15 01:24:19]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Jun 15 01:24:19]  INFO [localhost] Scannable servers are below...
ubuntu

$ ./vuls scan
[Jun 15 01:24:12]  INFO [localhost] Start scanning
[Jun 15 01:24:12]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Jun 15 01:24:12]  INFO [localhost] Validating config...
[Jun 15 01:24:12]  INFO [localhost] Detecting Server/Container OS...
[Jun 15 01:24:12]  INFO [localhost] Detecting OS of servers...
[Jun 15 01:24:13]  INFO [localhost] (1/1) Detected: ubuntu: ubuntu 20.04
[Jun 15 01:24:13]  INFO [localhost] Detecting OS of containers...
[Jun 15 01:24:13]  INFO [localhost] Checking Scan Modes...
[Jun 15 01:24:13]  INFO [localhost] Detecting Platforms...
[Jun 15 01:24:13]  INFO [localhost] (1/1) ubuntu is running on other
[Jun 15 01:24:13]  INFO [localhost] Detecting IPS identifiers...
[Jun 15 01:24:13]  INFO [localhost] (1/1) ubuntu has 0 IPS integration
[Jun 15 01:24:13]  INFO [localhost] Scanning vulnerabilities...
[Jun 15 01:24:13]  INFO [localhost] Scanning vulnerable OS packages...
[Jun 15 01:24:13]  INFO [ubuntu] Scanning in fast mode


One Line Summary
================
ubuntu  ubuntu20.04     186 installed





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

```

Also, `-ssh-config` has been deprecated and fails with Error.
```terminal
$  ./vuls configtest -ssh-config
[Jun 15 03:10:52] ERROR [localhost] -ssh-config is deprecated
If you update Vuls and get this error, there may be incompatible changes in config.toml
Please check config.toml template : https://vuls.io/docs/en/usage-settings.html

$ ./vuls scan -ssh-config
[Jun 15 03:10:55] ERROR [localhost] -ssh-config is deprecated
If you update Vuls and get this error, there may be incompatible changes in config.toml
Please check config.toml template : https://vuls.io/docs/en/usage-settings.html
```

# How to use SSH Config
If you want to avoid the owner issue or specify the SSH Config you want to use, please describe the SSH Config PATH(`sshConfigPath`) in the server section of config.toml.
Below is an example of `config.toml` that specifies `sshConfigPath`.

```toml
[servers]

[servers.ubuntu]
host = "172.17.0.2"
port = "22"
user = "root"
sshConfigPath = "/root/.ssh/config"
keyPath = "/root/.ssh/id_rsa"
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference
- [man ssh](https://linux.die.net/man/1/ssh)