### PR TITLE
fix(portscan): to keep backward compatibility before v0.13.0

### DIFF
--- a/models/packages_test.go
+++ b/models/packages_test.go
@@ -381,3 +381,50 @@ func Test_IsRaspbianPackage(t *testing.T) {
 		})
 	}
 }
+
+func Test_parseListenPorts(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   string
+		expect PortStat
+	}{{
+		name: "empty",
+		args: "",
+		expect: PortStat{
+			BindAddress: "",
+			Port:        "",
+		},
+	}, {
+		name: "normal",
+		args: "127.0.0.1:22",
+		expect: PortStat{
+			BindAddress: "127.0.0.1",
+			Port:        "22",
+		},
+	}, {
+		name: "asterisk",
+		args: "*:22",
+		expect: PortStat{
+			BindAddress: "*",
+			Port:        "22",
+		},
+	}, {
+		name: "ipv6_loopback",
+		args: "[::1]:22",
+		expect: PortStat{
+			BindAddress: "[::1]",
+			Port:        "22",
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listenPort, err := NewPortStat(tt.args)
+			if err != nil {
+				t.Errorf("unexpected error occurred: %s", err)
+			} else if !reflect.DeepEqual(*listenPort, tt.expect) {
+				t.Errorf("base.parseListenPorts() = %v, want %v", *listenPort, tt.expect)
+			}
+		})
+	}
+}

--- a/report/report.go
+++ b/report/report.go
@@ -181,6 +181,21 @@ func FillCveInfo(dbclient DBClient, r *models.ScanResult, cpeURIs []string, igno
 		}
 	}
 
+	// To keep backward compatibility
+	for i, pkg := range r.Packages {
+		for j, proc := range pkg.AffectedProcs {
+			for _, ipPort := range proc.ListenPorts {
+				ps, err := models.NewPortStat(ipPort)
+				if err != nil {
+					util.Log.Warnf("Failed to parse ip:port: %s, err:%+v", ipPort, err)
+					continue
+				}
+				r.Packages[i].AffectedProcs[j].ListenPortStats = append(
+					r.Packages[i].AffectedProcs[j].ListenPortStats, *ps)
+			}
+		}
+	}
+
 	nCVEs, err = DetectCpeURIsCves(dbclient.CveDB, r, cpeURIs)
 	if err != nil {
 		return xerrors.Errorf("Failed to detect vulns of `%s`: %w", cpeURIs, err)

--- a/report/tui.go
+++ b/report/tui.go
@@ -619,7 +619,7 @@ func summaryLines(r models.ScanResult) string {
 
 		av := vinfo.AttackVector()
 		for _, pname := range vinfo.AffectedPackages.Names() {
-			if r.Packages[pname].HasPortScanSuccessOn() {
+			if r.Packages[pname].HasReachablePort() {
 				av = fmt.Sprintf("%s ◉", av)
 				break
 			}
@@ -719,18 +719,18 @@ func setChangelogLayout(g *gocui.Gui) error {
 
 				if len(pack.AffectedProcs) != 0 {
 					for _, p := range pack.AffectedProcs {
-						if len(p.ListenPorts) == 0 {
+						if len(p.ListenPortStats) == 0 {
 							lines = append(lines, fmt.Sprintf("  * PID: %s %s Port: []",
 								p.PID, p.Name))
 							continue
 						}
 
 						var ports []string
-						for _, pp := range p.ListenPorts {
-							if len(pp.PortScanSuccessOn) == 0 {
-								ports = append(ports, fmt.Sprintf("%s:%s", pp.Address, pp.Port))
+						for _, pp := range p.ListenPortStats {
+							if len(pp.PortReachableTo) == 0 {
+								ports = append(ports, fmt.Sprintf("%s:%s", pp.BindAddress, pp.Port))
 							} else {
-								ports = append(ports, fmt.Sprintf("%s:%s(◉ Scannable: %s)", pp.Address, pp.Port, pp.PortScanSuccessOn))
+								ports = append(ports, fmt.Sprintf("%s:%s(◉ Scannable: %s)", pp.BindAddress, pp.Port, pp.PortReachableTo))
 							}
 						}
 

--- a/report/util.go
+++ b/report/util.go
@@ -262,17 +262,17 @@ No CVE-IDs are found in updatable packages.
 
 				if len(pack.AffectedProcs) != 0 {
 					for _, p := range pack.AffectedProcs {
-						if len(p.ListenPorts) == 0 {
+						if len(p.ListenPortStats) == 0 {
 							data = append(data, []string{"",
 								fmt.Sprintf("  - PID: %s %s, Port: []", p.PID, p.Name)})
 						}
 
 						var ports []string
-						for _, pp := range p.ListenPorts {
-							if len(pp.PortScanSuccessOn) == 0 {
-								ports = append(ports, fmt.Sprintf("%s:%s", pp.Address, pp.Port))
+						for _, pp := range p.ListenPortStats {
+							if len(pp.PortReachableTo) == 0 {
+								ports = append(ports, fmt.Sprintf("%s:%s", pp.BindAddress, pp.Port))
 							} else {
-								ports = append(ports, fmt.Sprintf("%s:%s(◉ Scannable: %s)", pp.Address, pp.Port, pp.PortScanSuccessOn))
+								ports = append(ports, fmt.Sprintf("%s:%s(◉ Scannable: %s)", pp.BindAddress, pp.Port, pp.PortReachableTo))
 							}
 						}
 

--- a/scan/base.go
+++ b/scan/base.go
@@ -748,11 +748,11 @@ func (l *base) detectScanDest() map[string][]string {
 			continue
 		}
 		for _, proc := range p.AffectedProcs {
-			if proc.ListenPorts == nil {
+			if proc.ListenPortStats == nil {
 				continue
 			}
-			for _, port := range proc.ListenPorts {
-				scanIPPortsMap[port.Address] = append(scanIPPortsMap[port.Address], port.Port)
+			for _, port := range proc.ListenPortStats {
+				scanIPPortsMap[port.BindAddress] = append(scanIPPortsMap[port.BindAddress], port.Port)
 			}
 		}
 	}
@@ -809,27 +809,31 @@ func (l *base) updatePortStatus(listenIPPorts []string) {
 			continue
 		}
 		for i, proc := range p.AffectedProcs {
-			if proc.ListenPorts == nil {
+			if proc.ListenPortStats == nil {
 				continue
 			}
-			for j, port := range proc.ListenPorts {
-				l.osPackages.Packages[name].AffectedProcs[i].ListenPorts[j].PortScanSuccessOn = l.findPortScanSuccessOn(listenIPPorts, port)
+			for j, port := range proc.ListenPortStats {
+				l.osPackages.Packages[name].AffectedProcs[i].ListenPortStats[j].PortReachableTo = l.findPortTestSuccessOn(listenIPPorts, port)
 			}
 		}
 	}
 }
 
-func (l *base) findPortScanSuccessOn(listenIPPorts []string, searchListenPort models.ListenPort) []string {
+func (l *base) findPortTestSuccessOn(listenIPPorts []string, searchListenPort models.PortStat) []string {
 	addrs := []string{}
 
 	for _, ipPort := range listenIPPorts {
-		ipPort := l.parseListenPorts(ipPort)
-		if searchListenPort.Address == "*" {
+		ipPort, err := models.NewPortStat(ipPort)
+		if err != nil {
+			util.Log.Warnf("Failed to find: %+v", err)
+			continue
+		}
+		if searchListenPort.BindAddress == "*" {
 			if searchListenPort.Port == ipPort.Port {
-				addrs = append(addrs, ipPort.Address)
+				addrs = append(addrs, ipPort.BindAddress)
 			}
-		} else if searchListenPort.Address == ipPort.Address && searchListenPort.Port == ipPort.Port {
-			addrs = append(addrs, ipPort.Address)
+		} else if searchListenPort.BindAddress == ipPort.BindAddress && searchListenPort.Port == ipPort.Port {
+			addrs = append(addrs, ipPort.BindAddress)
 		}
 	}
 
@@ -915,12 +919,4 @@ func (l *base) parseLsOf(stdout string) map[string][]string {
 		portPids[ipPort] = util.AppendIfMissing(portPids[ipPort], pid)
 	}
 	return portPids
-}
-
-func (l *base) parseListenPorts(port string) models.ListenPort {
-	sep := strings.LastIndex(port, ":")
-	if sep == -1 {
-		return models.ListenPort{}
-	}
-	return models.ListenPort{Address: port[:sep], Port: port[sep+1:]}
 }

--- a/scan/base_test.go
+++ b/scan/base_test.go
@@ -323,7 +323,7 @@ func Test_detectScanDest(t *testing.T) {
 					Version:    "1:2.8.4-3",
 					NewVersion: "1:2.8.4-3",
 					AffectedProcs: []models.AffectedProcess{
-						{PID: "21", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "22"}}}, {PID: "10876", Name: "sshd"}},
+						{PID: "21", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "22"}}}, {PID: "10876", Name: "sshd"}},
 				},
 				}},
 			},
@@ -337,7 +337,7 @@ func Test_detectScanDest(t *testing.T) {
 					Version:    "1:2.8.4-3",
 					NewVersion: "1:2.8.4-3",
 					AffectedProcs: []models.AffectedProcess{
-						{PID: "21", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "22"}}}, {PID: "21", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "22"}}}},
+						{PID: "21", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "22"}}}, {PID: "21", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "22"}}}},
 				},
 				}},
 			},
@@ -351,7 +351,7 @@ func Test_detectScanDest(t *testing.T) {
 					Version:    "1:2.8.4-3",
 					NewVersion: "1:2.8.4-3",
 					AffectedProcs: []models.AffectedProcess{
-						{PID: "21", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "22"}}}, {PID: "21", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "192.168.1.1", Port: "22"}}}, {PID: "6261", Name: "nginx", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "80"}}}},
+						{PID: "21", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "22"}}}, {PID: "21", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "192.168.1.1", Port: "22"}}}, {PID: "6261", Name: "nginx", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "80"}}}},
 				},
 				}},
 			},
@@ -366,7 +366,7 @@ func Test_detectScanDest(t *testing.T) {
 						Version:    "1:2.8.4-3",
 						NewVersion: "1:2.8.4-3",
 						AffectedProcs: []models.AffectedProcess{
-							{PID: "21", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "*", Port: "22"}}}},
+							{PID: "21", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "*", Port: "22"}}}},
 					},
 					}},
 				ServerInfo: config.ServerInfo{
@@ -411,45 +411,45 @@ func Test_updatePortStatus(t *testing.T) {
 		{name: "update_match_single_address",
 			args: args{
 				l: base{osPackages: osPackages{
-					Packages: models.Packages{"libc6": models.Package{Name: "libc6", AffectedProcs: []models.AffectedProcess{{PID: "1", Name: "bash"}, {PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "22"}}}}}},
+					Packages: models.Packages{"libc6": models.Package{Name: "libc6", AffectedProcs: []models.AffectedProcess{{PID: "1", Name: "bash"}, {PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "22"}}}}}},
 				}},
 				listenIPPorts: []string{"127.0.0.1:22"}},
-			expect: models.Packages{"libc6": models.Package{Name: "libc6", AffectedProcs: []models.AffectedProcess{{PID: "1", Name: "bash"}, {PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "22", PortScanSuccessOn: []string{"127.0.0.1"}}}}}}}},
+			expect: models.Packages{"libc6": models.Package{Name: "libc6", AffectedProcs: []models.AffectedProcess{{PID: "1", Name: "bash"}, {PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "22", PortReachableTo: []string{"127.0.0.1"}}}}}}}},
 		{name: "update_match_multi_address",
 			args: args{
 				l: base{osPackages: osPackages{
-					Packages: models.Packages{"libc6": models.Package{Name: "libc6", AffectedProcs: []models.AffectedProcess{{PID: "1", Name: "bash"}, {PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "22"}, {Address: "192.168.1.1", Port: "22"}}}}}},
+					Packages: models.Packages{"libc6": models.Package{Name: "libc6", AffectedProcs: []models.AffectedProcess{{PID: "1", Name: "bash"}, {PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "22"}, {BindAddress: "192.168.1.1", Port: "22"}}}}}},
 				}},
 				listenIPPorts: []string{"127.0.0.1:22", "192.168.1.1:22"}},
-			expect: models.Packages{"libc6": models.Package{Name: "libc6", AffectedProcs: []models.AffectedProcess{{PID: "1", Name: "bash"}, {PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{
-				{Address: "127.0.0.1", Port: "22", PortScanSuccessOn: []string{"127.0.0.1"}},
-				{Address: "192.168.1.1", Port: "22", PortScanSuccessOn: []string{"192.168.1.1"}},
+			expect: models.Packages{"libc6": models.Package{Name: "libc6", AffectedProcs: []models.AffectedProcess{{PID: "1", Name: "bash"}, {PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{
+				{BindAddress: "127.0.0.1", Port: "22", PortReachableTo: []string{"127.0.0.1"}},
+				{BindAddress: "192.168.1.1", Port: "22", PortReachableTo: []string{"192.168.1.1"}},
 			}}}}}},
 		{name: "update_match_asterisk",
 			args: args{
 				l: base{osPackages: osPackages{
-					Packages: models.Packages{"libc6": models.Package{Name: "libc6", AffectedProcs: []models.AffectedProcess{{PID: "1", Name: "bash"}, {PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "*", Port: "22"}}}}}},
+					Packages: models.Packages{"libc6": models.Package{Name: "libc6", AffectedProcs: []models.AffectedProcess{{PID: "1", Name: "bash"}, {PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "*", Port: "22"}}}}}},
 				}},
 				listenIPPorts: []string{"127.0.0.1:22", "127.0.0.1:80", "192.168.1.1:22"}},
-			expect: models.Packages{"libc6": models.Package{Name: "libc6", AffectedProcs: []models.AffectedProcess{{PID: "1", Name: "bash"}, {PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{
-				{Address: "*", Port: "22", PortScanSuccessOn: []string{"127.0.0.1", "192.168.1.1"}},
+			expect: models.Packages{"libc6": models.Package{Name: "libc6", AffectedProcs: []models.AffectedProcess{{PID: "1", Name: "bash"}, {PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{
+				{BindAddress: "*", Port: "22", PortReachableTo: []string{"127.0.0.1", "192.168.1.1"}},
 			}}}}}},
 		{name: "update_multi_packages",
 			args: args{
 				l: base{osPackages: osPackages{
 					Packages: models.Packages{
-						"packa": models.Package{Name: "packa", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "80"}}}}},
-						"packb": models.Package{Name: "packb", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "22"}}}}},
-						"packc": models.Package{Name: "packc", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "22"}, {Address: "192.168.1.1", Port: "22"}}}}},
-						"packd": models.Package{Name: "packd", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "*", Port: "22"}}}}},
+						"packa": models.Package{Name: "packa", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "80"}}}}},
+						"packb": models.Package{Name: "packb", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "22"}}}}},
+						"packc": models.Package{Name: "packc", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "22"}, {BindAddress: "192.168.1.1", Port: "22"}}}}},
+						"packd": models.Package{Name: "packd", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "*", Port: "22"}}}}},
 					},
 				}},
 				listenIPPorts: []string{"127.0.0.1:22", "192.168.1.1:22"}},
 			expect: models.Packages{
-				"packa": models.Package{Name: "packa", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "80", PortScanSuccessOn: []string{}}}}}},
-				"packb": models.Package{Name: "packb", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "22", PortScanSuccessOn: []string{"127.0.0.1"}}}}}},
-				"packc": models.Package{Name: "packc", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "127.0.0.1", Port: "22", PortScanSuccessOn: []string{"127.0.0.1"}}, {Address: "192.168.1.1", Port: "22", PortScanSuccessOn: []string{"192.168.1.1"}}}}}},
-				"packd": models.Package{Name: "packd", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPorts: []models.ListenPort{{Address: "*", Port: "22", PortScanSuccessOn: []string{"127.0.0.1", "192.168.1.1"}}}}}},
+				"packa": models.Package{Name: "packa", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "80", PortReachableTo: []string{}}}}}},
+				"packb": models.Package{Name: "packb", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "22", PortReachableTo: []string{"127.0.0.1"}}}}}},
+				"packc": models.Package{Name: "packc", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "127.0.0.1", Port: "22", PortReachableTo: []string{"127.0.0.1"}}, {BindAddress: "192.168.1.1", Port: "22", PortReachableTo: []string{"192.168.1.1"}}}}}},
+				"packd": models.Package{Name: "packd", AffectedProcs: []models.AffectedProcess{{PID: "75", Name: "sshd", ListenPortStats: []models.PortStat{{BindAddress: "*", Port: "22", PortReachableTo: []string{"127.0.0.1", "192.168.1.1"}}}}}},
 			},
 		},
 	}
@@ -467,71 +467,26 @@ func Test_updatePortStatus(t *testing.T) {
 func Test_matchListenPorts(t *testing.T) {
 	type args struct {
 		listenIPPorts    []string
-		searchListenPort models.ListenPort
+		searchListenPort models.PortStat
 	}
 	tests := []struct {
 		name   string
 		args   args
 		expect []string
 	}{
-		{name: "open_empty", args: args{listenIPPorts: []string{}, searchListenPort: models.ListenPort{Address: "127.0.0.1", Port: "22"}}, expect: []string{}},
-		{name: "port_empty", args: args{listenIPPorts: []string{"127.0.0.1:22"}, searchListenPort: models.ListenPort{}}, expect: []string{}},
-		{name: "single_match", args: args{listenIPPorts: []string{"127.0.0.1:22"}, searchListenPort: models.ListenPort{Address: "127.0.0.1", Port: "22"}}, expect: []string{"127.0.0.1"}},
-		{name: "no_match_address", args: args{listenIPPorts: []string{"127.0.0.1:22"}, searchListenPort: models.ListenPort{Address: "192.168.1.1", Port: "22"}}, expect: []string{}},
-		{name: "no_match_port", args: args{listenIPPorts: []string{"127.0.0.1:22"}, searchListenPort: models.ListenPort{Address: "127.0.0.1", Port: "80"}}, expect: []string{}},
-		{name: "asterisk_match", args: args{listenIPPorts: []string{"127.0.0.1:22", "127.0.0.1:80", "192.168.1.1:22"}, searchListenPort: models.ListenPort{Address: "*", Port: "22"}}, expect: []string{"127.0.0.1", "192.168.1.1"}},
+		{name: "open_empty", args: args{listenIPPorts: []string{}, searchListenPort: models.PortStat{BindAddress: "127.0.0.1", Port: "22"}}, expect: []string{}},
+		{name: "port_empty", args: args{listenIPPorts: []string{"127.0.0.1:22"}, searchListenPort: models.PortStat{}}, expect: []string{}},
+		{name: "single_match", args: args{listenIPPorts: []string{"127.0.0.1:22"}, searchListenPort: models.PortStat{BindAddress: "127.0.0.1", Port: "22"}}, expect: []string{"127.0.0.1"}},
+		{name: "no_match_address", args: args{listenIPPorts: []string{"127.0.0.1:22"}, searchListenPort: models.PortStat{BindAddress: "192.168.1.1", Port: "22"}}, expect: []string{}},
+		{name: "no_match_port", args: args{listenIPPorts: []string{"127.0.0.1:22"}, searchListenPort: models.PortStat{BindAddress: "127.0.0.1", Port: "80"}}, expect: []string{}},
+		{name: "asterisk_match", args: args{listenIPPorts: []string{"127.0.0.1:22", "127.0.0.1:80", "192.168.1.1:22"}, searchListenPort: models.PortStat{BindAddress: "*", Port: "22"}}, expect: []string{"127.0.0.1", "192.168.1.1"}},
 	}
 
 	l := base{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if match := l.findPortScanSuccessOn(tt.args.listenIPPorts, tt.args.searchListenPort); !reflect.DeepEqual(match, tt.expect) {
-				t.Errorf("findPortScanSuccessOn() = %v, want %v", match, tt.expect)
-			}
-		})
-	}
-}
-
-func Test_base_parseListenPorts(t *testing.T) {
-	tests := []struct {
-		name   string
-		args   string
-		expect models.ListenPort
-	}{{
-		name: "empty",
-		args: "",
-		expect: models.ListenPort{
-			Address: "",
-			Port:    "",
-		},
-	}, {
-		name: "normal",
-		args: "127.0.0.1:22",
-		expect: models.ListenPort{
-			Address: "127.0.0.1",
-			Port:    "22",
-		},
-	}, {
-		name: "asterisk",
-		args: "*:22",
-		expect: models.ListenPort{
-			Address: "*",
-			Port:    "22",
-		},
-	}, {
-		name: "ipv6_loopback",
-		args: "[::1]:22",
-		expect: models.ListenPort{
-			Address: "[::1]",
-			Port:    "22",
-		},
-	}}
-
-	l := base{}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if listenPort := l.parseListenPorts(tt.args); !reflect.DeepEqual(listenPort, tt.expect) {
-				t.Errorf("base.parseListenPorts() = %v, want %v", listenPort, tt.expect)
+			if match := l.findPortTestSuccessOn(tt.args.listenIPPorts, tt.args.searchListenPort); !reflect.DeepEqual(match, tt.expect) {
+				t.Errorf("findPortTestSuccessOn() = %v, want %v", match, tt.expect)
 			}
 		})
 	}

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -1294,15 +1294,20 @@ func (o *debian) dpkgPs() error {
 		pidLoadedFiles[pid] = append(pidLoadedFiles[pid], ss...)
 	}
 
-	pidListenPorts := map[string][]models.ListenPort{}
+	pidListenPorts := map[string][]models.PortStat{}
 	stdout, err = o.lsOfListen()
 	if err != nil {
 		return xerrors.Errorf("Failed to ls of: %w", err)
 	}
 	portPids := o.parseLsOf(stdout)
-	for port, pids := range portPids {
+	for ipPort, pids := range portPids {
 		for _, pid := range pids {
-			pidListenPorts[pid] = append(pidListenPorts[pid], o.parseListenPorts(port))
+			portStat, err := models.NewPortStat(ipPort)
+			if err != nil {
+				o.log.Warnf("Failed to parse ip:port: %s, err: %+v", ipPort, err)
+				continue
+			}
+			pidListenPorts[pid] = append(pidListenPorts[pid], *portStat)
 		}
 	}
 
@@ -1319,9 +1324,9 @@ func (o *debian) dpkgPs() error {
 			procName = pidNames[pid]
 		}
 		proc := models.AffectedProcess{
-			PID:         pid,
-			Name:        procName,
-			ListenPorts: pidListenPorts[pid],
+			PID:             pid,
+			Name:            procName,
+			ListenPortStats: pidListenPorts[pid],
 		}
 
 		for _, n := range pkgNames {


### PR DESCRIPTION
# What did you implement:

Enable reporting of scan results by Vuls v0.13.0 and earlier in the latest version of Vuls.

In the current implementation, an error occurred.

- scan vuls (before v0.13.0)
- vuls report

```
ubuntu@dev  ~│g│s│g│f│vuls  ⎇ master~  ./vuls.master  tui
[Nov 19 16:11:44] ERROR Failed to create log file. path: /var/log/vuls/localhost.log, err: open /var/log/vuls/localhost.log: permission denied
[Nov 19 16:11:44]  INFO [localhost] Validating config...
INFO[0000] -cvedb-type: sqlite3, -cvedb-url: , -cvedb-path: /home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/cve.sqlite3 
[Nov 19 16:11:44] ERROR [localhost] Failed to parse /home/ubuntu/go/src/github.com/future-architect/vuls/results/2020-11-19T16:11:02+09:00/localhost.json: json: cannot unmarshal string into Go struct field AffectedProcess.packages.AffectedProcs.listenPorts of type models.ListenPort
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
ubuntu@dev  ~│g│s│g│f│vuls  ⎇ master~  ./vuls.old scan localhost
[Nov 19 16:11:01] ERROR Failed to create log file. path: /var/log/vuls/localhost.log, err: open /var/log/vuls/localhost.log: permission denied
[Nov 19 16:11:01]  INFO [localhost] Start scanning
[Nov 19 16:11:01]  INFO [localhost] config: /home/ubuntu/go/src/github.com/future-architect/vuls/config.toml
[Nov 19 16:11:01]  INFO [localhost] Validating config...
[Nov 19 16:11:01]  INFO [localhost] Detecting Server/Container OS... 
[Nov 19 16:11:01]  INFO [localhost] Detecting OS of servers... 
[Nov 19 16:11:01] ERROR Failed to create log file. path: /var/log/vuls/localhost.log, err: open /var/log/vuls/localhost.log: permission denied
[Nov 19 16:11:01] ERROR Failed to create log file. path: /var/log/vuls/localhost.log, err: open /var/log/vuls/localhost.log: permission denied
[Nov 19 16:11:01]  INFO [localhost] (1/1) Detected: localhost: ubuntu 18.04
[Nov 19 16:11:01]  INFO [localhost] Detecting OS of containers... 
[Nov 19 16:11:01]  INFO [localhost] Checking Scan Modes... 
[Nov 19 16:11:01]  INFO [localhost] Detecting Platforms... 
[Nov 19 16:11:02]  INFO [localhost] (1/1) localhost is running on other
[Nov 19 16:11:02]  INFO [localhost] Detecting IPS identifiers... 
[Nov 19 16:11:02]  INFO [localhost] (1/1) localhost has 0 IPS integration
[Nov 19 16:11:02]  INFO [localhost] Scanning vulnerabilities... 
[Nov 19 16:11:02]  INFO [localhost] Scanning vulnerable OS packages...
[Nov 19 16:11:02]  INFO [localhost] Scanning in fast-root mode
[Nov 19 16:11:02]  INFO [localhost] apt-get update...
Scan Summary
================
localhost       ubuntu18.04     902 installed, 193 updatable
To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

```
 ubuntu@dev  ~│g│s│g│f│vuls  ⎇ master~  ./vuls.master  tui
[Nov 19 16:11:44] ERROR Failed to create log file. path: /var/log/vuls/localhost.log, err: open /var/log/vuls/localhost.log: permission denied
[Nov 19 16:11:44]  INFO [localhost] Validating config...
INFO[0000] -cvedb-type: sqlite3, -cvedb-url: , -cvedb-path: /home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/cve.sqlite3 
[Nov 19 16:11:44] ERROR [localhost] Failed to parse /home/ubuntu/go/src/github.com/future-architect/vuls/results/2020-11-19T16:11:02+09:00/localhost.json: json: cannot unmarshal string into Go struct field AffectedProcess.packages.AffectedProcs.listenPorts of type models.ListenPort
```

```
 ✗  ubuntu@dev  ~│g│s│g│f│vuls  ⎇ master~  ./vuls.latest tui
[Nov 19 16:11:53] ERROR Failed to create log file. path: /var/log/vuls/localhost.log, err: open /var/log/vuls/localhost.log: permission denied
[Nov 19 16:11:53]  INFO [localhost] Validating config...
INFO[0000] -cvedb-type: sqlite3, -cvedb-url: , -cvedb-path: /home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/cve.sqlite3 
[Nov 19 16:11:53]  INFO [localhost] Loaded: /home/ubuntu/go/src/github.com/future-architect/vuls/results/2020-11-19T16:11:02+09:00
[Nov 19 16:11:53]  INFO [localhost] Validating db config...
INFO[0000] -cvedb-type: sqlite3, -cvedb-url: , -cvedb-path: /home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/cve.sqlite3 
INFO[0000] -ovaldb-type: sqlite3, -ovaldb-url: , -ovaldb-path: /home/ubuntu/go/src/github.com/kotakanbe/goval-dictionary/oval.sqlite3 
INFO[0000] -gostdb-type: sqlite3, -gostdb-url: , -gostdb-path: /home/ubuntu/go/src/github.com/future-architect/vuls/gost.sqlite3 
INFO[0000] -exploitdb-type: sqlite3, -exploitdb-url: , -exploitdb-path: /home/ubuntu/go/src/github.com/vulsio/go-exploitdb/go-exploitdb.sqlite3 
INFO[0000] -msfdb-type: sqlite3, -msfdb-url: , -msfdb-path: /home/ubuntu/go/src/github.com/takuzoo3868/go-msfdb/go-msfdb.sqlite3 
[Nov 19 16:11:53]  WARN [localhost] --cvedb-path=/home/ubuntu/go/src/github.com/kotakanbe/go-cve-dictionary/cve.sqlite3 file not found. [CPE-scan](https://vuls.io/docs/en/usage-scan-non-os-packages.html#cpe-scan) needs cve-dictionary. if you specify cpe in config.toml, fetch cve-dictionary before reporting. For details, see `https://github.com/kotakanbe/go-cve-dictionary#deploy-go-cve-dictionary`
[Nov 19 16:11:53]  WARN [localhost] --gostdb-path=/home/ubuntu/go/src/github.com/future-architect/vuls/gost.sqlite3 file not found. Vuls can detect `patch-not-released-CVE-ID` using gost if the scan target server is Debian, RHEL or CentOS, For details, see `https://github.com/knqyf263/gost#fetch-redhat`
INFO[11-19|16:11:53] Opening Database.                        db=sqlite3
INFO[11-19|16:11:53] Migrating DB.                            db=sqlite3
INFO[11-19|16:11:53] Opening DB                               db=sqlite3
INFO[11-19|16:11:53] Migrating DB                             db=sqlite3
[Nov 19 16:11:53]  INFO [localhost] localhost: 0 CVEs are detected with Library
[Nov 19 16:11:53]  WARN [localhost] OVAL for ubuntu 18.04 is old, last modified is 2020-10-14 11:11:23.027412289 +0900 +0900. It's recommended to update OVAL to improve scanning accuracy. How to update OVAL database, see https://github.com/kotakanbe/goval-dictionary#usage
[Nov 19 16:11:53]  WARN [localhost] The OVAL name of the running kernel image {Release:4.15.0-99-generic Version: RebootRequired:false} is not found. So vulns of `linux` wll be detected. server: localhost
[Nov 19 16:12:00]  INFO [localhost] localhost: 296 CVEs are detected with OVAL
[Nov 19 16:12:00]  INFO [localhost] localhost: 0 CVEs are detected with CPE
[Nov 19 16:12:00]  INFO [localhost] localhost: 0 CVEs are detected with GitHub Security Alerts
[Nov 19 16:12:00]  INFO [localhost] localhost: 0 unfixed CVEs are detected with gost
[Nov 19 16:12:00]  INFO [localhost] Fill CVE detailed information with CVE-DB
[Nov 19 16:12:00]  INFO [localhost] Fill exploit information with Exploit-DB
[Nov 19 16:12:00]  INFO [localhost] localhost: 4 exploits are detected
[Nov 19 16:12:00]  INFO [localhost] Fill metasploit module information with Metasploit-DB
[Nov 19 16:12:00]  INFO [localhost] localhost: 0 modules are detected
[Nov 19 16:12:08] ERROR [localhost] quit
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

