### PR TITLE
fix(redhat): possibility of false positives on RHEL

### DIFF
--- a/oval/util.go
+++ b/oval/util.go
@@ -378,9 +378,6 @@ func isOvalDefAffected(def ovalmodels.Definition, req request, family string, ru
 	return false, false, ""
 }
 
-var centosVerPattern = regexp.MustCompile(`\.[es]l(\d+)(?:_\d+)?(?:\.centos)?`)
-var esVerPattern = regexp.MustCompile(`\.el(\d+)(?:_\d+)?`)
-
 func lessThan(family, newVer string, packInOVAL ovalmodels.Package) (bool, error) {
 	switch family {
 	case config.Debian,
@@ -416,12 +413,18 @@ func lessThan(family, newVer string, packInOVAL ovalmodels.Package) (bool, error
 
 	case config.RedHat,
 		config.CentOS:
-		vera := rpmver.NewVersion(centosVerPattern.ReplaceAllString(newVer, ".el$1"))
-		verb := rpmver.NewVersion(esVerPattern.ReplaceAllString(packInOVAL.Version, ".el$1"))
+		vera := rpmver.NewVersion(centOSVersionToRHEL(newVer))
+		verb := rpmver.NewVersion(packInOVAL.Version)
 		return vera.LessThan(verb), nil
 
 	default:
 		util.Log.Errorf("Not implemented yet: %s", family)
 	}
 	return false, xerrors.Errorf("Package version comparison not supported: %s", family)
+}
+
+var centosVerPattern = regexp.MustCompile(`\.[es]l(\d+)(?:_\d+)?(?:\.centos)?`)
+
+func centOSVersionToRHEL(ver string) string {
+	return centosVerPattern.ReplaceAllString(ver, ".el$1")
 }

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -1193,3 +1193,36 @@ func Test_major(t *testing.T) {
 		}
 	}
 }
+
+func Test_centOSVersionToRHEL(t *testing.T) {
+	type args struct {
+		ver string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "remove centos.",
+			args: args{
+				ver: "grub2-tools-2.02-0.80.el7.centos.x86_64",
+			},
+			want: "grub2-tools-2.02-0.80.el7.x86_64",
+		},
+		{
+			name: "noop",
+			args: args{
+				ver: "grub2-tools-2.02-0.80.el7.x86_64",
+			},
+			want: "grub2-tools-2.02-0.80.el7.x86_64",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := centOSVersionToRHEL(tt.args.ver); got != tt.want {
+				t.Errorf("centOSVersionToRHEL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What did you implement:

`0:2-el8 < 0:2-el8_3`

`# yum install rpmdevtools`

```
[root@ip-192-168-0-219 ~]# rpmdev-vercmp
  Epoch1: 0
Version1: 2
Release1: el8_3.1
  Epoch2: 0
Version2: 2
Release2: el8_3
0:2-el8_3.1 > 0:2-el8_3
[root@ip-192-168-0-219 ~]# rpmdev-vercmp
  Epoch1: 0
Version1: 2
Release1: el8
  Epoch2: 0
Version2: 2
Release2: el8_3
0:2-el8 < 0:2-el8_3
```

https://stackoverflow.com/a/26047243/1834557

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?



# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
