### PR TITLE
fix(scan): kindness msg when no-cache err on dnf mod list

### DIFF
--- a/scan/redhatbase.go
+++ b/scan/redhatbase.go
@@ -710,7 +710,10 @@ func (o *redhatBase) detectEnabledDnfModules() ([]string, error) {
 	cmd := `dnf --cacheonly --color=never --quiet module list --enabled`
 	r := o.exec(util.PrependProxyEnv(cmd), noSudo)
 	if !r.isSuccess() {
-		return nil, xerrors.Errorf("Failed to dnf module list: %s, cmd: %s", r, cmd)
+		if strings.Contains(r.Stdout, "Cache-only enabled but no cache") {
+			return nil, xerrors.Errorf("sudo yum check-update to make local cache before scanning: %s", r)
+		}
+		return nil, xerrors.Errorf("Failed to dnf module list: %s", r)
 	}
 	return o.parseDnfModuleList(r.Stdout)
 }


### PR DESCRIPTION
# What did you implement:

before

```
    github.com/future-architect/vuls/scan.(*redhatBase).scanPackages
        /home/ubuntu/go/src/github.com/future-architect/vuls/scan/redhatbase.go:209
  - Failed to dnf module list: execResult: servername: rhel8
      cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/ubuntu/.vuls/controlmaster-%r-rhel8.%p -o Controlpersist=10m ec2-user@54.95.80.39 -p 22 -i /home/ubuntu/.ssh/stg.pem -o PasswordAuthentication=no stty cols 1000; dnf --cacheonly --color=never --quiet module list --enabled
      exitstatus: 1
      stdout: Error: Cache-only enabled but no cache for 'rhui-client-config-server-8'
      stderr:
      err: %!s(<nil>), cmd: dnf --cacheonly --color=never --quiet module list --enabled:
    github.com/future-architect/vuls/scan.(*redhatBase).detectEnabledDnfModules
        /home/ubuntu/go/src/github.com/future-architect/vuls/scan/redhatbase.go:713
```

after

```
[Jan 14 08:03:51] ERROR [localhost] Error on rhel8, err: [Failed to detect installed dnf modules:
    github.com/future-architect/vuls/scan.(*redhatBase).scanPackages
        /home/ubuntu/go/src/github.com/future-architect/vuls/scan/redhatbase.go:209
  - sudo yum check-update to make local cache before scanning: execResult: servername: rhel8
      cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/ubuntu/.vuls/controlmaster-%r-rhel8.%p -o Controlpersist=10m ec2-user@3.112.204.253 -p 22 -i /home/ubuntu/.ssh/stg.pem -o PasswordAuthentication=no stty cols 1000; dnf --cacheonly --color=never --quiet module list --enabled
      exitstatus: 1
      stdout: Error: Cache-only enabled but no cache for 'rhui-client-config-server-8'
      stderr:
      err: %!s(<nil>):
    github.com/future-architect/vuls/scan.(*redhatBase).detectEnabledDnfModules
        /home/ubuntu/go/src/github.com/future-architect/vuls/scan/redhatbase.go:714]
Scan Summary
================
rhel8   Error           Use configtest subcommand or scan with --debug to view the details
```


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Launch an instance of RHEL8 in AWS and scan it immediately.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES