### PR TITLE
add(report) -format-csv option

### DIFF
--- a/commands/report.go
+++ b/commands/report.go
@@ -143,6 +143,7 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&c.Conf.FormatJSON, "format-json", false, "JSON format")
 	f.BoolVar(&c.Conf.FormatXML, "format-xml", false, "XML format")
+	f.BoolVar(&c.Conf.FormatCsvList, "format-csv", false, "CSV format")
 	f.BoolVar(&c.Conf.FormatOneEMail, "format-one-email", false,
 		"Send all the host report via only one EMail (Specify with -to-email)")
 	f.BoolVar(&c.Conf.FormatOneLineText, "format-one-line-text", false,
@@ -317,7 +318,7 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	}
 
 	if !(c.Conf.FormatJSON || c.Conf.FormatOneLineText ||
-		c.Conf.FormatList || c.Conf.FormatFullText || c.Conf.FormatXML) {
+		c.Conf.FormatList || c.Conf.FormatFullText || c.Conf.FormatXML || c.Conf.FormatCsvList) {
 		c.Conf.FormatList = true
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -151,6 +151,7 @@ type Config struct {
 	FormatOneLineText bool `json:"formatOneLineText,omitempty"`
 	FormatList        bool `json:"formatList,omitempty"`
 	FormatFullText    bool `json:"formatFullText,omitempty"`
+	FormatCsvList     bool `json:"formatCsvList,omitempty"`
 	GZIP              bool `json:"gzip,omitempty"`
 	Diff              bool `json:"diff,omitempty"`
 	WpIgnoreInactive  bool `json:"wpIgnoreInactive,omitempty"`

--- a/report/localfile.go
+++ b/report/localfile.go
@@ -102,6 +102,22 @@ func (w LocalFileWriter) Write(rs ...models.ScanResult) (err error) {
 				return xerrors.Errorf("Failed to write XML. path: %s, err: %w", p, err)
 			}
 		}
+
+		if c.Conf.FormatCsvList {
+			var p string
+			if c.Conf.Diff {
+				p = path + "_short_diff.csv"
+			} else {
+				p = path + "_short.csv"
+			}
+
+			err := formatCsvList(r, p)
+
+			if err == "" {
+				return xerrors.Errorf("Failed to write CSV. path: %s", p)
+			}
+		}
+
 	}
 	return nil
 }

--- a/report/stdout.go
+++ b/report/stdout.go
@@ -27,7 +27,7 @@ func (w StdoutWriter) Write(rs ...models.ScanResult) error {
 		fmt.Print("\n")
 	}
 
-	if c.Conf.FormatList {
+	if c.Conf.FormatList || c.Conf.FormatCsvList {
 		for _, r := range rs {
 			fmt.Println(formatList(r))
 		}


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Hello,

I added "CSV" support.

Currently only supports normal output.

In the future, full format will be supported.

Fixes #1018

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

```
root@karas:~# vuls scan
[Aug 15 12:50:58]  INFO [localhost] Start scanning
[Aug 15 12:50:58]  INFO [localhost] config: /root/config.toml
[Aug 15 12:50:58]  INFO [localhost] Validating config...
[Aug 15 12:50:58]  INFO [localhost] Detecting Server/Container OS...
[Aug 15 12:50:58]  INFO [localhost] Detecting OS of servers...
[Aug 15 12:50:58]  INFO [localhost] (1/1) Detected: localhost: ubuntu 18.04
[Aug 15 12:50:58]  INFO [localhost] Detecting OS of containers...
[Aug 15 12:50:58]  INFO [localhost] Checking Scan Modes...
[Aug 15 12:50:58]  INFO [localhost] Detecting Platforms...
[Aug 15 12:50:58]  INFO [localhost] (1/1) localhost is running on other
[Aug 15 12:50:58]  INFO [localhost] Detecting IPS identifiers...
[Aug 15 12:50:58]  INFO [localhost] (1/1) localhost has 0 IPS integration
[Aug 15 12:50:58]  INFO [localhost] Scanning vulnerabilities...
[Aug 15 12:50:58]  INFO [localhost] Scanning vulnerable OS packages...
[Aug 15 12:50:58]  INFO [localhost] Scanning in fast mode

One Line Summary
================
[Reboot Required] localhost     ubuntu18.04     537 installed


To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

```
root@karas:~# vuls report -format-csv
[Aug 15 12:51:31]  INFO [localhost] Validating config...
[Aug 15 12:51:31]  INFO [localhost] Loaded: /root/results/2020-08-15T12:50:58Z
[Aug 15 12:51:31]  INFO [localhost] Validating db config...
INFO[0000] -cvedb-type: sqlite3, -cvedb-url: , -cvedb-path: /root/cve.sqlite3
INFO[0000] -ovaldb-type: sqlite3, -ovaldb-url: , -ovaldb-path: /root/oval.sqlite3
INFO[0000] -gostdb-type: sqlite3, -gostdb-url: , -gostdb-path: /root/gost.sqlite3
INFO[0000] -exploitdb-type: sqlite3, -exploitdb-url: , -exploitdb-path: /root/go-exploitdb.sqlite3
INFO[0000] -msfdb-type: sqlite3, -msfdb-url: , -msfdb-path: /root/go-msfdb.sqlite3
DBUG[08-15|12:51:31] Opening DB (sqlite3).
DBUG[08-15|12:51:31] Migrating DB (sqlite3).
[Aug 15 12:51:31]  WARN [localhost] --gostdb-path=/root/gost.sqlite3 file not found. Vuls can detect `patch-not-released-CVE-ID` using gost if the scan target server is Debian, RHEL or CentOS, For details, see `https://github.com/knqyf263/gost#fetch-redhat`
[Aug 15 12:51:31]  WARN [localhost] --exploitdb-path=/root/go-exploitdb.sqlite3 file not found. Fetch go-exploit-db before reporting if you want to display exploit codes of detected CVE-IDs. For details, see `https://github.com/mozqnet/go-exploitdb`
[Aug 15 12:51:31]  WARN [localhost] --msfdb-path=/root/go-msfdb.sqlite3 file not found. Fetch go-msfdb before reporting if you want to display metasploit modules of detected CVE-IDs. For details, see `https://github.com/takuzoo3868/go-msfdb`
[Aug 15 12:51:31]  INFO [localhost] [Reboot Required] localhost: 0 CVEs are detected with Library
[Aug 15 12:51:31]  INFO [localhost] OVAL is fresh: ubuntu 18.04
[Aug 15 12:51:31]  WARN [localhost] The OVAL name of the running kernel image {Release:4.15.0-66-generic Version: RebootRequired:true} is not found. So vulns of `linux` wll be detected. server: localhost
[Aug 15 12:51:33]  INFO [localhost] [Reboot Required] localhost: 341 CVEs are detected with OVAL
[Aug 15 12:51:33]  INFO [localhost] [Reboot Required] localhost: 0 CVEs are detected with CPE
[Aug 15 12:51:33]  INFO [localhost] [Reboot Required] localhost: 0 CVEs are detected with GitHub Security Alerts
[Aug 15 12:51:33]  INFO [localhost] [Reboot Required] localhost: 0 unfixed CVEs are detected with gost
[Aug 15 12:51:33]  INFO [localhost] Fill CVE detailed information with CVE-DB
[Aug 15 12:51:33]  INFO [localhost] Fill exploit information with Exploit-DB
[Aug 15 12:51:33]  INFO [localhost] [Reboot Required] localhost: 0 exploits are detected
[Aug 15 12:51:33]  INFO [localhost] Fill metasploit module information with Metasploit-DB
[Aug 15 12:51:33]  INFO [localhost] [Reboot Required] localhost: 0 modules are detected
[Reboot Required] localhost (ubuntu18.04)
=========================================
Total: 341 (High:9 Medium:152 Low:160 ?:20), 236/341 Fixed, 537 installed, 0 exploits, 0 modules, en: 1, ja: 0 alerts

CVE-ID,                 CVSS,   ATTACK, POC,    CERT,   FIXED,          NVD
CVE-2020-10108,          9.8,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10108
CVE-2020-10109,          9.8,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10109
CVE-2018-12207,          8.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-12207
CVE-2019-0155,           8.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-0155
CVE-2019-11135,          8.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-11135
CVE-2020-10531,          8.8,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10531
CVE-2020-10878,          8.6,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-10878
CVE-2020-8616,           8.6,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8616
CVE-2020-10543,          8.2,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-10543
CVE-2020-10713,          8.2,   AV:L,   ,       USCERT, fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10713
CVE-2020-6096,           8.1,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-6096
CVE-2020-9794,           8.1,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-9794
CVE-2020-10757,          7.8,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10757
CVE-2020-11725,          7.8,   AV:L,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-11725
CVE-2020-12653,          7.8,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12653
CVE-2020-12657,          7.8,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12657
CVE-2020-12762,          7.8,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12762
CVE-2020-1712,           7.8,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-1712
CVE-2020-7053,           7.8,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-7053
CVE-2019-20907,          7.5,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20907
CVE-2020-12243,          7.5,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12243
CVE-2020-12723,          7.5,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-12723
CVE-2020-7595,           7.5,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-7595
CVE-2020-8617,           7.5,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8617
CVE-2019-14899,          7.4,   AV:A,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-14899
CVE-2020-11501,          7.4,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11501
CVE-2020-12464,          7.2,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12464
CVE-2020-15780,          7.2,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15780
CVE-2020-11668,          7.1,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11668
CVE-2020-12654,          7.1,   AV:A,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12654
CVE-2020-8428,           7.1,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8428
CVE-2020-8492,           7.1,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8492
CVE-2020-8648,           7.1,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8648
CVE-2020-9383,           7.1,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-9383
CVE-2020-11884,          7.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11884
CVE-2020-15702,          7.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15702
CVE-2020-1751,           7.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-1751
CVE-2020-1752,           7.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-1752
CVE-2013-7445,           6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2013-7445
CVE-2015-8553,           6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2015-8553
CVE-2016-1585,           6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-1585
CVE-2016-8660,           6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-8660
CVE-2018-1000500,        6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-1000500
CVE-2018-10103,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-10103
CVE-2018-10105,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-10105
CVE-2018-11236,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-11236
CVE-2018-11237,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-11237
CVE-2018-14461,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14461
CVE-2018-14462,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14462
CVE-2018-14463,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14463
CVE-2018-14464,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14464
CVE-2018-14465,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14465
CVE-2018-14466,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14466
CVE-2018-14467,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14467
CVE-2018-14468,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14468
CVE-2018-14469,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14469
CVE-2018-14470,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14470
CVE-2018-14880,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14880
CVE-2018-14881,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14881
CVE-2018-14882,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14882
CVE-2018-16227,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16227
CVE-2018-16228,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16228
CVE-2018-16229,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16229
CVE-2018-16230,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16230
CVE-2018-16300,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16300
CVE-2018-16451,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16451
CVE-2018-16452,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16452
CVE-2018-17977,          6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-17977
CVE-2018-19591,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-19591
CVE-2018-20217,          6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-20217
CVE-2018-20839,          6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-20839
CVE-2019-0154,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-0154
CVE-2019-10220,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-10220
CVE-2019-11482,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-11482
CVE-2019-11483,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-11483
CVE-2019-11485,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-11485
CVE-2019-12290,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-12290
CVE-2019-13627,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-13627
CVE-2019-14615,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-14615
CVE-2019-14866,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-14866
CVE-2019-14895,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-14895
CVE-2019-14896,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-14896
CVE-2019-14897,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-14897
CVE-2019-14901,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-14901
CVE-2019-15098,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15098
CVE-2019-15099,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15099
CVE-2019-15165,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15165
CVE-2019-15166,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15166
CVE-2019-15167,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15167
CVE-2019-15790,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15790
CVE-2019-15795,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15795
CVE-2019-15796,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15796
CVE-2019-16746,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16746
CVE-2019-17052,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17052
CVE-2019-17053,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17053
CVE-2019-17054,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17054
CVE-2019-17055,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17055
CVE-2019-17056,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17056
CVE-2019-17133,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17133
CVE-2019-17666,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17666
CVE-2019-18197,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18197
CVE-2019-18218,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18218
CVE-2019-18224,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18224
CVE-2019-18282,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18282
CVE-2019-18348,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18348
CVE-2019-18660,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18660
CVE-2019-19062,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19062
CVE-2019-19332,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19332
CVE-2019-19462,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19462
CVE-2019-19529,          6.9,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19529
CVE-2019-19768,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19768
CVE-2019-19807,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19807
CVE-2019-19906,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19906
CVE-2019-19922,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19922
CVE-2019-19965,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19965
CVE-2019-20096,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20096
CVE-2019-20367,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20367
CVE-2019-20636,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20636
CVE-2019-20812,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20812
CVE-2019-20908,          6.9,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20908
CVE-2019-2182,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-2182
CVE-2019-5108,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-5108
CVE-2019-5188,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-5188
CVE-2019-6477,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-6477
CVE-2019-9511,           6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-9511
CVE-2019-9512,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-9512
CVE-2019-9513,           6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-9513
CVE-2019-9514,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-9514
CVE-2019-9515,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-9515
CVE-2020-0255,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-0255
CVE-2020-11935,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11935
CVE-2020-11936,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11936
CVE-2020-14314,          6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-14314
CVE-2020-14343,          6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-14343
CVE-2020-15709,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15709
CVE-2020-1749,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-1749
CVE-2020-8177,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8177
CVE-2020-2732,           6.8,   AV:A,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-2732
CVE-2019-20795,          6.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20795
CVE-2020-12770,          6.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12770
CVE-2020-13776,          6.7,   AV:L,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-13776
CVE-2020-14309,          6.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-14309
CVE-2020-14344,          6.7,   AV:L,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-14344
CVE-2020-13143,          6.5,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-13143
CVE-2020-8834,           6.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8834
CVE-2020-10690,          6.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10690
CVE-2020-14308,          6.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-14308
CVE-2020-15705,          6.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15705
CVE-2020-15706,          6.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15706
CVE-2020-15707,          6.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15707
CVE-2020-10751,          6.1,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10751
CVE-2020-8647,           6.1,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8647
CVE-2020-11565,          6.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11565
CVE-2020-14310,          6.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-14310
CVE-2020-14311,          6.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-14311
CVE-2020-10711,          5.9,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10711
CVE-2020-11934,          5.9,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11934
CVE-2020-14422,          5.9,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-14422
CVE-2020-8649,           5.9,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8649
CVE-2019-18885,          5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18885
CVE-2020-0009,           5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-0009
CVE-2020-10029,          5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10029
CVE-2020-11669,          5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11669
CVE-2020-12049,          5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12049
CVE-2020-12769,          5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12769
CVE-2020-15701,          5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15701
CVE-2020-3810,           5.5,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-3810
CVE-2020-8831,           5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8831
CVE-2020-8832,           5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8832
CVE-2020-8992,           5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8992
CVE-2020-10942,          5.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10942
CVE-2020-12826,          5.3,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12826
CVE-2020-12888,          5.3,   AV:L,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-12888
CVE-2020-14155,          5.3,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-14155
CVE-2020-11608,          4.9,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11608
CVE-2020-11609,          4.9,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11609
CVE-2020-8619,           4.9,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8619
CVE-2020-12114,          4.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12114
CVE-2020-12652,          4.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12652
CVE-2020-14416,          4.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-14416
CVE-2020-8833,           4.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8833
CVE-2020-0067,           4.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-0067
CVE-2020-11494,          4.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11494
CVE-2020-16166,          4.3,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-16166
CVE-2009-5080,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2009-5080
CVE-2009-5155,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2009-5155
CVE-2012-2663,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2012-2663
CVE-2012-6655,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2012-6655
CVE-2013-4235,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2013-4235
CVE-2015-3416,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2015-3416
CVE-2015-8985,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2015-8985
CVE-2015-9019,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2015-9019
CVE-2016-10723,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-10723
CVE-2016-10739,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-10739
CVE-2016-2568,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-2568
CVE-2016-2781,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-2781
CVE-2016-4484,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-4484
CVE-2016-9840,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2016-9840
CVE-2016-9841,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2016-9841
CVE-2016-9842,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2016-9842
CVE-2016-9843,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2016-9843
CVE-2017-0537,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-0537
CVE-2017-13716,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-13716
CVE-2017-14159,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-14159
CVE-2017-15131,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-15131
CVE-2017-16808,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2017-16808
CVE-2017-18342,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-18342
CVE-2017-8845,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-8845
CVE-2017-9525,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-9525
CVE-2018-1000021,        3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-1000021
CVE-2018-10322,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-10322
CVE-2018-1121,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-1121
CVE-2018-12929,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-12929
CVE-2018-12930,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-12930
CVE-2018-12931,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-12931
CVE-2018-13095,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-13095
CVE-2018-14036,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-14036
CVE-2018-14048,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-14048
CVE-2018-14879,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14879
CVE-2018-16868,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-16868
CVE-2018-16869,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-16869
CVE-2018-19519,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-19519
CVE-2018-20482,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-20482
CVE-2018-20673,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-20673
CVE-2018-20786,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-20786
CVE-2018-5710,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-5710
CVE-2018-7169,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-7169
CVE-2018-9996,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-9996
CVE-2019-1010204,        3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-1010204
CVE-2019-1010220,        3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-1010220
CVE-2019-11481,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-11481
CVE-2019-12098,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-12098
CVE-2019-12387,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-12387
CVE-2019-12855,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-12855
CVE-2019-12904,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-12904
CVE-2019-13050,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-13050
CVE-2019-13117,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-13117
CVE-2019-13118,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-13118
CVE-2019-14834,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-14834
CVE-2019-14855,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-14855
CVE-2019-15213,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-15213
CVE-2019-1547,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-1547
CVE-2019-1549,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-1549
CVE-2019-1551,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-1551
CVE-2019-1563,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-1563
CVE-2019-16089,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16089
CVE-2019-16229,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16229
CVE-2019-16231,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16231
CVE-2019-16232,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16232
CVE-2019-16233,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16233
CVE-2019-16234,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16234
CVE-2019-17041,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-17041
CVE-2019-17042,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-17042
CVE-2019-17514,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17514
CVE-2019-17543,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-17543
CVE-2019-18276,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-18276
CVE-2019-18634,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18634
CVE-2019-18683,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18683
CVE-2019-18786,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18786
CVE-2019-18806,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18806
CVE-2019-18808,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-18808
CVE-2019-18809,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18809
CVE-2019-19036,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19036
CVE-2019-19037,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19037
CVE-2019-19045,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19045
CVE-2019-19046,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19046
CVE-2019-19051,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19051
CVE-2019-19052,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19052
CVE-2019-19054,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19054
CVE-2019-19056,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19056
CVE-2019-19057,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19057
CVE-2019-19058,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19058
CVE-2019-19060,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19060
CVE-2019-19061,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19061
CVE-2019-19063,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19063
CVE-2019-19065,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19065
CVE-2019-19066,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19066
CVE-2019-19067,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19067
CVE-2019-19068,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19068
CVE-2019-19071,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19071
CVE-2019-19073,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19073
CVE-2019-19074,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19074
CVE-2019-19075,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19075
CVE-2019-19078,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19078
CVE-2019-19082,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19082
CVE-2019-19083,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19083
CVE-2019-19126,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19126
CVE-2019-19227,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19227
CVE-2019-19377,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19377
CVE-2019-19378,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19378
CVE-2019-19447,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19447
CVE-2019-19523,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19523
CVE-2019-19524,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19524
CVE-2019-19525,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19525
CVE-2019-19526,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19526
CVE-2019-19528,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19528
CVE-2019-19532,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19532
CVE-2019-19533,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19533
CVE-2019-19534,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19534
CVE-2019-19767,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19767
CVE-2019-19770,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19770
CVE-2019-19813,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19813
CVE-2019-19814,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19814
CVE-2019-19815,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19815
CVE-2019-19816,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19816
CVE-2019-19956,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19956
CVE-2019-20079,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20079
CVE-2019-20386,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20386
CVE-2019-20425,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-20425
CVE-2019-20429,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-20429
CVE-2019-20806,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20806
CVE-2019-20807,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-20807
CVE-2019-20838,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-20838
CVE-2019-3843,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-3843
CVE-2019-3844,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-3844
CVE-2019-7306,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-7306
CVE-2019-9169,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-9169
CVE-2019-9445,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-9445
CVE-2019-9674,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-9674
CVE-2019-9923,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-9923
CVE-2020-10781,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-10781
CVE-2016-10228,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-10228
CVE-2017-11164,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-11164
CVE-2017-13165,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-13165
CVE-2017-13693,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-13693
CVE-2017-8283,           0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-8283
CVE-2018-1000654,        0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-1000654
CVE-2018-12928,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-12928
CVE-2018-5709,           0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-5709
CVE-2018-6952,           0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-6952
CVE-2018-7738,           0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-7738
CVE-2019-11360,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-11360
CVE-2019-12380,          0.0,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-12380
CVE-2019-15217,          0.0,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15217
CVE-2019-15291,          0.0,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15291
CVE-2019-16230,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-16230
CVE-2019-17075,          0.0,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17075
CVE-2019-17594,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-17594
CVE-2019-17595,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-17595
CVE-2019-19039,          0.0,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19039
CVE-2020-14331,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-14331
```

```
root@karas:~# cat results/2020-08-15T12\:50\:58Z/localhost_short.csv
[Reboot Required] localhost (ubuntu18.04)
=========================================
Total: 341 (High:9 Medium:152 Low:160 ?:20), 236/341 Fixed, 537 installed, 0 exploits, 0 modules, en: 1, ja: 0 alerts

CVE-ID,                 CVSS,   ATTACK, POC,    CERT,   FIXED,          NVD
CVE-2020-10108,          9.8,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10108
CVE-2020-10109,          9.8,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10109
CVE-2018-12207,          8.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-12207
CVE-2019-0155,           8.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-0155
CVE-2019-11135,          8.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-11135
CVE-2020-10531,          8.8,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10531
CVE-2020-10878,          8.6,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-10878
CVE-2020-8616,           8.6,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8616
CVE-2020-10543,          8.2,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-10543
CVE-2020-10713,          8.2,   AV:L,   ,       USCERT, fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10713
CVE-2020-6096,           8.1,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-6096
CVE-2020-9794,           8.1,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-9794
CVE-2020-10757,          7.8,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10757
CVE-2020-11725,          7.8,   AV:L,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-11725
CVE-2020-12653,          7.8,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12653
CVE-2020-12657,          7.8,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12657
CVE-2020-12762,          7.8,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12762
CVE-2020-1712,           7.8,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-1712
CVE-2020-7053,           7.8,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-7053
CVE-2019-20907,          7.5,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20907
CVE-2020-12243,          7.5,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12243
CVE-2020-12723,          7.5,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-12723
CVE-2020-7595,           7.5,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-7595
CVE-2020-8617,           7.5,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8617
CVE-2019-14899,          7.4,   AV:A,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-14899
CVE-2020-11501,          7.4,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11501
CVE-2020-12464,          7.2,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12464
CVE-2020-15780,          7.2,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15780
CVE-2020-11668,          7.1,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11668
CVE-2020-12654,          7.1,   AV:A,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12654
CVE-2020-8428,           7.1,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8428
CVE-2020-8492,           7.1,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8492
CVE-2020-8648,           7.1,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8648
CVE-2020-9383,           7.1,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-9383
CVE-2020-11884,          7.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11884
CVE-2020-15702,          7.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15702
CVE-2020-1751,           7.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-1751
CVE-2020-1752,           7.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-1752
CVE-2013-7445,           6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2013-7445
CVE-2015-8553,           6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2015-8553
CVE-2016-1585,           6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-1585
CVE-2016-8660,           6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-8660
CVE-2018-1000500,        6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-1000500
CVE-2018-10103,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-10103
CVE-2018-10105,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-10105
CVE-2018-11236,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-11236
CVE-2018-11237,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-11237
CVE-2018-14461,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14461
CVE-2018-14462,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14462
CVE-2018-14463,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14463
CVE-2018-14464,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14464
CVE-2018-14465,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14465
CVE-2018-14466,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14466
CVE-2018-14467,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14467
CVE-2018-14468,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14468
CVE-2018-14469,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14469
CVE-2018-14470,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14470
CVE-2018-14880,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14880
CVE-2018-14881,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14881
CVE-2018-14882,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14882
CVE-2018-16227,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16227
CVE-2018-16228,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16228
CVE-2018-16229,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16229
CVE-2018-16230,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16230
CVE-2018-16300,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16300
CVE-2018-16451,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16451
CVE-2018-16452,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-16452
CVE-2018-17977,          6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-17977
CVE-2018-19591,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-19591
CVE-2018-20217,          6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-20217
CVE-2018-20839,          6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-20839
CVE-2019-0154,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-0154
CVE-2019-10220,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-10220
CVE-2019-11482,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-11482
CVE-2019-11483,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-11483
CVE-2019-11485,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-11485
CVE-2019-12290,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-12290
CVE-2019-13627,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-13627
CVE-2019-14615,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-14615
CVE-2019-14866,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-14866
CVE-2019-14895,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-14895
CVE-2019-14896,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-14896
CVE-2019-14897,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-14897
CVE-2019-14901,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-14901
CVE-2019-15098,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15098
CVE-2019-15099,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15099
CVE-2019-15165,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15165
CVE-2019-15166,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15166
CVE-2019-15167,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15167
CVE-2019-15790,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15790
CVE-2019-15795,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15795
CVE-2019-15796,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15796
CVE-2019-16746,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16746
CVE-2019-17052,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17052
CVE-2019-17053,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17053
CVE-2019-17054,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17054
CVE-2019-17055,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17055
CVE-2019-17056,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17056
CVE-2019-17133,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17133
CVE-2019-17666,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17666
CVE-2019-18197,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18197
CVE-2019-18218,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18218
CVE-2019-18224,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18224
CVE-2019-18282,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18282
CVE-2019-18348,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18348
CVE-2019-18660,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18660
CVE-2019-19062,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19062
CVE-2019-19332,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19332
CVE-2019-19462,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19462
CVE-2019-19529,          6.9,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19529
CVE-2019-19768,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19768
CVE-2019-19807,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19807
CVE-2019-19906,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19906
CVE-2019-19922,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19922
CVE-2019-19965,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19965
CVE-2019-20096,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20096
CVE-2019-20367,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20367
CVE-2019-20636,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20636
CVE-2019-20812,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20812
CVE-2019-20908,          6.9,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20908
CVE-2019-2182,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-2182
CVE-2019-5108,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-5108
CVE-2019-5188,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-5188
CVE-2019-6477,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-6477
CVE-2019-9511,           6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-9511
CVE-2019-9512,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-9512
CVE-2019-9513,           6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-9513
CVE-2019-9514,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-9514
CVE-2019-9515,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-9515
CVE-2020-0255,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-0255
CVE-2020-11935,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11935
CVE-2020-11936,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11936
CVE-2020-14314,          6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-14314
CVE-2020-14343,          6.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-14343
CVE-2020-15709,          6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15709
CVE-2020-1749,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-1749
CVE-2020-8177,           6.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8177
CVE-2020-2732,           6.8,   AV:A,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-2732
CVE-2019-20795,          6.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20795
CVE-2020-12770,          6.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12770
CVE-2020-13776,          6.7,   AV:L,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-13776
CVE-2020-14309,          6.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-14309
CVE-2020-14344,          6.7,   AV:L,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-14344
CVE-2020-13143,          6.5,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-13143
CVE-2020-8834,           6.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8834
CVE-2020-10690,          6.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10690
CVE-2020-14308,          6.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-14308
CVE-2020-15705,          6.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15705
CVE-2020-15706,          6.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15706
CVE-2020-15707,          6.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15707
CVE-2020-10751,          6.1,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10751
CVE-2020-8647,           6.1,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8647
CVE-2020-11565,          6.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11565
CVE-2020-14310,          6.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-14310
CVE-2020-14311,          6.0,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-14311
CVE-2020-10711,          5.9,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10711
CVE-2020-11934,          5.9,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11934
CVE-2020-14422,          5.9,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-14422
CVE-2020-8649,           5.9,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8649
CVE-2019-18885,          5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18885
CVE-2020-0009,           5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-0009
CVE-2020-10029,          5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10029
CVE-2020-11669,          5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11669
CVE-2020-12049,          5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12049
CVE-2020-12769,          5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12769
CVE-2020-15701,          5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-15701
CVE-2020-3810,           5.5,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-3810
CVE-2020-8831,           5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8831
CVE-2020-8832,           5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8832
CVE-2020-8992,           5.5,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8992
CVE-2020-10942,          5.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-10942
CVE-2020-12826,          5.3,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12826
CVE-2020-12888,          5.3,   AV:L,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-12888
CVE-2020-14155,          5.3,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-14155
CVE-2020-11608,          4.9,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11608
CVE-2020-11609,          4.9,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11609
CVE-2020-8619,           4.9,   AV:N,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8619
CVE-2020-12114,          4.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12114
CVE-2020-12652,          4.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-12652
CVE-2020-14416,          4.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-14416
CVE-2020-8833,           4.7,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-8833
CVE-2020-0067,           4.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-0067
CVE-2020-11494,          4.4,   AV:L,   ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2020-11494
CVE-2020-16166,          4.3,   AV:N,   ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-16166
CVE-2009-5080,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2009-5080
CVE-2009-5155,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2009-5155
CVE-2012-2663,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2012-2663
CVE-2012-6655,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2012-6655
CVE-2013-4235,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2013-4235
CVE-2015-3416,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2015-3416
CVE-2015-8985,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2015-8985
CVE-2015-9019,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2015-9019
CVE-2016-10723,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-10723
CVE-2016-10739,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-10739
CVE-2016-2568,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-2568
CVE-2016-2781,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-2781
CVE-2016-4484,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-4484
CVE-2016-9840,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2016-9840
CVE-2016-9841,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2016-9841
CVE-2016-9842,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2016-9842
CVE-2016-9843,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2016-9843
CVE-2017-0537,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-0537
CVE-2017-13716,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-13716
CVE-2017-14159,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-14159
CVE-2017-15131,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-15131
CVE-2017-16808,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2017-16808
CVE-2017-18342,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-18342
CVE-2017-8845,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-8845
CVE-2017-9525,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-9525
CVE-2018-1000021,        3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-1000021
CVE-2018-10322,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-10322
CVE-2018-1121,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-1121
CVE-2018-12929,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-12929
CVE-2018-12930,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-12930
CVE-2018-12931,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-12931
CVE-2018-13095,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-13095
CVE-2018-14036,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-14036
CVE-2018-14048,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-14048
CVE-2018-14879,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-14879
CVE-2018-16868,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-16868
CVE-2018-16869,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-16869
CVE-2018-19519,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-19519
CVE-2018-20482,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-20482
CVE-2018-20673,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-20673
CVE-2018-20786,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-20786
CVE-2018-5710,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2018-5710
CVE-2018-7169,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-7169
CVE-2018-9996,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-9996
CVE-2019-1010204,        3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-1010204
CVE-2019-1010220,        3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-1010220
CVE-2019-11481,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-11481
CVE-2019-12098,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-12098
CVE-2019-12387,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-12387
CVE-2019-12855,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-12855
CVE-2019-12904,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-12904
CVE-2019-13050,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-13050
CVE-2019-13117,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-13117
CVE-2019-13118,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-13118
CVE-2019-14834,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-14834
CVE-2019-14855,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-14855
CVE-2019-15213,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-15213
CVE-2019-1547,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-1547
CVE-2019-1549,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-1549
CVE-2019-1551,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-1551
CVE-2019-1563,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-1563
CVE-2019-16089,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16089
CVE-2019-16229,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16229
CVE-2019-16231,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16231
CVE-2019-16232,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16232
CVE-2019-16233,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16233
CVE-2019-16234,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-16234
CVE-2019-17041,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-17041
CVE-2019-17042,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-17042
CVE-2019-17514,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17514
CVE-2019-17543,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-17543
CVE-2019-18276,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-18276
CVE-2019-18634,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18634
CVE-2019-18683,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18683
CVE-2019-18786,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18786
CVE-2019-18806,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18806
CVE-2019-18808,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-18808
CVE-2019-18809,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-18809
CVE-2019-19036,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19036
CVE-2019-19037,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19037
CVE-2019-19045,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19045
CVE-2019-19046,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19046
CVE-2019-19051,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19051
CVE-2019-19052,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19052
CVE-2019-19054,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19054
CVE-2019-19056,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19056
CVE-2019-19057,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19057
CVE-2019-19058,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19058
CVE-2019-19060,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19060
CVE-2019-19061,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19061
CVE-2019-19063,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19063
CVE-2019-19065,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19065
CVE-2019-19066,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19066
CVE-2019-19067,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19067
CVE-2019-19068,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19068
CVE-2019-19071,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19071
CVE-2019-19073,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19073
CVE-2019-19074,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19074
CVE-2019-19075,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19075
CVE-2019-19078,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19078
CVE-2019-19082,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19082
CVE-2019-19083,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19083
CVE-2019-19126,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19126
CVE-2019-19227,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19227
CVE-2019-19377,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19377
CVE-2019-19378,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19378
CVE-2019-19447,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19447
CVE-2019-19523,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19523
CVE-2019-19524,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19524
CVE-2019-19525,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19525
CVE-2019-19526,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19526
CVE-2019-19528,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19528
CVE-2019-19532,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19532
CVE-2019-19533,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19533
CVE-2019-19534,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19534
CVE-2019-19767,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19767
CVE-2019-19770,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19770
CVE-2019-19813,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19813
CVE-2019-19814,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19814
CVE-2019-19815,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-19815
CVE-2019-19816,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19816
CVE-2019-19956,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19956
CVE-2019-20079,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20079
CVE-2019-20386,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20386
CVE-2019-20425,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-20425
CVE-2019-20429,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-20429
CVE-2019-20806,          3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-20806
CVE-2019-20807,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-20807
CVE-2019-20838,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-20838
CVE-2019-3843,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-3843
CVE-2019-3844,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-3844
CVE-2019-7306,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-7306
CVE-2019-9169,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-9169
CVE-2019-9445,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-9445
CVE-2019-9674,           3.9,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-9674
CVE-2019-9923,           3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-9923
CVE-2020-10781,          3.9,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-10781
CVE-2016-10228,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2016-10228
CVE-2017-11164,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-11164
CVE-2017-13165,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-13165
CVE-2017-13693,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-13693
CVE-2017-8283,           0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2017-8283
CVE-2018-1000654,        0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-1000654
CVE-2018-12928,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-12928
CVE-2018-5709,           0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-5709
CVE-2018-6952,           0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-6952
CVE-2018-7738,           0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2018-7738
CVE-2019-11360,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-11360
CVE-2019-12380,          0.0,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-12380
CVE-2019-15217,          0.0,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15217
CVE-2019-15291,          0.0,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-15291
CVE-2019-16230,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-16230
CVE-2019-17075,          0.0,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-17075
CVE-2019-17594,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-17594
CVE-2019-17595,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2019-17595
CVE-2019-19039,          0.0,   ,       ,       ,       fixed,          https://nvd.nist.gov/vuln/detail/CVE-2019-19039
CVE-2020-14331,          0.0,   ,       ,       ,       unfixed,        https://nvd.nist.gov/vuln/detail/CVE-2020-14331
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

![csv_output](https://user-images.githubusercontent.com/29292618/90312931-3c8e8f00-df43-11ea-8c3a-72e9b1c881a3.PNG)


