### PR TITLE
fix(fast-root): affectedProcs, litening ports bug

### DIFF
--- a/scan/base.go
+++ b/scan/base.go
@@ -898,13 +898,13 @@ func (l *base) lsOfListen() (stdout string, err error) {
 	cmd := `lsof -i -P -n | grep LISTEN`
 	r := l.exec(util.PrependProxyEnv(cmd), sudo)
 	if !r.isSuccess(0, 1) {
-		return "", xerrors.Errorf("Failed to SSH: %s", r)
+		return "", xerrors.Errorf("Failed to lsof: %s", r)
 	}
 	return r.Stdout, nil
 }
 
-func (l *base) parseLsOf(stdout string) map[string]string {
-	portPid := map[string]string{}
+func (l *base) parseLsOf(stdout string) map[string][]string {
+	portPids := map[string][]string{}
 	scanner := bufio.NewScanner(strings.NewReader(stdout))
 	for scanner.Scan() {
 		ss := strings.Fields(scanner.Text())
@@ -912,9 +912,9 @@ func (l *base) parseLsOf(stdout string) map[string]string {
 			continue
 		}
 		pid, ipPort := ss[1], ss[8]
-		portPid[ipPort] = pid
+		portPids[ipPort] = util.AppendIfMissing(portPids[ipPort], pid)
 	}
-	return portPid
+	return portPids
 }
 
 func (l *base) parseListenPorts(port string) models.ListenPort {

--- a/scan/base_test.go
+++ b/scan/base_test.go
@@ -244,7 +244,7 @@ func Test_base_parseLsOf(t *testing.T) {
 	tests := []struct {
 		name        string
 		args        args
-		wantPortPid map[string]string
+		wantPortPid map[string][]string
 	}{
 		{
 			name: "lsof",
@@ -257,13 +257,34 @@ node       1498          ubuntu   21u  IPv6  20132      0t0  TCP *:35401 (LISTEN
 node       1498          ubuntu   22u  IPv6  20133      0t0  TCP *:44801 (LISTEN)
 docker-pr  9135            root    4u  IPv6 297133      0t0  TCP *:6379 (LISTEN)`,
 			},
-			wantPortPid: map[string]string{
-				"localhost:53": "474",
-				"*:22":         "644",
-				"*:3128":       "959",
-				"*:35401":      "1498",
-				"*:44801":      "1498",
-				"*:6379":       "9135",
+			wantPortPid: map[string][]string{
+				"localhost:53": {"474"},
+				"*:22":         {"644"},
+				"*:3128":       {"959"},
+				"*:35401":      {"1498"},
+				"*:44801":      {"1498"},
+				"*:6379":       {"9135"},
+			},
+		},
+		{
+			name: "lsof-duplicate-port",
+			args: args{
+				stdout: `sshd      832   root    3u  IPv4  15731      0t0  TCP *:22 (LISTEN)
+sshd      832   root    4u  IPv6  15740      0t0  TCP *:22 (LISTEN)
+master   1099   root   13u  IPv4  16657      0t0  TCP 127.0.0.1:25 (LISTEN)
+master   1099   root   14u  IPv6  16658      0t0  TCP [::1]:25 (LISTEN)
+httpd   32250   root    4u  IPv6 334982      0t0  TCP *:80 (LISTEN)
+httpd   32251 apache    4u  IPv6 334982      0t0  TCP *:80 (LISTEN)
+httpd   32252 apache    4u  IPv6 334982      0t0  TCP *:80 (LISTEN)
+httpd   32253 apache    4u  IPv6 334982      0t0  TCP *:80 (LISTEN)
+httpd   32254 apache    4u  IPv6 334982      0t0  TCP *:80 (LISTEN)
+httpd   32255 apache    4u  IPv6 334982      0t0  TCP *:80 (LISTEN)`,
+			},
+			wantPortPid: map[string][]string{
+				"*:22":         {"832"},
+				"127.0.0.1:25": {"1099"},
+				"[::1]:25":     {"1099"},
+				"*:80":         {"32250", "32251", "32252", "32253", "32254", "32255"},
 			},
 		},
 	}

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -1299,9 +1299,11 @@ func (o *debian) dpkgPs() error {
 	if err != nil {
 		return xerrors.Errorf("Failed to ls of: %w", err)
 	}
-	portPid := o.parseLsOf(stdout)
-	for port, pid := range portPid {
-		pidListenPorts[pid] = append(pidListenPorts[pid], o.parseListenPorts(port))
+	portPids := o.parseLsOf(stdout)
+	for port, pids := range portPids {
+		for _, pid := range pids {
+			pidListenPorts[pid] = append(pidListenPorts[pid], o.parseListenPorts(port))
+		}
 	}
 
 	for pid, loadedFiles := range pidLoadedFiles {


### PR DESCRIPTION
# What did you implement:

AffectedProcs was missing when an error occurred on `rpm -qa`.
Also, fixed a bug of port listening in the case of multiple processes listening to the same port.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES