### PR TITLE
fix dnf prompt and ssh user

### DIFF
--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -155,8 +155,7 @@ func setDefaultIfEmpty(server *ServerInfo, d ServerInfo) error {
 		if server.User == "" {
 			if Conf.Default.User != "" {
 				server.User = Conf.Default.User
-			}
-			if server.Port != "local" {
+			} else {
 				return xerrors.Errorf("server.user is empty")
 			}
 		}

--- a/scan/redhatbase.go
+++ b/scan/redhatbase.go
@@ -707,7 +707,7 @@ func (o *redhatBase) detectEnabledDnfModules() ([]string, error) {
 		return nil, nil
 	}
 
-	cmd := `dnf --cacheonly --color=never --quiet module list --enabled`
+	cmd := `dnf --assumeyes --cacheonly --color=never --quiet module list --enabled`
 	r := o.exec(util.PrependProxyEnv(cmd), noSudo)
 	if !r.isSuccess() {
 		return nil, xerrors.Errorf("Failed to dnf module list: %s, cmd: %s", r, cmd)


### PR DESCRIPTION
# What did you implement:

* Bypass with -assumeyes when dnf module list stoped at GPG key import prompt appeared.

* Fix to use ssh default user when server.user is empty.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES

