### PR TITLE
fix(gost): suppress err logging when unsupported debian

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1250,21 +1250,18 @@ func (l Distro) String() string {
 }
 
 // MajorVersion returns Major version
-func (l Distro) MajorVersion() (ver int, err error) {
+func (l Distro) MajorVersion() (int, error) {
 	if l.Family == Amazon {
 		ss := strings.Fields(l.Release)
 		if len(ss) == 1 {
 			return 1, nil
 		}
-		ver, err = strconv.Atoi(ss[0])
-		return
+		return strconv.Atoi(ss[0])
 	}
 	if 0 < len(l.Release) {
-		ver, err = strconv.Atoi(strings.Split(l.Release, ".")[0])
-	} else {
-		err = xerrors.New("Release is empty")
+		return strconv.Atoi(strings.Split(l.Release, ".")[0])
 	}
-	return
+	return 0, xerrors.New("Release is empty")
 }
 
 // IsContainer returns whether this ServerInfo is about container

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -63,7 +63,7 @@ func TestSyslogConfValidate(t *testing.T) {
 	}
 }
 
-func TestMajorVersion(t *testing.T) {
+func TestDistro_MajorVersion(t *testing.T) {
 	var tests = []struct {
 		in  Distro
 		out int

--- a/gost/debian.go
+++ b/gost/debian.go
@@ -21,8 +21,23 @@ type packCves struct {
 	cves      []models.CveContent
 }
 
+func (deb Debian) Supported(major string) bool {
+	_, ok := map[string]string{
+		"8":  "jessie",
+		"9":  "stretch",
+		"10": "buster",
+	}[major]
+	return ok
+}
+
 // DetectUnfixed fills cve information that has in Gost
 func (deb Debian) DetectUnfixed(driver db.DB, r *models.ScanResult, _ bool) (nCVEs int, err error) {
+	if !deb.Supported(major(r.Release)) {
+		// only logging
+		util.Log.Warnf("Debian %s is not supported yet", r.Release)
+		return 0, nil
+	}
+
 	linuxImage := "linux-image-" + r.RunningKernel.Release
 	// Add linux and set the version of running kernel to search OVAL.
 	if r.Container.ContainerID == "" {

--- a/gost/debian_test.go
+++ b/gost/debian_test.go
@@ -1,0 +1,61 @@
+package gost
+
+import "testing"
+
+func TestDebian_Supported(t *testing.T) {
+	type fields struct {
+		Base Base
+	}
+	type args struct {
+		major string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "8 is supported",
+			args: args{
+				major: "8",
+			},
+			want: true,
+		},
+		{
+			name: "9 is supported",
+			args: args{
+				major: "9",
+			},
+			want: true,
+		},
+		{
+			name: "10 is supported",
+			args: args{
+				major: "10",
+			},
+			want: true,
+		},
+		{
+			name: "11 is not supported yet",
+			args: args{
+				major: "11",
+			},
+			want: false,
+		},
+		{
+			name: "empty string is not supported yet",
+			args: args{
+				major: "",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deb := Debian{}
+			if got := deb.Supported(tt.args.major); got != tt.want {
+				t.Errorf("Debian.Supported() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -1089,7 +1089,7 @@ func TestIsOvalDefAffected(t *testing.T) {
 	}
 }
 
-func TestMajor(t *testing.T) {
+func Test_major(t *testing.T) {
 	var tests = []struct {
 		in       string
 		expected string


### PR DESCRIPTION
# What did you implement:

suppress err logging when unsupported debian
 
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

