### PR TITLE
fix: hard-coded version #1057

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Version of Vuls
-var Version = "0.9.9"
+var Version = "`make build` or `make install` will show the version"
 
 // Revision of Git
 var Revision string


### PR DESCRIPTION
# What did you implement:

Fixes #1057 

I forget to increment the version number of Vuls every time :)
The version number is injected at make time, so I'll put the initial values in text.
https://github.com/future-architect/vuls/blob/master/GNUmakefile#L17-L21

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
ubuntu@dev  ~│g│s│g│f│vuls  ⎇ version~  go build 
ubuntu@dev  ~│g│s│g│f│vuls  ⎇ version~  ./vuls -v
vuls `make build` or `make install` will show the version 
```

```
ubuntu@dev  ~│g│s│g│f│vuls  ⎇ version~  make build
...
ubuntu@dev  ~│g│s│g│f│vuls  ⎇ version~  ./vuls -v
vuls v0.12.3 build-20201012_135526_858beab
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES