### PR TITLE
Update WordPress vulnerability URL and API Endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Vuls is a tool created to solve the problems listed above. It has the following 
   - [RustSec Advisory Database](https://github.com/RustSec/advisory-db)
 
 - WordPress
-  - [WPVulnDB](https://wpvulndb.com/api)
+  - [WPVulnDB](https://wpscan.com/api)
 
 ### Scan mode
 

--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -694,7 +694,7 @@ func (v VulnInfo) Cvss3CalcURL() string {
 func (v VulnInfo) VendorLinks(family string) map[string]string {
 	links := map[string]string{}
 	if strings.HasPrefix(v.CveID, "WPVDBID") {
-		links["WPVulnDB"] = fmt.Sprintf("https://wpvulndb.com/vulnerabilities/%s",
+		links["WPVulnDB"] = fmt.Sprintf("https://wpscan.com/vulnerability/%s",
 			strings.TrimPrefix(v.CveID, "WPVDBID-"))
 		return links
 	}

--- a/report/util.go
+++ b/report/util.go
@@ -140,7 +140,7 @@ No CVE-IDs are found in updatable packages.
 		if strings.HasPrefix(vinfo.CveID, "CVE-") {
 			link = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vinfo.CveID)
 		} else if strings.HasPrefix(vinfo.CveID, "WPVDBID-") {
-			link = fmt.Sprintf("https://wpvulndb.com/vulnerabilities/%s", strings.TrimPrefix(vinfo.CveID, "WPVDBID-"))
+			link = fmt.Sprintf("https://wpscan.com/vulnerabilities/%s", strings.TrimPrefix(vinfo.CveID, "WPVDBID-"))
 		}
 
 		data = append(data, []string{
@@ -401,7 +401,7 @@ func formatCsvList(r models.ScanResult, path string) error {
 		if strings.HasPrefix(vinfo.CveID, "CVE-") {
 			link = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vinfo.CveID)
 		} else if strings.HasPrefix(vinfo.CveID, "WPVDBID-") {
-			link = fmt.Sprintf("https://wpvulndb.com/vulnerabilities/%s", strings.TrimPrefix(vinfo.CveID, "WPVDBID-"))
+			link = fmt.Sprintf("https://wpscan.com/vulnerabilities/%s", strings.TrimPrefix(vinfo.CveID, "WPVDBID-"))
 		}
 
 		data = append(data, []string{

--- a/wordpress/wordpress.go
+++ b/wordpress/wordpress.go
@@ -47,7 +47,7 @@ type References struct {
 }
 
 // FillWordPress access to wpvulndb and fetch scurity alerts and then set to the given ScanResult.
-// https://wpvulndb.com/
+// https://wpscan.com/
 func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]string) (int, error) {
 	// Core
 	ver := strings.Replace(r.WordPressPackages.CoreVersion(), ".", "", -1)
@@ -57,7 +57,7 @@ func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]
 
 	body, ok := searchCache(ver, wpVulnCaches)
 	if !ok {
-		url := fmt.Sprintf("https://wpvulndb.com/api/v3/wordpresses/%s", ver)
+		url := fmt.Sprintf("https://wpscan.com/api/v3/wordpresses/%s", ver)
 		var err error
 		body, err = httpRequest(url, token)
 		if err != nil {
@@ -87,7 +87,7 @@ func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]
 	for _, p := range themes {
 		body, ok := searchCache(p.Name, wpVulnCaches)
 		if !ok {
-			url := fmt.Sprintf("https://wpvulndb.com/api/v3/themes/%s", p.Name)
+			url := fmt.Sprintf("https://wpscan.com/api/v3/themes/%s", p.Name)
 			var err error
 			body, err = httpRequest(url, token)
 			if err != nil {
@@ -129,7 +129,7 @@ func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]
 	for _, p := range plugins {
 		body, ok := searchCache(p.Name, wpVulnCaches)
 		if !ok {
-			url := fmt.Sprintf("https://wpvulndb.com/api/v3/plugins/%s", p.Name)
+			url := fmt.Sprintf("https://wpscan.com/api/v3/plugins/%s", p.Name)
 			var err error
 			body, err = httpRequest(url, token)
 			if err != nil {


### PR DESCRIPTION
# What did you implement:

Fixed to new WordPress vulnerability URL and API Endpoint.

- [We have a new website! | WPScan Blog](https://blog.wpscan.com/2020/10/09/new-wpscan-website.html)

- [WordPress Vulnerability Database API](https://wpscan.com/api)


Fixes #1079

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

`vuls scan -wordpress-only` command Successful.

`vuls report -format-full-text` command Successful.

before
<img width="536" alt="1079_before" src="https://user-images.githubusercontent.com/3177297/100808834-3a135f00-3478-11eb-8ace-91af5e9833be.png">

after
<img width="536" alt="1079_after" src="https://user-images.githubusercontent.com/3177297/100808837-3bdd2280-3478-11eb-85ba-03ffa30394e0.png">


# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES  

