### PR TITLE
[WIP] Prioritize gost results over OVAL in Debian

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 replace (
 	gopkg.in/mattn/go-colorable.v0 => github.com/mattn/go-colorable v0.1.0
 	gopkg.in/mattn/go-isatty.v0 => github.com/mattn/go-isatty v0.0.6
+	github.com/knqyf263/gost v0.1.4 => github.com/MaineK00n/gost v0.1.5-0.20200923162501-f0f35c1cce43
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/docker-credential-gcr v1.5.0/go.mod h1:BB1eHdMLYEFuFdBlRMb0N7YGVdM5s6Pt0njxgvfbGGs=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
+github.com/MaineK00n/gost v0.1.5-0.20200923162501-f0f35c1cce43 h1:6hLmpSgc8FjuWgt84i/IUnk0IWhJrnF90Sxt0MtJKTs=
+github.com/MaineK00n/gost v0.1.5-0.20200923162501-f0f35c1cce43/go.mod h1:okRxldLs7RVZEjNVBOQEqKj93OU91TmULMnHWU6gJ1s=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=

--- a/gost/debian.go
+++ b/gost/debian.go
@@ -182,13 +182,11 @@ func getAllCvesViaHTTP(r *models.ScanResult, url string) ([]response, error) {
 }
 
 func (deb Debian) getCvesDebian(driver db.DB, release, pkgName string) (cves []models.CveContent) {
-	unfixedCves := driver.GetUnfixedCvesDebian(release, pkgName)
-	for _, cve := range unfixedCves {
+	for _, cve := range driver.GetUnfixedCvesDebian(release, pkgName) {
 		cves = append(cves, *deb.ConvertToModel(&cve))
 	}
 
-	fixedCves := driver.GetFixedCvesDebian(release, pkgName)
-	for _, cve := range fixedCves {
+	for _, cve := range driver.GetFixedCvesDebian(release, pkgName) {
 		cves = append(cves, *deb.ConvertToModel(&cve))
 	}
 

--- a/gost/debian.go
+++ b/gost/debian.go
@@ -8,6 +8,7 @@ import (
 	"github.com/future-architect/vuls/util"
 	"github.com/knqyf263/gost/db"
 	gostmodels "github.com/knqyf263/gost/models"
+	"golang.org/x/xerrors"
 )
 
 // Debian is Gost client for Debian GNU/Linux
@@ -19,6 +20,7 @@ type packCves struct {
 	packName  string
 	isSrcPack bool
 	cves      []models.CveContent
+	fixes     models.PackageFixStatuses
 }
 
 func (deb Debian) Supported(major string) bool {
@@ -30,19 +32,18 @@ func (deb Debian) Supported(major string) bool {
 	return ok
 }
 
-// DetectUnfixed fills cve information that has in Gost
-func (deb Debian) DetectUnfixed(driver db.DB, r *models.ScanResult, _ bool) (nCVEs int, err error) {
+// DetectCVEs fills cve information that has in Gost
+func (deb Debian) DetectCVEs(driver db.DB, r *models.ScanResult, _ bool) (int, error) {
 	if !deb.Supported(major(r.Release)) {
 		// only logging
 		util.Log.Warnf("Debian %s is not supported yet", r.Release)
 		return 0, nil
 	}
 
-	linuxImage := "linux-image-" + r.RunningKernel.Release
 	// Add linux and set the version of running kernel to search OVAL.
 	if r.Container.ContainerID == "" {
 		newVer := ""
-		if p, ok := r.Packages[linuxImage]; ok {
+		if p, ok := r.Packages["linux-image-"+r.RunningKernel.Release]; ok {
 			newVer = p.NewVersion
 		}
 		r.Packages["linux"] = models.Package{
@@ -57,10 +58,35 @@ func (deb Debian) DetectUnfixed(driver db.DB, r *models.ScanResult, _ bool) (nCV
 		r = r.RemoveRaspbianPackFromResult()
 	}
 
+	nFixedCVEs, err := deb.detectCVEsWithFixState(driver, r, "resolved")
+	if err != nil {
+		return 0, err
+	}
+
+	nUnfixedCVEs, err := deb.detectCVEsWithFixState(driver, r, "open")
+	if err != nil {
+		return 0, err
+	}
+
+	return (nFixedCVEs + nUnfixedCVEs), nil
+}
+
+func (deb Debian) detectCVEsWithFixState(driver db.DB, r *models.ScanResult, fixStatus string) (nCVEs int, err error) {
+	if fixStatus != "resolved" && fixStatus != "open" {
+		return 0, xerrors.Errorf(`Failed to detectCVEsWithFixState. fixStatus is not allowed except "open" and "resolved"(actual: fixStatus -> %s).`, fixStatus)
+	}
+
 	packCvesList := []packCves{}
 	if config.Conf.Gost.IsFetchViaHTTP() {
 		url, _ := util.URLPathJoin(config.Conf.Gost.URL, "debian", major(r.Release), "pkgs")
-		responses, err := getAllCvesViaHTTP(r, url)
+		s := func(s string) string {
+			if s == "resolved" {
+				return "fixed-cves"
+			}
+			return "unfixed-cves"
+		}(fixStatus)
+
+		responses, err := getCvesWithFixStateViaHTTP(r, url, s)
 		if err != nil {
 			return 0, err
 		}
@@ -71,13 +97,17 @@ func (deb Debian) DetectUnfixed(driver db.DB, r *models.ScanResult, _ bool) (nCV
 				return 0, err
 			}
 			cves := []models.CveContent{}
+			var fixes models.PackageFixStatuses
 			for _, debcve := range debCves {
-				cves = append(cves, *deb.ConvertToModel(&debcve))
+				cve, fix := deb.ConvertToModel(&debcve)
+				cves = append(cves, *cve)
+				fixes = append(fixes, fix...)
 			}
 			packCvesList = append(packCvesList, packCves{
 				packName:  res.request.packName,
 				isSrcPack: res.request.isSrcPack,
 				cves:      cves,
+				fixes:     fixes,
 			})
 		}
 	} else {
@@ -85,21 +115,23 @@ func (deb Debian) DetectUnfixed(driver db.DB, r *models.ScanResult, _ bool) (nCV
 			return 0, nil
 		}
 		for _, pack := range r.Packages {
-			cves := deb.getCvesDebian(driver, major(r.Release), pack.Name)
+			cves, fixes := deb.getCvesDebianWithfixStatus(driver, fixStatus, major(r.Release), pack.Name)
 			packCvesList = append(packCvesList, packCves{
 				packName:  pack.Name,
 				isSrcPack: false,
 				cves:      cves,
+				fixes:     fixes,
 			})
 		}
 
 		// SrcPack
 		for _, pack := range r.SrcPackages {
-			cves := deb.getCvesDebian(driver, major(r.Release), pack.Name)
+			cves, fixes := deb.getCvesDebianWithfixStatus(driver, fixStatus, major(r.Release), pack.Name)
 			packCvesList = append(packCvesList, packCves{
 				packName:  pack.Name,
 				isSrcPack: true,
 				cves:      cves,
+				fixes:     fixes,
 			})
 		}
 	}
@@ -126,75 +158,50 @@ func (deb Debian) DetectUnfixed(driver db.DB, r *models.ScanResult, _ bool) (nCV
 				nCVEs++
 			}
 
-			names := []string{}
-			if p.isSrcPack {
-				if srcPack, ok := r.SrcPackages[p.packName]; ok {
-					for _, binName := range srcPack.BinaryNames {
-						if _, ok := r.Packages[binName]; ok {
-							names = append(names, binName)
-						}
-					}
+			for _, f := range p.fixes {
+				if f.Name == "linux" {
+					f.Name = "linux-image-" + r.RunningKernel.Release
 				}
-			} else {
-				if p.packName == "linux" {
-					names = append(names, linuxImage)
-				} else {
-					names = append(names, p.packName)
-				}
-			}
-
-			for _, name := range names {
-				v.AffectedPackages = v.AffectedPackages.Store(models.PackageFixStatus{
-					Name:        name,
-					FixState:    "open",
-					NotFixedYet: true,
-				})
+				v.AffectedPackages = v.AffectedPackages.Store(f)
 			}
 			r.ScannedCves[cve.CveID] = v
 		}
 	}
+
 	return nCVEs, nil
 }
 
-func getAllFixedCvesViaHTTP(r *models.ScanResult, urlPrefix string) ([]response, error) {
-	return getCvesWithFixStateViaHTTP(r, urlPrefix, "fixed-cves")
-}
+func (deb Debian) getCvesDebianWithfixStatus(driver db.DB, fixStatus, release, pkgName string) (cves []models.CveContent, fixes models.PackageFixStatuses) {
+	cveDebs := func(s string) map[string]gostmodels.DebianCVE {
+		if s == "resolved" {
+			return driver.GetFixedCvesDebian(release, pkgName)
+		}
+		return driver.GetUnfixedCvesDebian(release, pkgName)
+	}(fixStatus)
 
-func getAllCvesViaHTTP(r *models.ScanResult, url string) ([]response, error) {
-	var responses []response
-
-	res, err := getAllUnfixedCvesViaHTTP(r, url)
-	if err != nil {
-		return []response{}, err
-	}
-	responses = append(responses, res...)
-
-	res, err = getAllFixedCvesViaHTTP(r, url)
-	if err != nil {
-		return []response{}, err
-	}
-	responses = append(responses, res...)
-
-	return responses, nil
-}
-
-func (deb Debian) getCvesDebian(driver db.DB, release, pkgName string) (cves []models.CveContent) {
-	for _, cve := range driver.GetUnfixedCvesDebian(release, pkgName) {
-		cves = append(cves, *deb.ConvertToModel(&cve))
-	}
-
-	for _, cve := range driver.GetFixedCvesDebian(release, pkgName) {
-		cves = append(cves, *deb.ConvertToModel(&cve))
+	for _, cveDeb := range cveDebs {
+		cve, fix := deb.ConvertToModel(&cveDeb)
+		cves = append(cves, *cve)
+		fixes = append(fixes, fix...)
 	}
 
 	return
 }
 
 // ConvertToModel converts gost model to vuls model
-func (deb Debian) ConvertToModel(cve *gostmodels.DebianCVE) *models.CveContent {
+func (deb Debian) ConvertToModel(cve *gostmodels.DebianCVE) (*models.CveContent, models.PackageFixStatuses) {
 	severity := ""
+	var fixes models.PackageFixStatuses
 	for _, p := range cve.Package {
 		for _, r := range p.Release {
+			f := func(name string, rel gostmodels.DebianRelease) models.PackageFixStatus {
+				if r.Status == "open" {
+					return models.PackageFixStatus{Name: name, NotFixedYet: true, FixState: rel.Status}
+				}
+				return models.PackageFixStatus{Name: name, FixedIn: r.FixedVersion}
+			}(p.PackageName, r)
+			fixes = append(fixes, f)
+
 			severity = r.Urgency
 			break
 		}
@@ -209,5 +216,5 @@ func (deb Debian) ConvertToModel(cve *gostmodels.DebianCVE) *models.CveContent {
 		Optional: map[string]string{
 			"attack range": cve.Scope,
 		},
-	}
+	}, fixes
 }

--- a/gost/debian.go
+++ b/gost/debian.go
@@ -123,8 +123,10 @@ func (deb Debian) DetectUnfixed(driver db.DB, r *models.ScanResult, _ bool) (nCV
 			if ok {
 				if v.CveContents == nil {
 					v.CveContents = models.NewCveContents(cve)
+					v.Confidences = models.Confidences{models.DebianSecurityTrackerMatch}
 				} else {
 					v.CveContents[models.DebianSecurityTracker] = cve
+					v.Confidences = models.Confidences{models.DebianSecurityTrackerMatch}
 				}
 			} else {
 				v = models.VulnInfo{

--- a/gost/gost.go
+++ b/gost/gost.go
@@ -8,7 +8,7 @@ import (
 
 // Client is the interface of OVAL client.
 type Client interface {
-	DetectUnfixed(db.DB, *models.ScanResult, bool) (int, error)
+	DetectCVEs(db.DB, *models.ScanResult, bool) (int, error)
 	FillCVEsWithRedHat(db.DB, *models.ScanResult) error
 
 	//TODO implement

--- a/gost/microsoft.go
+++ b/gost/microsoft.go
@@ -13,8 +13,8 @@ type Microsoft struct {
 	Base
 }
 
-// DetectUnfixed fills cve information that has in Gost
-func (ms Microsoft) DetectUnfixed(driver db.DB, r *models.ScanResult, _ bool) (nCVEs int, err error) {
+// DetectCVEs fills cve information that has in Gost
+func (ms Microsoft) DetectCVEs(driver db.DB, r *models.ScanResult, _ bool) (nCVEs int, err error) {
 	if driver == nil {
 		return 0, nil
 	}

--- a/gost/pseudo.go
+++ b/gost/pseudo.go
@@ -12,8 +12,8 @@ type Pseudo struct {
 	Base
 }
 
-// DetectUnfixed fills cve information that has in Gost
-func (pse Pseudo) DetectUnfixed(driver db.DB, r *models.ScanResult, _ bool) (int, error) {
+// DetectCVEs fills cve information that has in Gost
+func (pse Pseudo) DetectCVEs(driver db.DB, r *models.ScanResult, _ bool) (int, error) {
 	return 0, nil
 }
 

--- a/gost/redhat.go
+++ b/gost/redhat.go
@@ -17,8 +17,8 @@ type RedHat struct {
 	Base
 }
 
-// DetectUnfixed fills cve information that has in Gost
-func (red RedHat) DetectUnfixed(driver db.DB, r *models.ScanResult, ignoreWillNotFix bool) (nCVEs int, err error) {
+// DetectCVEs fills cve information that has in Gost
+func (red RedHat) DetectCVEs(driver db.DB, r *models.ScanResult, ignoreWillNotFix bool) (nCVEs int, err error) {
 	return red.fillUnfixed(driver, r, ignoreWillNotFix)
 }
 

--- a/gost/util.go
+++ b/gost/util.go
@@ -79,7 +79,11 @@ type request struct {
 	cveID          string
 }
 
-func getAllUnfixedCvesViaHTTP(r *models.ScanResult, urlPrefix string) (
+func getAllUnfixedCvesViaHTTP(r *models.ScanResult, urlPrefix string) ([]response, error) {
+	return getCvesWithFixStateViaHTTP(r, urlPrefix, "unfixed-cves")
+}
+
+func getCvesWithFixStateViaHTTP(r *models.ScanResult, urlPrefix, fixState string) (
 	responses []response, err error) {
 
 	nReq := len(r.Packages) + len(r.SrcPackages)
@@ -116,7 +120,7 @@ func getAllUnfixedCvesViaHTTP(r *models.ScanResult, urlPrefix string) (
 				url, err := util.URLPathJoin(
 					urlPrefix,
 					req.packName,
-					"unfixed-cves",
+					fixState,
 				)
 				if err != nil {
 					errChan <- err

--- a/models/scanresults.go
+++ b/models/scanresults.go
@@ -478,12 +478,11 @@ type Platform struct {
 }
 
 // RemoveRaspbianPackFromResult is for Raspberry Pi and removes the Raspberry Pi dedicated package from ScanResult.
-func (r ScanResult) RemoveRaspbianPackFromResult() ScanResult {
+func (r ScanResult) RemoveRaspbianPackFromResult() *ScanResult {
 	if r.Family != config.Raspbian {
-		return r
+		return &r
 	}
 
-	result := r
 	packs := make(Packages)
 	for _, pack := range r.Packages {
 		if !IsRaspbianPackage(pack.Name, pack.Version) {
@@ -498,8 +497,8 @@ func (r ScanResult) RemoveRaspbianPackFromResult() ScanResult {
 		}
 	}
 
-	result.Packages = packs
-	result.SrcPackages = srcPacks
+	r.Packages = packs
+	r.SrcPackages = srcPacks
 
-	return result
+	return &r
 }

--- a/models/scanresults_test.go
+++ b/models/scanresults_test.go
@@ -720,3 +720,52 @@ func TestIsDisplayUpdatableNum(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoveRaspbianPackFromResult(t *testing.T) {
+	var tests = []struct {
+		in  ScanResult
+		out ScanResult
+	}{
+		{
+			in: ScanResult{
+				Family: config.Raspbian,
+				Packages: Packages{
+					"apt":                Package{Name: "apt", Version: "1.8.2.1"},
+					"libraspberrypi-dev": Package{Name: "libraspberrypi-dev", Version: "1.20200811-1"},
+				},
+				SrcPackages: SrcPackages{},
+			},
+			out: ScanResult{
+				Family: config.Raspbian,
+				Packages: Packages{
+					"apt": Package{Name: "apt", Version: "1.8.2.1"},
+				},
+				SrcPackages: SrcPackages{},
+			},
+		},
+		{
+			in: ScanResult{
+				Family: config.Debian,
+				Packages: Packages{
+					"apt": Package{Name: "apt", Version: "1.8.2.1"},
+				},
+				SrcPackages: SrcPackages{},
+			},
+			out: ScanResult{
+				Family: config.Debian,
+				Packages: Packages{
+					"apt": Package{Name: "apt", Version: "1.8.2.1"},
+				},
+				SrcPackages: SrcPackages{},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		r := tt.in
+		r = *r.RemoveRaspbianPackFromResult()
+		if !reflect.DeepEqual(r, tt.out) {
+			t.Errorf("[%d] expected %+v, actual %+v", i, tt.out.Packages, r.Packages)
+		}
+	}
+}

--- a/oval/debian.go
+++ b/oval/debian.go
@@ -136,30 +136,19 @@ func (o Debian) FillWithOval(driver db.DB, r *models.ScanResult) (nCVEs int, err
 		}
 	}
 
+	// OVAL does not support Package for Raspbian, so skip it.
+	if r.Family == config.Raspbian {
+		r = r.RemoveRaspbianPackFromResult()
+	}
+
 	var relatedDefs ovalResult
 	if config.Conf.OvalDict.IsFetchViaHTTP() {
-		if r.Family != config.Raspbian {
-			if relatedDefs, err = getDefsByPackNameViaHTTP(r); err != nil {
-				return 0, err
-			}
-		} else {
-			// OVAL does not support Package for Raspbian, so skip it.
-			result := r.RemoveRaspbianPackFromResult()
-			if relatedDefs, err = getDefsByPackNameViaHTTP(&result); err != nil {
-				return 0, err
-			}
+		if relatedDefs, err = getDefsByPackNameViaHTTP(r); err != nil {
+			return 0, err
 		}
 	} else {
-		if r.Family != config.Raspbian {
-			if relatedDefs, err = getDefsByPackNameFromOvalDB(driver, r); err != nil {
-				return 0, err
-			}
-		} else {
-			// OVAL does not support Package for Raspbian, so skip it.
-			result := r.RemoveRaspbianPackFromResult()
-			if relatedDefs, err = getDefsByPackNameFromOvalDB(driver, &result); err != nil {
-				return 0, err
-			}
+		if relatedDefs, err = getDefsByPackNameFromOvalDB(driver, r); err != nil {
+			return 0, err
 		}
 	}
 

--- a/report/report.go
+++ b/report/report.go
@@ -354,7 +354,7 @@ func FillWithGost(driver gostdb.DB, r *models.ScanResult, ignoreWillNotFix bool)
 	gostClient := gost.NewClient(r.Family)
 	// TODO chekc if fetched
 	// TODO chekc if fresh enough
-	if nCVEs, err = gostClient.DetectUnfixed(driver, r, ignoreWillNotFix); err != nil {
+	if nCVEs, err = gostClient.DetectCVEs(driver, r, ignoreWillNotFix); err != nil {
 		return
 	}
 	return nCVEs, gostClient.FillCVEsWithRedHat(driver, r)


### PR DESCRIPTION
# What did you implement:
OVAL seems to be wrong sometimes in Debian, and gost (Debian Secutiry Tracker) seems to be correct, so give priority to the result of gost over OVAL.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

