### PR TITLE
fix(log): suppress err msg if no access priv to logfile

### DIFF
--- a/commands/configtest.go
+++ b/commands/configtest.go
@@ -79,7 +79,6 @@ func (p *ConfigtestCmd) SetFlags(f *flag.FlagSet) {
 
 // Execute execute
 func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	// Setup Logger
 	util.Log = util.NewCustomLogger(c.ServerInfo{})
 
 	if err := mkdirDotVuls(); err != nil {

--- a/commands/report.go
+++ b/commands/report.go
@@ -17,7 +17,6 @@ import (
 	"github.com/future-architect/vuls/util"
 	"github.com/google/subcommands"
 	"github.com/k0kubun/pp"
-	cvelog "github.com/kotakanbe/go-cve-dictionary/log"
 )
 
 // ReportCmd is subcommand for reporting
@@ -212,8 +211,6 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 // Execute execute
 func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	util.Log = util.NewCustomLogger(c.ServerInfo{})
-	cvelog.SetLogger(c.Conf.LogDir, false, c.Conf.Debug, false)
-
 	if err := c.Load(p.configPath, ""); err != nil {
 		util.Log.Errorf("Error loading %s, %+v", p.configPath, err)
 		return subcommands.ExitUsageError

--- a/commands/scan.go
+++ b/commands/scan.go
@@ -49,6 +49,7 @@ func (*ScanCmd) Usage() string {
 		[-timeout=300]
 		[-timeout-scan=7200]
 		[-debug]
+		[-quiet]
 		[-pipe]
 		[-vvv]
 		[-ips]
@@ -61,6 +62,7 @@ func (*ScanCmd) Usage() string {
 // SetFlags set flag
 func (p *ScanCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.Conf.Debug, "debug", false, "debug mode")
+	f.BoolVar(&c.Conf.Quiet, "quiet", false, "Quiet mode. No output on stdout")
 
 	wd, _ := os.Getwd()
 	defaultConfPath := filepath.Join(wd, "config.toml")

--- a/commands/server.go
+++ b/commands/server.go
@@ -19,7 +19,6 @@ import (
 	"github.com/future-architect/vuls/server"
 	"github.com/future-architect/vuls/util"
 	"github.com/google/subcommands"
-	cvelog "github.com/kotakanbe/go-cve-dictionary/log"
 )
 
 // ServerCmd is subcommand for server
@@ -142,8 +141,6 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 // Execute execute
 func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	util.Log = util.NewCustomLogger(c.ServerInfo{})
-	cvelog.SetLogger(c.Conf.LogDir, false, c.Conf.Debug, false)
-
 	if p.configPath != "" {
 		if err := c.Load(p.configPath, ""); err != nil {
 			util.Log.Errorf("Error loading %s. err: %+v", p.configPath, err)

--- a/commands/tui.go
+++ b/commands/tui.go
@@ -16,7 +16,6 @@ import (
 	"github.com/future-architect/vuls/report"
 	"github.com/future-architect/vuls/util"
 	"github.com/google/subcommands"
-	cvelog "github.com/kotakanbe/go-cve-dictionary/log"
 )
 
 // TuiCmd is Subcommand of host discovery mode
@@ -144,17 +143,13 @@ func (p *TuiCmd) SetFlags(f *flag.FlagSet) {
 
 // Execute execute
 func (p *TuiCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
-	c.Conf.Lang = "en"
-
-	// Setup Logger
 	util.Log = util.NewCustomLogger(c.ServerInfo{})
-	cvelog.SetLogger(c.Conf.LogDir, false, c.Conf.Debug, false)
-
 	if err := c.Load(p.configPath, ""); err != nil {
 		util.Log.Errorf("Error loading %s, err: %+v", p.configPath, err)
 		return subcommands.ExitUsageError
 	}
 
+	c.Conf.Lang = "en"
 	c.Conf.CveDict.Overwrite(p.cveDict)
 	c.Conf.OvalDict.Overwrite(p.ovalDict)
 	c.Conf.Gost.Overwrite(p.gostConf)

--- a/scan/executil.go
+++ b/scan/executil.go
@@ -333,7 +333,7 @@ func sshExecExternal(c conf.ServerInfo, cmd string, sudo bool) (result execResul
 
 func getSSHLogger(log ...*logrus.Entry) *logrus.Entry {
 	if len(log) == 0 {
-		return util.NewCustomLogger(conf.ServerInfo{})
+		return util.Log
 	}
 	return log[0]
 }

--- a/util/logutil.go
+++ b/util/logutil.go
@@ -34,6 +34,10 @@ func NewCustomLogger(c config.ServerInfo) *logrus.Entry {
 		log.Level = logrus.DebugLevel
 	}
 
+	if flag.Lookup("test.v") != nil {
+		return logrus.NewEntry(log)
+	}
+
 	// File output
 	logDir := GetDefaultLogDir()
 	if 0 < len(config.Conf.LogDir) {
@@ -52,6 +56,7 @@ func NewCustomLogger(c config.ServerInfo) *logrus.Entry {
 		if file, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err == nil {
 			log.Out = file
 		} else {
+			log.Out = os.Stderr
 			log.Errorf("Failed to create log file. path: %s, err: %s", logFile, err)
 		}
 	} else {
@@ -65,14 +70,18 @@ func NewCustomLogger(c config.ServerInfo) *logrus.Entry {
 
 	if _, err := os.Stat(logDir); err == nil {
 		path := filepath.Join(logDir, fmt.Sprintf("%s.log", whereami))
-		log.Hooks.Add(lfshook.NewHook(lfshook.PathMap{
-			logrus.DebugLevel: path,
-			logrus.InfoLevel:  path,
-			logrus.WarnLevel:  path,
-			logrus.ErrorLevel: path,
-			logrus.FatalLevel: path,
-			logrus.PanicLevel: path,
-		}, nil))
+		if _, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err == nil {
+			log.Hooks.Add(lfshook.NewHook(lfshook.PathMap{
+				logrus.DebugLevel: path,
+				logrus.InfoLevel:  path,
+				logrus.WarnLevel:  path,
+				logrus.ErrorLevel: path,
+				logrus.FatalLevel: path,
+				logrus.PanicLevel: path,
+			}, nil))
+		} else {
+			log.Errorf("Failed to create log file. path: %s, err: %s", path, err)
+		}
 	}
 
 	fields := logrus.Fields{"prefix": whereami}


### PR DESCRIPTION
# What did you implement:

before 

```
ubuntu@dev  ~│g│s│g│f│vuls  ⎇ master…~  ./vuls scan c7
2020/07/31 16:47:37 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:37]  INFO [localhost] Start scanning
2020/07/31 16:47:37 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:37]  INFO [localhost] config: /home/ubuntu/go/src/github.com/future-architect/vuls/config.toml
2020/07/31 16:47:37 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:37]  INFO [localhost] Validating config...
2020/07/31 16:47:37 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:37]  INFO [localhost] Detecting Server/Container OS... 
2020/07/31 16:47:37 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:37]  INFO [localhost] Detecting OS of servers... 
2020/07/31 16:47:38 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:38]  INFO [localhost] (1/1) Detected: c7: centos 7.7.1908
2020/07/31 16:47:38 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:38]  INFO [localhost] Detecting OS of containers... 
2020/07/31 16:47:38 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:38]  INFO [localhost] Checking Scan Modes... 
2020/07/31 16:47:38 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:38]  INFO [localhost] Detecting Platforms... 
2020/07/31 16:47:38 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:38]  INFO [localhost] (1/1) c7 is running on aws
2020/07/31 16:47:38 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:38]  INFO [localhost] Detecting IPS identifiers... 
2020/07/31 16:47:38 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:38]  INFO [localhost] (1/1) c7 has 0 IPS integration
2020/07/31 16:47:38 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:38]  INFO [localhost] Scanning vulnerabilities... 
2020/07/31 16:47:38 failed to open logfile: /var/log/vuls/localhost.log open /var/log/vuls/localhost.log: permission denied
Failed to fire hook: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:47:38]  INFO [localhost] Scanning vulnerable OS packages...
[Jul 31 16:47:38]  INFO [c7] Scanning in fast mode


One Line Summary
================
[Reboot Required] c7    centos7.7.1908  306 installed, 99 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

after

```
ubuntu@dev  ~│g│s│g│f│vuls  ⎇ fix-log-setup…~  ./vuls scan c7
[Jul 31 16:50:45] ERROR Failed to create log file. path: /var/log/vuls/localhost.log, err: open /var/log/vuls/localhost.log: permission denied
[Jul 31 16:50:45]  INFO [localhost] Start scanning
[Jul 31 16:50:45]  INFO [localhost] config: /home/ubuntu/go/src/github.com/future-architect/vuls/config.toml
[Jul 31 16:50:45]  INFO [localhost] Validating config...
[Jul 31 16:50:45]  INFO [localhost] Detecting Server/Container OS... 
[Jul 31 16:50:45]  INFO [localhost] Detecting OS of servers... 
[Jul 31 16:50:46]  INFO [localhost] (1/1) Detected: c7: centos 7.7.1908
[Jul 31 16:50:46]  INFO [localhost] Detecting OS of containers... 
[Jul 31 16:50:46]  INFO [localhost] Checking Scan Modes... 
[Jul 31 16:50:46]  INFO [localhost] Detecting Platforms... 
[Jul 31 16:50:46]  INFO [localhost] (1/1) c7 is running on aws
[Jul 31 16:50:46]  INFO [localhost] Detecting IPS identifiers... 
[Jul 31 16:50:46]  INFO [localhost] (1/1) c7 has 0 IPS integration
[Jul 31 16:50:46]  INFO [localhost] Scanning vulnerabilities... 
[Jul 31 16:50:46]  INFO [localhost] Scanning vulnerable OS packages...
[Jul 31 16:50:46]  INFO [c7] Scanning in fast mode


One Line Summary
================
[Reboot Required] c7    centos7.7.1908  306 installed, 99 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

```


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

