### PR TITLE
fix(config): err occurs when host not set in local-scan-mode

### DIFF
--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -153,9 +153,8 @@ func setDefaultIfEmpty(server *ServerInfo, d ServerInfo) error {
 		}
 
 		if server.User == "" {
-			if Conf.Default.User != "" {
-				server.User = Conf.Default.User
-			} else {
+			server.User = Conf.Default.User
+			if server.User == "" && server.Port != "local" {
 				return xerrors.Errorf("server.user is empty")
 			}
 		}


### PR DESCRIPTION
# What did you implement:

```
[default]
[servers.localhost]
host = "localhost"
port = "local"
```

```
If you update Vuls and get this error, there may be incompatible changes in config.toml
Please check config.toml template : https://vuls.io/docs/en/usage-settings.html
Failed to set default value to config. server: localhost, err:
    github.com/future-architect/vuls/config.TOMLLoader.Load                                                                                                 /home/ubuntu/go/src/github.com/future-architect/vuls/config/tomlloader.go:39
  - server.user is empty:
    github.com/future-architect/vuls/config.setDefaultIfEmpty
        /home/ubuntu/go/src/github.com/future-architect/vuls/config/tomlloader.go:159
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

see above

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
