### PR TITLE
Ignore apk warning when scanning alpine linux before apk update

### DIFF
--- a/scan/alpine.go
+++ b/scan/alpine.go
@@ -147,6 +147,9 @@ func (o *alpine) parseApkInfo(stdout string) (models.Packages, error) {
 		line := scanner.Text()
 		ss := strings.Split(line, "-")
 		if len(ss) < 3 {
+			if strings.Contains(ss[0], "WARNING") {
+				continue
+			}
 			return nil, xerrors.Errorf("Failed to parse apk info -v: %s", line)
 		}
 		name := strings.Join(ss[:len(ss)-2], "-")


### PR DESCRIPTION
# What did you implement

Avoided the error when scanning alpine linux before apk update.
The reason why the error occurred is that the command ``apk info -v'' outputs ``WARNING: Ignoring APKINDEX.2c4ac24e.tar.gz: No such file or directory''. 

Fixes #1045 

## Type of change

- [*] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I confirmed that the scan was completed successfully on alpine linux before running apk update.
![image](https://user-images.githubusercontent.com/39241071/93694922-870bb880-fb4c-11ea-83af-d76cdfaf0326.png)
