### PR TITLE
fix(report): wpvulndb poor versioning(#1088)

### DIFF
--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -694,7 +694,7 @@ func (v VulnInfo) Cvss3CalcURL() string {
 func (v VulnInfo) VendorLinks(family string) map[string]string {
 	links := map[string]string{}
 	if strings.HasPrefix(v.CveID, "WPVDBID") {
-		links["WPVulnDB"] = fmt.Sprintf("https://wpvulndb.com/vulnerabilities/%s",
+		links["WPVulnDB"] = fmt.Sprintf("https://wpscan.com/vulnerabilities/%s",
 			strings.TrimPrefix(v.CveID, "WPVDBID-"))
 		return links
 	}

--- a/report/util.go
+++ b/report/util.go
@@ -140,7 +140,7 @@ No CVE-IDs are found in updatable packages.
 		if strings.HasPrefix(vinfo.CveID, "CVE-") {
 			link = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vinfo.CveID)
 		} else if strings.HasPrefix(vinfo.CveID, "WPVDBID-") {
-			link = fmt.Sprintf("https://wpvulndb.com/vulnerabilities/%s", strings.TrimPrefix(vinfo.CveID, "WPVDBID-"))
+			link = fmt.Sprintf("https://wpscan.com/vulnerabilities/%s", strings.TrimPrefix(vinfo.CveID, "WPVDBID-"))
 		}
 
 		data = append(data, []string{
@@ -401,7 +401,7 @@ func formatCsvList(r models.ScanResult, path string) error {
 		if strings.HasPrefix(vinfo.CveID, "CVE-") {
 			link = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vinfo.CveID)
 		} else if strings.HasPrefix(vinfo.CveID, "WPVDBID-") {
-			link = fmt.Sprintf("https://wpvulndb.com/vulnerabilities/%s", strings.TrimPrefix(vinfo.CveID, "WPVDBID-"))
+			link = fmt.Sprintf("https://wpscan.com/vulnerabilities/%s", strings.TrimPrefix(vinfo.CveID, "WPVDBID-"))
 		}
 
 		data = append(data, []string{

--- a/wordpress/wordpress.go
+++ b/wordpress/wordpress.go
@@ -47,7 +47,7 @@ type References struct {
 }
 
 // FillWordPress access to wpvulndb and fetch scurity alerts and then set to the given ScanResult.
-// https://wpvulndb.com/
+// https://wpscan.com/
 func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]string) (int, error) {
 	// Core
 	ver := strings.Replace(r.WordPressPackages.CoreVersion(), ".", "", -1)
@@ -57,7 +57,7 @@ func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]
 
 	body, ok := searchCache(ver, wpVulnCaches)
 	if !ok {
-		url := fmt.Sprintf("https://wpvulndb.com/api/v3/wordpresses/%s", ver)
+		url := fmt.Sprintf("https://wpscan.com/api/v3/wordpresses/%s", ver)
 		var err error
 		body, err = httpRequest(url, token)
 		if err != nil {
@@ -87,7 +87,7 @@ func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]
 	for _, p := range themes {
 		body, ok := searchCache(p.Name, wpVulnCaches)
 		if !ok {
-			url := fmt.Sprintf("https://wpvulndb.com/api/v3/themes/%s", p.Name)
+			url := fmt.Sprintf("https://wpscan.com/api/v3/themes/%s", p.Name)
 			var err error
 			body, err = httpRequest(url, token)
 			if err != nil {
@@ -113,7 +113,8 @@ func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]
 				}
 				ok, err := match(pkg.Version, fixstat.FixedIn)
 				if err != nil {
-					return 0, xerrors.Errorf("Not a semantic versioning: %w", err)
+					util.Log.Infof("[poor] %s installed: %s, fixedIn: %s", pkg.Name, pkg.Version, fixstat.FixedIn)
+					continue
 				}
 				if ok {
 					wpVinfos = append(wpVinfos, v)
@@ -129,7 +130,7 @@ func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]
 	for _, p := range plugins {
 		body, ok := searchCache(p.Name, wpVulnCaches)
 		if !ok {
-			url := fmt.Sprintf("https://wpvulndb.com/api/v3/plugins/%s", p.Name)
+			url := fmt.Sprintf("https://wpscan.com/api/v3/plugins/%s", p.Name)
 			var err error
 			body, err = httpRequest(url, token)
 			if err != nil {
@@ -155,7 +156,8 @@ func FillWordPress(r *models.ScanResult, token string, wpVulnCaches *map[string]
 				}
 				ok, err := match(pkg.Version, fixstat.FixedIn)
 				if err != nil {
-					return 0, xerrors.Errorf("Not a semantic versioning: %w", err)
+					util.Log.Infof("[poor] %s installed: %s, fixedIn: %s", pkg.Name, pkg.Version, fixstat.FixedIn)
+					continue
 				}
 				if ok {
 					wpVinfos = append(wpVinfos, v)


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

vuls report skip wpvulndb poor versioning data

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes #1088 

## Type of change

- vuls report skip wpvulndb poor versioning data
- replace from wpvulndb.com to wpscan.com

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
[vuls@vuls ~]$ vuls report -debug -ignore-unscored-cves -lang=ja -cvss-over=7 -to-email -format-full-text
 :snip
[Dec 10 13:17:50] DEBUG [localhost] https://wpscan.com/api/v3/plugins/search-regex
[Dec 10 13:17:50] DEBUG [localhost] https://wpscan.com/api/v3/plugins/tinymce-advanced
[Dec 10 13:17:50]  INFO [localhost] [match] tinymce-advanced installed: 4.1.9, fixedIn: 4.2.3
[Dec 10 13:17:50] DEBUG [localhost] https://wpscan.com/api/v3/plugins/tinymce-clear-buttons
[Dec 10 13:17:50] DEBUG [localhost] https://wpscan.com/api/v3/plugins/wordpress-importer
[Dec 10 13:17:50] DEBUG [localhost] https://wpscan.com/api/v3/plugins/wp-pagenavi
[Dec 10 13:17:51] DEBUG [localhost] https://wpscan.com/api/v3/plugins/wp-serverinfo
[Dec 10 13:17:51] DEBUG [localhost] https://wpscan.com/api/v3/plugins/wp-admin-ui-customize
[Dec 10 13:17:51] DEBUG [localhost] https://wpscan.com/api/v3/plugins/wp-custom-fields-search
[Dec 10 13:17:51]  INFO [localhost] [poor] wp-custom-fields-search installed: 1.2.9, fixedIn: <<< HERE!!!
[Dec 10 13:17:51] DEBUG [localhost] https://wpscan.com/api/v3/plugins/wp-multibyte-patch
[Dec 10 13:17:51] DEBUG [localhost] https://wpscan.com/api/v3/plugins/zipaddr-jp
[Dec 10 13:17:52]  INFO [localhost] wp-example: 0 CVEs are detected with GitHub Security Alerts
[Dec 10 13:17:52]  INFO [localhost] wp-example: 0 unfixed CVEs are detected with gost
[Dec 10 13:17:52]  INFO [localhost] Fill CVE detailed information with CVE-DB
[Dec 10 13:17:52]  INFO [localhost] Fill exploit information with Exploit-DB
[Dec 10 13:17:52]  INFO [localhost] wp-example: 0 exploits are detected
[Dec 10 13:17:52]  INFO [localhost] Fill metasploit module information with Metasploit-DB
[Dec 10 13:17:52]  INFO [localhost] wp-example: 0 modules are detected

wp-example (centos7.9.2009)
==============================
Total: 0 (High:0 Medium:0 Low:0), 0/0 Fixed, 0 installed, 0 updatable, 0 exploits, 0 modules, en: 0, ja: 0 alerts
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes  

