### PR TITLE
fix(email.go):Fix runtime error(invalid memory address)

### DIFF
--- a/report/email.go
+++ b/report/email.go
@@ -123,11 +123,11 @@ func (e *emailSender) sendMail(smtpServerAddr, message string) (err error) {
 	if ok, param := c.Extension("AUTH"); ok {
 		authList := strings.Split(param, " ")
 		auth = e.newSaslClient(authList)
+		if err = c.Auth(auth); err != nil {
+			return xerrors.Errorf("Failed to authenticate: %w", err)
+		}
 	}
 
-	if err = c.Auth(auth); err != nil {
-		return xerrors.Errorf("Failed to authenticate: %w", err)
-	}
 	if err = c.Mail(emailConf.From, nil); err != nil {
 		return xerrors.Errorf("Failed to send Mail command: %w", err)
 	}


### PR DESCRIPTION
# What did you implement:

The cause of this bug is passing nil as the argument of c.Auth() when the auth is not obtained.
```golang
        if ok, param := c.Extension("AUTH"); ok {
		authList := strings.Split(param, " ")
		auth = e.newSaslClient(authList)
	}
        // The following code has a problem
	if err = c.Auth(auth); err != nil {
		return xerrors.Errorf("Failed to authenticate: %w", err)
	}
```

- After
```golang
        if ok, param := c.Extension("AUTH"); ok {
		authList := strings.Split(param, " ")
		auth = e.newSaslClient(authList)
		if err = c.Auth(auth); err != nil {
			return xerrors.Errorf("Failed to authenticate: %w", err)
		}
	}
```

Fixes #1130 

## Type of change

- [*] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
I confirmed that I would receive an email. (Gmail)

# Reference
https://github.com/future-architect/vuls/blob/3bacb648a5c8d7ca744b5d76057eca7a05c7df43/report/email.go#L128

