### PR TITLE
feat(scanner): vuls-scanner binary on release archive

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -19,4 +19,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_user_name: kotakanbe
           git_user_email: kotakanbe@gmail.com
-          go_version: 1.14.x
+          go_version: 1.15.6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,12 +64,24 @@ builds:
   - -tags=scanner
   main: ./contrib/future-vuls/cmd/main.go
   binary: future-vuls
+
 archives:
 
 - id: vuls
   name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
   builds:
   - vuls
+  format: tar.gz
+  files:
+  - LICENSE
+  - NOTICE
+  - README*
+  - CHANGELOG.md
+
+- id: vuls-scanner
+  name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  builds:
+  - vuls-scanner
   format: tar.gz
   files:
   - LICENSE


### PR DESCRIPTION
Place the vuls-scanner binary on the release page when pushing tags.
https://github.com/future-architect/vuls/releases
 
Make binaries for multiple architectures.
 - 386
  - amd64
  - arm
  - arm64

The vuls-scanner binary does not include the report function.
