### PR TITLE
fix(scan): err detecting EOL for alpine Linux

### DIFF
--- a/config/os.go
+++ b/config/os.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 	"time"
 )
@@ -211,7 +212,7 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 			"3.10": {StandardSupportUntil: time.Date(2021, 5, 1, 23, 59, 59, 0, time.UTC)},
 			"3.11": {StandardSupportUntil: time.Date(2021, 11, 1, 23, 59, 59, 0, time.UTC)},
 			"3.12": {StandardSupportUntil: time.Date(2022, 5, 1, 23, 59, 59, 0, time.UTC)},
-		}[release]
+		}[majorDotMinor(release)]
 	case FreeBSD:
 		// https://www.freebsd.org/security/
 		eol, found = map[string]EOL{
@@ -228,6 +229,14 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 
 func major(osVer string) (majorVersion string) {
 	return strings.Split(osVer, ".")[0]
+}
+
+func majorDotMinor(osVer string) (majorDotMinor string) {
+	ss := strings.SplitN(osVer, ".", 3)
+	if len(ss) == 1 {
+		return osVer
+	}
+	return fmt.Sprintf("%s.%s", ss[0], ss[1])
 }
 
 func isAmazonLinux1(osRelease string) bool {

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -324,3 +324,50 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 		})
 	}
 }
+
+func Test_majorDotMinor(t *testing.T) {
+	type args struct {
+		osVer string
+	}
+	tests := []struct {
+		name              string
+		args              args
+		wantMajorDotMinor string
+	}{
+		{
+			name: "empty",
+			args: args{
+				osVer: "",
+			},
+			wantMajorDotMinor: "",
+		},
+		{
+			name: "major",
+			args: args{
+				osVer: "3",
+			},
+			wantMajorDotMinor: "3",
+		},
+		{
+			name: "major dot minor",
+			args: args{
+				osVer: "3.1",
+			},
+			wantMajorDotMinor: "3.1",
+		},
+		{
+			name: "major dot minor dot release",
+			args: args{
+				osVer: "3.1.4",
+			},
+			wantMajorDotMinor: "3.1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotMajorDotMinor := majorDotMinor(tt.args.osVer); gotMajorDotMinor != tt.wantMajorDotMinor {
+				t.Errorf("majorDotMinor() = %v, want %v", gotMajorDotMinor, tt.wantMajorDotMinor)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What did you implement:

before 

```
Scan Summary
================
jolly_lovelace@localhost        alpine3.8.4     18 installed, 1 updatable
localhost                       ubuntu18.04     941 installed, 201 updatable
Warning: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family: alpine Release: 3.8.4`]
```

after

```
[Jan 12 20:04:18]  WARN [localhost] Some warnings occurred during scanning on localhost. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Standard OS support is EOL(End-of-Life). Purchase extended support if available or Upgrading your OS is strongly recommended.]
Scan Summary
================
jolly_lovelace@localhost        alpine3.8.4     18 installed, 1 updatable
localhost                       ubuntu18.04     941 installed, 201 updatable
Warning: [Standard OS support is EOL(End-of-Life). Purchase extended support if available or Upgrading your OS is strongly recommended.]
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

./vuls scan

# Checklist:

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

