### PR TITLE
fix(scan): add an error case for `rpm -qa`

### DIFF
--- a/scan/redhatbase.go
+++ b/scan/redhatbase.go
@@ -317,6 +317,11 @@ func (o *redhatBase) parseInstalledPackagesLine(line string) (models.Package, er
 		return models.Package{},
 			xerrors.Errorf("Failed to parse package line: %s", line)
 	}
+	if strings.HasSuffix(line, "Permission denied") {
+		return models.Package{},
+			xerrors.Errorf("Failed to parse package line: %s", line)
+	}
+
 	ver := ""
 	epoch := fields[1]
 	if epoch == "0" || epoch == "(none)" {

--- a/scan/redhatbase_test.go
+++ b/scan/redhatbase_test.go
@@ -137,12 +137,13 @@ kernel-devel 0 2.6.32 695.20.3.el6 x86_64`,
 	}
 
 }
-func TestParseScanedPackagesLineRedhat(t *testing.T) {
+func TestParseInstalledPackagesLine(t *testing.T) {
 	r := newRHEL(config.ServerInfo{})
 
 	var packagetests = []struct {
 		in   string
 		pack models.Package
+		err  bool
 	}{
 		{
 			"openssl	0	1.0.1e	30.el6.11 x86_64",
@@ -151,6 +152,7 @@ func TestParseScanedPackagesLineRedhat(t *testing.T) {
 				Version: "1.0.1e",
 				Release: "30.el6.11",
 			},
+			false,
 		},
 		{
 			"Percona-Server-shared-56	1	5.6.19	rel67.0.el6 x84_64",
@@ -159,11 +161,23 @@ func TestParseScanedPackagesLineRedhat(t *testing.T) {
 				Version: "1:5.6.19",
 				Release: "rel67.0.el6",
 			},
+			false,
+		},
+		{
+			"error: file /run/log/journal/346a500b7fb944199748954baca56086/system.journal: Permission denied",
+			models.Package{},
+			true,
 		},
 	}
 
-	for _, tt := range packagetests {
-		p, _ := r.parseInstalledPackagesLine(tt.in)
+	for i, tt := range packagetests {
+		p, err := r.parseInstalledPackagesLine(tt.in)
+		if err == nil && tt.err {
+			t.Errorf("Expected err not occurred: %d", i)
+		}
+		if err != nil && !tt.err {
+			t.Errorf("UnExpected err not occurred: %d", i)
+		}
 		if p.Name != tt.pack.Name {
 			t.Errorf("name: expected %s, actual %s", tt.pack.Name, p.Name)
 		}


### PR DESCRIPTION
# What did you implement:

Fix parse error on `rpm -qf`

```
[Dec 30 07:17:50]  WARN [c7s] err: Failed to execute yum-ps:
    github.com/future-architect/vuls/scan.(*redhatBase).postScan
        /home/ubuntu/go/src/github.com/future-architect/vuls/scan/redhatbase.go:177
  - Failed to find the package: error:-file:/run/log/journal/346a500b7fb944199748954baca56086/system.journal:-Permission.denied:
    github.com/future-architect/vuls/models.Packages.FindByFQPN
        /home/ubuntu/go/src/github.com/future-architect/vuls/models/packages.go:72
[Dec 30 07:17:52]  WARN [localhost] Some warnings occurred during scanning on c7s. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to execute yum-ps:
    github.com/future-architect/vuls/scan.(*redhatBase).postScan
        /home/ubuntu/go/src/github.com/future-architect/vuls/scan/redhatbase.go:177
  - Failed to find the package: error:-file:/run/log/journal/346a500b7fb944199748954baca56086/system.journal:-Permission.denied:
    github.com/future-architect/vuls/models.Packages.FindByFQPN
        /home/ubuntu/go/src/github.com/future-architect/vuls/models/packages.go:72]
Scan Summary
================
c7s     centos7.7.1908  307 installed, 136 updatable
Warning for c7s: [Failed to execute yum-ps:
    github.com/future-architect/vuls/scan.(*redhatBase).postScan
        /home/ubuntu/go/src/github.com/future-architect/vuls/scan/redhatbase.go:177
  - Failed to find the package: error:-file:/run/log/journal/346a500b7fb944199748954baca56086/system.journal:-Permission.denied:
    github.com/future-architect/vuls/models.Packages.FindByFQPN
        /home/ubuntu/go/src/github.com/future-architect/vuls/models/packages.go:72]
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

./vuls scan

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

