### PR TITLE
feat(scan): IgnoredJSONKyes to clear values in result json #1071

### DIFF
--- a/scan/serverapi.go
+++ b/scan/serverapi.go
@@ -504,6 +504,12 @@ func Scan(timeoutSec int) error {
 		return err
 	}
 
+	for i, r := range results {
+		if s, ok := config.Conf.Servers[r.ServerName]; ok {
+			results[i] = r.ClearFields(s.IgnoredJSONKeys)
+		}
+	}
+
 	return writeScanResults(dir, results)
 }
 


### PR DESCRIPTION
# What did you implement:

refs #1071 

Changed to also clear when scanning.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Run the scan in the following config.toml, and make sure that the key is not included in the json.

```
[servers.localhost]
host = "localhost"
port = "local"
user = "vuls"
scanMode = ["fast-root"]
ignoredJSONKeys = [
        "scannedIpv4Addrs",
        "ipv4Addrs",
]
```
```
 ubuntu@dev  ~│g│s│g│f│vuls  ⎇ ignore-json-keys-scan~  less results/current/localhost.json | jq "." | grep -3 "ipv4Addrs"
          "wordpress": {},
          "ignoredJSONKeys": [
            "scannedIpv4Addrs",
            "ipv4Addrs"
          ]
        }
      },
 ubuntu@dev  ~│g│s│g│f│vuls  ⎇ ignore-json-keys-scan~  less results/current/localhost.json | jq "." | grep -3 "scannedIpv4Addrs"
          ],
          "wordpress": {},
          "ignoredJSONKeys": [
            "scannedIpv4Addrs",
            "ipv4Addrs"
          ]
        }
```


# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 