### PR TITLE
fix(server): make config loading same as scan

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -29,6 +29,9 @@ all: build
 build: ./cmd/vuls/main.go pretest fmt
 	$(GO) build -a -ldflags "$(LDFLAGS)" -o vuls ./cmd/vuls
 
+b: ./cmd/vuls/main.go 
+	$(GO) build -a -ldflags "$(LDFLAGS)" -o vuls ./cmd/vuls
+
 install: ./cmd/vuls/main.go pretest fmt
 	$(GO) install -ldflags "$(LDFLAGS)" ./cmd/vuls
 

--- a/subcmds/report.go
+++ b/subcmds/report.go
@@ -23,13 +23,8 @@ import (
 
 // ReportCmd is subcommand for reporting
 type ReportCmd struct {
-	configPath     string
-	cveDict        c.GoCveDictConf
-	ovalDict       c.GovalDictConf
-	gostConf       c.GostConf
-	exploitConf    c.ExploitConf
-	metasploitConf c.MetasploitConf
-	httpConf       c.HTTPConf
+	configPath string
+	httpConf   c.HTTPConf
 }
 
 // Name return subcommand name
@@ -78,21 +73,6 @@ func (*ReportCmd) Usage() string {
 		[-quiet]
 		[-no-progress]
 		[-pipe]
-		[-cvedb-type=sqlite3|mysql|postgres|redis|http]
-		[-cvedb-sqlite3-path=/path/to/cve.sqlite3]
-		[-cvedb-url=http://127.0.0.1:1323 or DB connection string]
-		[-ovaldb-type=sqlite3|mysql|redis|http]
-		[-ovaldb-sqlite3-path=/path/to/oval.sqlite3]
-		[-ovaldb-url=http://127.0.0.1:1324 or DB connection string]
-		[-gostdb-type=sqlite3|mysql|redis|http]
-		[-gostdb-sqlite3-path=/path/to/gost.sqlite3]
-		[-gostdb-url=http://127.0.0.1:1325 or DB connection string]
-		[-exploitdb-type=sqlite3|mysql|redis|http]
-		[-exploitdb-sqlite3-path=/path/to/exploitdb.sqlite3]
-		[-exploitdb-url=http://127.0.0.1:1326 or DB connection string]
-		[-msfdb-type=sqlite3|mysql|redis|http]
-		[-msfdb-sqlite3-path=/path/to/msfdb.sqlite3]
-		[-msfdb-url=http://127.0.0.1:1327 or DB connection string]
 		[-http="http://vuls-report-server"]
 		[-trivy-cachedb-dir=/path/to/dir]
 
@@ -175,36 +155,6 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 		"Auto generate of scan target servers and then write to config.toml and scan result")
 	f.BoolVar(&c.Conf.Pipe, "pipe", false, "Use args passed via PIPE")
 
-	f.StringVar(&p.cveDict.Type, "cvedb-type", "",
-		"DB type of go-cve-dictionary (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.cveDict.SQLite3Path, "cvedb-sqlite3-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.cveDict.URL, "cvedb-url", "",
-		"http://go-cve-dictionary.com:1323 or DB connection string")
-
-	f.StringVar(&p.ovalDict.Type, "ovaldb-type", "",
-		"DB type of goval-dictionary (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.ovalDict.SQLite3Path, "ovaldb-sqlite3-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.ovalDict.URL, "ovaldb-url", "",
-		"http://goval-dictionary.com:1324 or DB connection string")
-
-	f.StringVar(&p.gostConf.Type, "gostdb-type", "",
-		"DB type of gost (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.gostConf.SQLite3Path, "gostdb-sqlite3-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.gostConf.URL, "gostdb-url", "",
-		"http://gost.com:1325 or DB connection string")
-
-	f.StringVar(&p.exploitConf.Type, "exploitdb-type", "",
-		"DB type of exploit (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.exploitConf.SQLite3Path, "exploitdb-sqlite3-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.exploitConf.URL, "exploitdb-url", "",
-		"http://exploit.com:1326 or DB connection string")
-
-	f.StringVar(&p.metasploitConf.Type, "msfdb-type", "",
-		"DB type of msf (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.metasploitConf.SQLite3Path, "msfdb-sqlite3-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.metasploitConf.URL, "msfdb-url", "",
-		"http://metasploit.com:1327 or DB connection string")
-
 	f.StringVar(&p.httpConf.URL, "http", "", "-to-http http://vuls-report")
 
 	f.StringVar(&c.Conf.TrivyCacheDBDir, "trivy-cachedb-dir",
@@ -218,12 +168,6 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 		util.Log.Errorf("Error loading %s, %+v", p.configPath, err)
 		return subcommands.ExitUsageError
 	}
-
-	c.Conf.CveDict.Overwrite(p.cveDict)
-	c.Conf.OvalDict.Overwrite(p.ovalDict)
-	c.Conf.Gost.Overwrite(p.gostConf)
-	c.Conf.Exploit.Overwrite(p.exploitConf)
-	c.Conf.Metasploit.Overwrite(p.metasploitConf)
 	c.Conf.HTTP.Overwrite(p.httpConf)
 
 	var dir string

--- a/subcmds/server.go
+++ b/subcmds/server.go
@@ -25,13 +25,8 @@ import (
 
 // ServerCmd is subcommand for server
 type ServerCmd struct {
-	configPath     string
-	listen         string
-	cveDict        c.GoCveDictConf
-	ovalDict       c.GovalDictConf
-	gostConf       c.GostConf
-	exploitConf    c.ExploitConf
-	metasploitConf c.MetasploitConf
+	configPath string
+	listen     string
 }
 
 // Name return subcommand name
@@ -56,21 +51,6 @@ func (*ServerCmd) Usage() string {
 		[-debug]
 		[-debug-sql]
 		[-listen=localhost:5515]
-		[-cvedb-type=sqlite3|mysql|postgres|redis|http]
-		[-cvedb-sqlite3-path=/path/to/cve.sqlite3]
-		[-cvedb-url=http://127.0.0.1:1323 or DB connection string]
-		[-ovaldb-type=sqlite3|mysql|redis|http]
-		[-ovaldb-sqlite3-path=/path/to/oval.sqlite3]
-		[-ovaldb-url=http://127.0.0.1:1324 or DB connection string]
-		[-gostdb-type=sqlite3|mysql|redis|http]
-		[-gostdb-sqlite3-path=/path/to/gost.sqlite3]
-		[-gostdb-url=http://127.0.0.1:1325 or DB connection string]
-		[-exploitdb-type=sqlite3|mysql|redis|http]
-		[-exploitdb-sqlite3-path=/path/to/exploitdb.sqlite3]
-		[-exploitdb-url=http://127.0.0.1:1326 or DB connection string]
-		[-msfdb-type=sqlite3|mysql|redis|http]
-		[-msfdb-sqlite3-path=/path/to/msfdb.sqlite3]
-		[-msfdb-url=http://127.0.0.1:1327 or DB connection string]
 
 		[RFC3339 datetime format under results dir]
 `
@@ -83,7 +63,8 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.Conf.DebugSQL, "debug-sql", false, "SQL debug mode")
 
 	wd, _ := os.Getwd()
-	f.StringVar(&p.configPath, "config", "", "/path/to/toml")
+	defaultConfPath := filepath.Join(wd, "config.toml")
+	f.StringVar(&p.configPath, "config", defaultConfPath, "/path/to/toml")
 
 	defaultResultsDir := filepath.Join(wd, "results")
 	f.StringVar(&c.Conf.ResultsDir, "results-dir", defaultResultsDir, "/path/to/results")
@@ -98,7 +79,7 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 		"Don't Server the unscored CVEs")
 
 	f.BoolVar(&c.Conf.IgnoreUnfixed, "ignore-unfixed", false,
-		"Don't Server the unfixed CVEs")
+		"Don't show the unfixed CVEs")
 
 	f.StringVar(&c.Conf.HTTPProxy, "http-proxy", "",
 		"http://proxy-url:port (default: empty)")
@@ -108,53 +89,15 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.Conf.ToLocalFile, "to-localfile", false, "Write report to localfile")
 	f.StringVar(&p.listen, "listen", "localhost:5515",
 		"host:port (default: localhost:5515)")
-
-	f.StringVar(&p.cveDict.Type, "cvedb-type", "",
-		"DB type of go-cve-dictionary (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.cveDict.SQLite3Path, "cvedb-sqlite3-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.cveDict.URL, "cvedb-url", "",
-		"http://go-cve-dictionary.com:1323 or DB connection string")
-
-	f.StringVar(&p.ovalDict.Type, "ovaldb-type", "",
-		"DB type of goval-dictionary (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.ovalDict.SQLite3Path, "ovaldb-sqlite3-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.ovalDict.URL, "ovaldb-url", "",
-		"http://goval-dictionary.com:1324 or DB connection string")
-
-	f.StringVar(&p.gostConf.Type, "gostdb-type", "",
-		"DB type of gost (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.gostConf.SQLite3Path, "gostdb-sqlite3-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.gostConf.URL, "gostdb-url", "",
-		"http://gost.com:1325 or DB connection string")
-
-	f.StringVar(&p.exploitConf.Type, "exploitdb-type", "",
-		"DB type of exploit (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.exploitConf.SQLite3Path, "exploitdb-sqlite3-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.exploitConf.URL, "exploitdb-url", "",
-		"http://exploit.com:1326 or DB connection string")
-
-	f.StringVar(&p.metasploitConf.Type, "msfdb-type", "",
-		"DB type of msf (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.metasploitConf.SQLite3Path, "msfdb-sqlite3-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.metasploitConf.URL, "msfdb-url", "",
-		"http://metasploit.com:1327 or DB connection string")
 }
 
 // Execute execute
 func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	util.Log = util.NewCustomLogger(c.ServerInfo{})
-	if p.configPath != "" {
-		if err := c.Load(p.configPath, ""); err != nil {
-			util.Log.Errorf("Error loading %s. err: %+v", p.configPath, err)
-			return subcommands.ExitUsageError
-		}
+	if err := c.Load(p.configPath, ""); err != nil {
+		util.Log.Errorf("Error loading %s. err: %+v", p.configPath, err)
+		return subcommands.ExitUsageError
 	}
-
-	c.Conf.CveDict.Overwrite(p.cveDict)
-	c.Conf.OvalDict.Overwrite(p.ovalDict)
-	c.Conf.Gost.Overwrite(p.gostConf)
-	c.Conf.Exploit.Overwrite(p.exploitConf)
-	c.Conf.Metasploit.Overwrite(p.metasploitConf)
 
 	util.Log.Info("Validating config...")
 	if !c.Conf.ValidateOnReport() {

--- a/subcmds/tui.go
+++ b/subcmds/tui.go
@@ -22,12 +22,7 @@ import (
 
 // TuiCmd is Subcommand of host discovery mode
 type TuiCmd struct {
-	configPath     string
-	cveDict        c.GoCveDictConf
-	ovalDict       c.GovalDictConf
-	gostConf       c.GostConf
-	exploitConf    c.ExploitConf
-	metasploitConf c.MetasploitConf
+	configPath string
 }
 
 // Name return subcommand name
@@ -53,21 +48,6 @@ func (*TuiCmd) Usage() string {
 		[-quiet]
 		[-no-progress]
 		[-pipe]
-		[-cvedb-type=sqlite3|mysql|postgres|redis|http]
-		[-cvedb-sqlite3-path=/path/to/cve.sqlite3]
-		[-cvedb-url=http://127.0.0.1:1323 or DB connection string]
-		[-ovaldb-type=sqlite3|mysql|redis|http]
-		[-ovaldb-sqlite3-path=/path/to/oval.sqlite3]
-		[-ovaldb-url=http://127.0.0.1:1324 or DB connection string]
-		[-gostdb-type=sqlite3|mysql|redis|http]
-		[-gostdb-sqlite3-path=/path/to/gost.sqlite3]
-		[-gostdb-url=http://127.0.0.1:1325 or DB connection string]
-		[-exploitdb-type=sqlite3|mysql|redis|http]
-		[-exploitdb-sqlite3-path=/path/to/exploitdb.sqlite3]
-		[-exploitdb-url=http://127.0.0.1:1326 or DB connection string]
-		[-msfdb-type=sqlite3|mysql|redis|http]
-		[-msfdb-sqlite3-path=/path/to/msfdb.sqlite3]
-		[-msfdb-url=http://127.0.0.1:1327 or DB connection string]
 		[-trivy-cachedb-dir=/path/to/dir]
 
 `
@@ -109,36 +89,6 @@ func (p *TuiCmd) SetFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&c.Conf.Pipe, "pipe", false, "Use stdin via PIPE")
 
-	f.StringVar(&p.cveDict.Type, "cvedb-type", "",
-		"DB type of go-cve-dictionary (sqlite3, mysql, postgres or redis)")
-	f.StringVar(&p.cveDict.SQLite3Path, "cvedb-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.cveDict.URL, "cvedb-url", "",
-		"http://go-cve-dictionary.com:1323 or DB connection string")
-
-	f.StringVar(&p.ovalDict.Type, "ovaldb-type", "",
-		"DB type of goval-dictionary (sqlite3, mysql, postgres or redis)")
-	f.StringVar(&p.ovalDict.SQLite3Path, "ovaldb-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.ovalDict.URL, "ovaldb-url", "",
-		"http://goval-dictionary.com:1324 or DB connection string")
-
-	f.StringVar(&p.gostConf.Type, "gostdb-type", "",
-		"DB type of gost (sqlite3, mysql, postgres or redis)")
-	f.StringVar(&p.gostConf.SQLite3Path, "gostdb-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.gostConf.URL, "gostdb-url", "",
-		"http://gost.com:1325 or DB connection string")
-
-	f.StringVar(&p.exploitConf.Type, "exploitdb-type", "",
-		"DB type of exploit (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.exploitConf.SQLite3Path, "exploitdb-sqlite3-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.exploitConf.URL, "exploitdb-url", "",
-		"http://exploit.com:1326 or DB connection string")
-
-	f.StringVar(&p.metasploitConf.Type, "msfdb-type", "",
-		"DB type of msf (sqlite3, mysql, postgres, redis or http)")
-	f.StringVar(&p.metasploitConf.SQLite3Path, "msfdb-sqlite3-path", "", "/path/to/sqlite3")
-	f.StringVar(&p.metasploitConf.URL, "msfdb-url", "",
-		"http://metasploit.com:1327 or DB connection string")
-
 	f.StringVar(&c.Conf.TrivyCacheDBDir, "trivy-cachedb-dir",
 		utils.DefaultCacheDir(), "/path/to/dir")
 }
@@ -152,11 +102,6 @@ func (p *TuiCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 	}
 
 	c.Conf.Lang = "en"
-	c.Conf.CveDict.Overwrite(p.cveDict)
-	c.Conf.OvalDict.Overwrite(p.ovalDict)
-	c.Conf.Gost.Overwrite(p.gostConf)
-	c.Conf.Exploit.Overwrite(p.exploitConf)
-	c.Conf.Metasploit.Overwrite(p.metasploitConf)
 
 	var dir string
 	var err error


### PR DESCRIPTION
# What did you implement:

Remove the below options and use config.toml.

```
./vuls server -h
Server:
        Server
                ...
                [-cvedb-type=sqlite3|mysql|postgres|redis|http]
                [-cvedb-sqlite3-path=/path/to/cve.sqlite3]
                [-cvedb-url=http://127.0.0.1:1323 or DB connection string]
                [-ovaldb-type=sqlite3|mysql|redis|http]
                [-ovaldb-sqlite3-path=/path/to/oval.sqlite3]
                [-ovaldb-url=http://127.0.0.1:1324 or DB connection string]
                [-gostdb-type=sqlite3|mysql|redis|http]
                [-gostdb-sqlite3-path=/path/to/gost.sqlite3]
                [-gostdb-url=http://127.0.0.1:1325 or DB connection string]
                [-exploitdb-type=sqlite3|mysql|redis|http]
                [-exploitdb-sqlite3-path=/path/to/exploitdb.sqlite3]
                [-exploitdb-url=http://127.0.0.1:1326 or DB connection string]
                [-msfdb-type=sqlite3|mysql|redis|http]
                [-msfdb-sqlite3-path=/path/to/msfdb.sqlite3]
                [-msfdb-url=http://127.0.0.1:1327 or DB connection string]
```


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

./vuls server

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
