### PR TITLE
feat(nocgo): enable to build with CGO_ENABLED=0

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,19 +20,23 @@ BUILDTIME := $(shell date "+%Y%m%d_%H%M%S")
 LDFLAGS := -X 'github.com/future-architect/vuls/config.Version=$(VERSION)' \
     -X 'github.com/future-architect/vuls/config.Revision=build-$(BUILDTIME)_$(REVISION)'
 GO := GO111MODULE=on go
+CGO_UNABLED := CGO_ENABLED=0 go
 GO_OFF := GO111MODULE=off go
 
 
 all: build
 
-build: main.go pretest fmt
-	$(GO) build -a -ldflags "$(LDFLAGS)" -o vuls $<
+build: ./cmd/vuls/main.go pretest fmt
+	$(GO) build -a -ldflags "$(LDFLAGS)" -o vuls ./cmd/vuls
 
-b: 	main.go pretest fmt
-	$(GO) build -ldflags "$(LDFLAGS)" -o vuls $<
+install: ./cmd/vuls/main.go pretest fmt
+	$(GO) install -ldflags "$(LDFLAGS)" ./cmd/vuls
 
-install: main.go pretest
-	$(GO) install -ldflags "$(LDFLAGS)"
+build-scanner: ./cmd/scanner/main.go pretest fmt
+	$(CGO_UNABLED) build -tags=scanner -a -ldflags "$(LDFLAGS)" -o vuls ./cmd/scanner
+
+install-scanner: ./cmd/scanner/main.go pretest fmt
+	$(CGO_UNABLED) install -tags=scanner -ldflags "$(LDFLAGS)" ./cmd/scanner
 
 lint:
 	$(GO_OFF) get -u golang.org/x/lint/golint

--- a/cmd/scanner/main.go
+++ b/cmd/scanner/main.go
@@ -7,8 +7,8 @@ import (
 
 	"context"
 
-	"github.com/future-architect/vuls/commands"
 	"github.com/future-architect/vuls/config"
+	commands "github.com/future-architect/vuls/subcmds"
 	"github.com/google/subcommands"
 )
 
@@ -17,12 +17,9 @@ func main() {
 	subcommands.Register(subcommands.FlagsCommand(), "")
 	subcommands.Register(subcommands.CommandsCommand(), "")
 	subcommands.Register(&commands.DiscoverCmd{}, "discover")
-	subcommands.Register(&commands.TuiCmd{}, "tui")
 	subcommands.Register(&commands.ScanCmd{}, "scan")
 	subcommands.Register(&commands.HistoryCmd{}, "history")
-	subcommands.Register(&commands.ReportCmd{}, "report")
 	subcommands.Register(&commands.ConfigtestCmd{}, "configtest")
-	subcommands.Register(&commands.ServerCmd{}, "server")
 
 	var v = flag.Bool("v", false, "Show version")
 

--- a/exploit/exploit.go
+++ b/exploit/exploit.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package exploit
 
 import (

--- a/gost/base.go
+++ b/gost/base.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package gost
 
 import (

--- a/gost/debian.go
+++ b/gost/debian.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package gost
 
 import (

--- a/gost/gost.go
+++ b/gost/gost.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package gost
 
 import (

--- a/gost/microsoft.go
+++ b/gost/microsoft.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package gost
 
 import (

--- a/gost/pseudo.go
+++ b/gost/pseudo.go
@@ -1,8 +1,8 @@
+// +build !scanner
+
 package gost
 
 import (
-	"strings"
-
 	"github.com/future-architect/vuls/models"
 	"github.com/knqyf263/gost/db"
 )
@@ -15,8 +15,4 @@ type Pseudo struct {
 // DetectUnfixed fills cve information that has in Gost
 func (pse Pseudo) DetectUnfixed(driver db.DB, r *models.ScanResult, _ bool) (int, error) {
 	return 0, nil
-}
-
-func major(osVer string) (majorVersion string) {
-	return strings.Split(osVer, ".")[0]
 }

--- a/gost/redhat.go
+++ b/gost/redhat.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package gost
 
 import (

--- a/gost/util.go
+++ b/gost/util.go
@@ -2,6 +2,7 @@ package gost
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -180,4 +181,8 @@ func httpGet(url string, req request, resChan chan<- response, errChan chan<- er
 		request: req,
 		json:    body,
 	}
+}
+
+func major(osVer string) (majorVersion string) {
+	return strings.Split(osVer, ".")[0]
 }

--- a/models/utils.go
+++ b/models/utils.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package models
 
 import (

--- a/msf/empty.go
+++ b/msf/empty.go
@@ -1,0 +1,1 @@
+package msf

--- a/msf/msf.go
+++ b/msf/msf.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package msf
 
 import (

--- a/oval/alpine.go
+++ b/oval/alpine.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package oval
 
 import (

--- a/oval/debian.go
+++ b/oval/debian.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package oval
 
 import (

--- a/oval/debian_test.go
+++ b/oval/debian_test.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package oval
 
 import (

--- a/oval/empty.go
+++ b/oval/empty.go
@@ -1,0 +1,1 @@
+package oval

--- a/oval/oval.go
+++ b/oval/oval.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package oval
 
 import (

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package oval
 
 import (

--- a/oval/redhat_test.go
+++ b/oval/redhat_test.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package oval
 
 import (

--- a/oval/suse.go
+++ b/oval/suse.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package oval
 
 import (

--- a/oval/util.go
+++ b/oval/util.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package oval
 
 import (

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package oval
 
 import (

--- a/report/cve_client.go
+++ b/report/cve_client.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package report
 
 import (

--- a/report/db_client.go
+++ b/report/db_client.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package report
 
 import (

--- a/report/report.go
+++ b/report/report.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package report
 
 import (
@@ -34,11 +36,6 @@ import (
 	exploitdb "github.com/mozqnet/go-exploitdb/db"
 	metasploitdb "github.com/takuzoo3868/go-msfdb/db"
 	"golang.org/x/xerrors"
-)
-
-const (
-	vulsOpenTag  = "<vulsreport>"
-	vulsCloseTag = "</vulsreport>"
 )
 
 // FillCveInfos fills CVE Detailed Information

--- a/report/util.go
+++ b/report/util.go
@@ -22,7 +22,11 @@ import (
 	"golang.org/x/xerrors"
 )
 
-const maxColWidth = 100
+const (
+	vulsOpenTag  = "<vulsreport>"
+	vulsCloseTag = "</vulsreport>"
+	maxColWidth  = 100
+)
 
 func formatScanSummary(rs ...models.ScanResult) string {
 	table := uitable.New()
@@ -555,7 +559,7 @@ func getDiffCves(previous, current models.ScanResult) models.VulnInfos {
 
 				// TODO commented out because  a bug of diff logic when multiple oval defs found for a certain CVE-ID and same updated_at
 				// if these OVAL defs have different affected packages, this logic detects as updated.
-				// This logic will be uncomented after integration with ghost https://github.com/knqyf263/gost
+				// This logic will be uncomented after integration with gost https://github.com/knqyf263/gost
 				// } else if isCveFixed(v, previous) {
 				// updated[v.CveID] = v
 				// util.Log.Debugf("fixed: %s", v.CveID)

--- a/server/empty.go
+++ b/server/empty.go
@@ -1,0 +1,1 @@
+package server

--- a/server/server.go
+++ b/server/server.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package server
 
 import (

--- a/subcmds/configtest.go
+++ b/subcmds/configtest.go
@@ -1,4 +1,4 @@
-package commands
+package subcmds
 
 import (
 	"context"

--- a/subcmds/discover.go
+++ b/subcmds/discover.go
@@ -1,4 +1,4 @@
-package commands
+package subcmds
 
 import (
 	"context"

--- a/subcmds/history.go
+++ b/subcmds/history.go
@@ -1,4 +1,4 @@
-package commands
+package subcmds
 
 import (
 	"context"

--- a/subcmds/report.go
+++ b/subcmds/report.go
@@ -1,4 +1,6 @@
-package commands
+// +build !scanner
+
+package subcmds
 
 import (
 	"context"

--- a/subcmds/scan.go
+++ b/subcmds/scan.go
@@ -1,4 +1,4 @@
-package commands
+package subcmds
 
 import (
 	"context"

--- a/subcmds/tui.go
+++ b/subcmds/tui.go
@@ -1,30 +1,28 @@
-package commands
+// +build !scanner
+
+package subcmds
 
 import (
 	"context"
 	"flag"
-	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 
-	// "github.com/future-architect/vuls/Server"
-
+	"github.com/aquasecurity/trivy/pkg/utils"
 	c "github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/exploit"
 	"github.com/future-architect/vuls/gost"
+	"github.com/future-architect/vuls/models"
 	"github.com/future-architect/vuls/msf"
 	"github.com/future-architect/vuls/oval"
 	"github.com/future-architect/vuls/report"
-	"github.com/future-architect/vuls/server"
 	"github.com/future-architect/vuls/util"
 	"github.com/google/subcommands"
 )
 
-// ServerCmd is subcommand for server
-type ServerCmd struct {
+// TuiCmd is Subcommand of host discovery mode
+type TuiCmd struct {
 	configPath     string
-	listen         string
 	cveDict        c.GoCveDictConf
 	ovalDict       c.GovalDictConf
 	gostConf       c.GostConf
@@ -33,27 +31,28 @@ type ServerCmd struct {
 }
 
 // Name return subcommand name
-func (*ServerCmd) Name() string { return "server" }
+func (*TuiCmd) Name() string { return "tui" }
 
 // Synopsis return synopsis
-func (*ServerCmd) Synopsis() string { return "Server" }
+func (*TuiCmd) Synopsis() string { return "Run Tui view to analyze vulnerabilities" }
 
 // Usage return usage
-func (*ServerCmd) Usage() string {
-	return `Server:
-	Server
-		[-lang=en|ja]
+func (*TuiCmd) Usage() string {
+	return `tui:
+	tui
+		[-refresh-cve]
 		[-config=/path/to/config.toml]
-		[-log-dir=/path/to/log]
 		[-cvss-over=7]
+		[-diff]
 		[-ignore-unscored-cves]
 		[-ignore-unfixed]
-		[-to-localfile]
-		[-format-json]
-		[-http-proxy=http://192.168.0.1:8080]
+		[-results-dir=/path/to/results]
+		[-log-dir=/path/to/log]
 		[-debug]
 		[-debug-sql]
-		[-listen=localhost:5515]
+		[-quiet]
+		[-no-progress]
+		[-pipe]
 		[-cvedb-type=sqlite3|mysql|postgres|redis|http]
 		[-cvedb-sqlite3-path=/path/to/cve.sqlite3]
 		[-cvedb-url=http://127.0.0.1:1323 or DB connection string]
@@ -69,59 +68,62 @@ func (*ServerCmd) Usage() string {
 		[-msfdb-type=sqlite3|mysql|redis|http]
 		[-msfdb-sqlite3-path=/path/to/msfdb.sqlite3]
 		[-msfdb-url=http://127.0.0.1:1327 or DB connection string]
+		[-trivy-cachedb-dir=/path/to/dir]
 
-		[RFC3339 datetime format under results dir]
 `
 }
 
 // SetFlags set flag
-func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
-	f.StringVar(&c.Conf.Lang, "lang", "en", "[en|ja]")
+func (p *TuiCmd) SetFlags(f *flag.FlagSet) {
+	//  f.StringVar(&p.lang, "lang", "en", "[en|ja]")
+	f.BoolVar(&c.Conf.DebugSQL, "debug-sql", false, "debug SQL")
 	f.BoolVar(&c.Conf.Debug, "debug", false, "debug mode")
-	f.BoolVar(&c.Conf.DebugSQL, "debug-sql", false, "SQL debug mode")
-
-	wd, _ := os.Getwd()
-	f.StringVar(&p.configPath, "config", "", "/path/to/toml")
-
-	defaultResultsDir := filepath.Join(wd, "results")
-	f.StringVar(&c.Conf.ResultsDir, "results-dir", defaultResultsDir, "/path/to/results")
+	f.BoolVar(&c.Conf.Quiet, "quiet", false, "Quiet mode. No output on stdout")
+	f.BoolVar(&c.Conf.NoProgress, "no-progress", false, "Suppress progress bar")
 
 	defaultLogDir := util.GetDefaultLogDir()
 	f.StringVar(&c.Conf.LogDir, "log-dir", defaultLogDir, "/path/to/log")
 
-	f.Float64Var(&c.Conf.CvssScoreOver, "cvss-over", 0,
-		"-cvss-over=6.5 means Servering CVSS Score 6.5 and over (default: 0 (means Server all))")
+	wd, _ := os.Getwd()
+	defaultResultsDir := filepath.Join(wd, "results")
+	f.StringVar(&c.Conf.ResultsDir, "results-dir", defaultResultsDir, "/path/to/results")
 
-	f.BoolVar(&c.Conf.IgnoreUnscoredCves, "ignore-unscored-cves", false,
-		"Don't Server the unscored CVEs")
+	defaultConfPath := filepath.Join(wd, "config.toml")
+	f.StringVar(&p.configPath, "config", defaultConfPath, "/path/to/toml")
+
+	f.BoolVar(&c.Conf.RefreshCve, "refresh-cve", false,
+		"Refresh CVE information in JSON file under results dir")
+
+	f.Float64Var(&c.Conf.CvssScoreOver, "cvss-over", 0,
+		"-cvss-over=6.5 means reporting CVSS Score 6.5 and over (default: 0 (means report all))")
+
+	f.BoolVar(&c.Conf.Diff, "diff", false,
+		"Difference between previous result and current result ")
+
+	f.BoolVar(
+		&c.Conf.IgnoreUnscoredCves, "ignore-unscored-cves", false,
+		"Don't report the unscored CVEs")
 
 	f.BoolVar(&c.Conf.IgnoreUnfixed, "ignore-unfixed", false,
-		"Don't Server the unfixed CVEs")
+		"Don't report the unfixed CVEs")
 
-	f.StringVar(&c.Conf.HTTPProxy, "http-proxy", "",
-		"http://proxy-url:port (default: empty)")
-
-	f.BoolVar(&c.Conf.FormatJSON, "format-json", false, "JSON format")
-
-	f.BoolVar(&c.Conf.ToLocalFile, "to-localfile", false, "Write report to localfile")
-	f.StringVar(&p.listen, "listen", "localhost:5515",
-		"host:port (default: localhost:5515)")
+	f.BoolVar(&c.Conf.Pipe, "pipe", false, "Use stdin via PIPE")
 
 	f.StringVar(&p.cveDict.Type, "cvedb-type", "",
-		"DB type of go-cve-dictionary (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.cveDict.SQLite3Path, "cvedb-sqlite3-path", "", "/path/to/sqlite3")
+		"DB type of go-cve-dictionary (sqlite3, mysql, postgres or redis)")
+	f.StringVar(&p.cveDict.SQLite3Path, "cvedb-path", "", "/path/to/sqlite3")
 	f.StringVar(&p.cveDict.URL, "cvedb-url", "",
 		"http://go-cve-dictionary.com:1323 or DB connection string")
 
 	f.StringVar(&p.ovalDict.Type, "ovaldb-type", "",
-		"DB type of goval-dictionary (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.ovalDict.SQLite3Path, "ovaldb-sqlite3-path", "", "/path/to/sqlite3")
+		"DB type of goval-dictionary (sqlite3, mysql, postgres or redis)")
+	f.StringVar(&p.ovalDict.SQLite3Path, "ovaldb-path", "", "/path/to/sqlite3")
 	f.StringVar(&p.ovalDict.URL, "ovaldb-url", "",
 		"http://goval-dictionary.com:1324 or DB connection string")
 
 	f.StringVar(&p.gostConf.Type, "gostdb-type", "",
-		"DB type of gost (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.gostConf.SQLite3Path, "gostdb-sqlite3-path", "", "/path/to/sqlite3")
+		"DB type of gost (sqlite3, mysql, postgres or redis)")
+	f.StringVar(&p.gostConf.SQLite3Path, "gostdb-path", "", "/path/to/sqlite3")
 	f.StringVar(&p.gostConf.URL, "gostdb-url", "",
 		"http://gost.com:1325 or DB connection string")
 
@@ -136,28 +138,49 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&p.metasploitConf.SQLite3Path, "msfdb-sqlite3-path", "", "/path/to/sqlite3")
 	f.StringVar(&p.metasploitConf.URL, "msfdb-url", "",
 		"http://metasploit.com:1327 or DB connection string")
+
+	f.StringVar(&c.Conf.TrivyCacheDBDir, "trivy-cachedb-dir",
+		utils.DefaultCacheDir(), "/path/to/dir")
 }
 
 // Execute execute
-func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (p *TuiCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	util.Log = util.NewCustomLogger(c.ServerInfo{})
-	if p.configPath != "" {
-		if err := c.Load(p.configPath, ""); err != nil {
-			util.Log.Errorf("Error loading %s. err: %+v", p.configPath, err)
-			return subcommands.ExitUsageError
-		}
+	if err := c.Load(p.configPath, ""); err != nil {
+		util.Log.Errorf("Error loading %s, err: %+v", p.configPath, err)
+		return subcommands.ExitUsageError
 	}
 
+	c.Conf.Lang = "en"
 	c.Conf.CveDict.Overwrite(p.cveDict)
 	c.Conf.OvalDict.Overwrite(p.ovalDict)
 	c.Conf.Gost.Overwrite(p.gostConf)
 	c.Conf.Exploit.Overwrite(p.exploitConf)
 	c.Conf.Metasploit.Overwrite(p.metasploitConf)
 
+	var dir string
+	var err error
+	if c.Conf.Diff {
+		dir, err = report.JSONDir([]string{})
+	} else {
+		dir, err = report.JSONDir(f.Args())
+	}
+	if err != nil {
+		util.Log.Errorf("Failed to read from JSON. err: %+v", err)
+		return subcommands.ExitFailure
+	}
+
 	util.Log.Info("Validating config...")
-	if !c.Conf.ValidateOnReport() {
+	if !c.Conf.ValidateOnTui() {
 		return subcommands.ExitUsageError
 	}
+
+	var res models.ScanResults
+	if res, err = report.LoadScanResults(dir); err != nil {
+		util.Log.Error(err)
+		return subcommands.ExitFailure
+	}
+	util.Log.Infof("Loaded: %s", dir)
 
 	util.Log.Info("Validating db config...")
 	if !c.Conf.ValidateOnReportDB() {
@@ -175,7 +198,7 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	if c.Conf.OvalDict.URL != "" {
 		err := oval.Base{}.CheckHTTPHealth()
 		if err != nil {
-			util.Log.Errorf("OVAL HTTP server is not running. err: %s", err)
+			util.Log.Errorf("OVAL HTTP server is not running. err: %+v", err)
 			util.Log.Errorf("Run goval-dictionary as server mode before reporting or run with `-ovaldb-type=sqlite3 -ovaldb-sqlite3-path` option instead of -ovaldb-url")
 			return subcommands.ExitFailure
 		}
@@ -228,14 +251,17 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 
 	defer dbclient.CloseDB()
 
-	http.Handle("/vuls", server.VulsHandler{DBclient: *dbclient})
-	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, "ok")
-	})
-	util.Log.Infof("Listening on %s", p.listen)
-	if err := http.ListenAndServe(p.listen, nil); err != nil {
-		util.Log.Errorf("Failed to start server. err: %+v", err)
+	if res, err = report.FillCveInfos(*dbclient, res, dir); err != nil {
+		util.Log.Error(err)
 		return subcommands.ExitFailure
 	}
-	return subcommands.ExitSuccess
+
+	for _, r := range res {
+		if len(r.Warnings) != 0 {
+			util.Log.Warnf("Warning: Some warnings occurred while scanning on %s: %s",
+				r.FormatServerName(), r.Warnings)
+		}
+	}
+
+	return report.RunTui(res)
 }

--- a/subcmds/util.go
+++ b/subcmds/util.go
@@ -1,4 +1,4 @@
-package commands
+package subcmds
 
 import (
 	"fmt"


### PR DESCRIPTION
# What did you implement:

Go has a cross-compilation feature that allows us to build binaries that run on a variety of architectures, but until this P/R, Vulls has been difficult to cross-compile because of its dependence on CGO.

This pull request uses build tags to exclude CGO-dependent parts of the code while compiling.

## Same as before（CGO_ENABLED=1）

`make build or make install`

## new feature（CGO_ENABLED=0）

Since the report function is in CGO, the scanner function is only included.
`make build-scanner or make install-scanner`

The official documentation describes `make` based and therefore not affected by this fix.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

maked

# Checklist:

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

