### PR TITLE
fix(model): omit changelog from json if empty

### DIFF
--- a/models/packages.go
+++ b/models/packages.go
@@ -81,7 +81,7 @@ type Package struct {
 	NewRelease       string               `json:"newRelease"`
 	Arch             string               `json:"arch"`
 	Repository       string               `json:"repository"`
-	Changelog        Changelog            `json:"changelog"`
+	Changelog        *Changelog           `json:"changelog,omitempty"`
 	AffectedProcs    []AffectedProcess    `json:",omitempty"`
 	NeedRestartProcs []NeedRestartProcess `json:",omitempty"`
 }

--- a/models/packages_test.go
+++ b/models/packages_test.go
@@ -287,7 +287,7 @@ func TestPackage_FormatVersionFromTo(t *testing.T) {
 				NewRelease:       tt.fields.NewRelease,
 				Arch:             tt.fields.Arch,
 				Repository:       tt.fields.Repository,
-				Changelog:        tt.fields.Changelog,
+				Changelog:        &tt.fields.Changelog,
 				AffectedProcs:    tt.fields.AffectedProcs,
 				NeedRestartProcs: tt.fields.NeedRestartProcs,
 			}

--- a/report/util_test.go
+++ b/report/util_test.go
@@ -267,7 +267,7 @@ func TestDiff(t *testing.T) {
 							NewVersion: "5.1.73",
 							NewRelease: "8.el6_8",
 							Repository: "",
-							Changelog: models.Changelog{
+							Changelog: &models.Changelog{
 								Contents: "",
 								Method:   "",
 							},
@@ -305,7 +305,7 @@ func TestDiff(t *testing.T) {
 						NewVersion: "5.1.73",
 						NewRelease: "8.el6_8",
 						Repository: "",
-						Changelog: models.Changelog{
+						Changelog: &models.Changelog{
 							Contents: "",
 							Method:   "",
 						},

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -968,7 +968,7 @@ func (o *debian) getCveIDsFromChangelog(
 
 	// If the version is not in changelog, return entire changelog to put into cache
 	pack := o.Packages[name]
-	pack.Changelog = models.Changelog{
+	pack.Changelog = &models.Changelog{
 		Contents: changelog,
 		Method:   models.FailedToFindVersionInChangelog,
 	}
@@ -1018,7 +1018,7 @@ func (o *debian) parseChangelog(changelog, name, ver string, confidence models.C
 	if !found {
 		if o.Distro.Family == config.Raspbian {
 			pack := o.Packages[name]
-			pack.Changelog = models.Changelog{
+			pack.Changelog = &models.Changelog{
 				Contents: strings.Join(buf, "\n"),
 				Method:   models.ChangelogLenientMatchStr,
 			}
@@ -1032,7 +1032,7 @@ func (o *debian) parseChangelog(changelog, name, ver string, confidence models.C
 		}
 
 		pack := o.Packages[name]
-		pack.Changelog = models.Changelog{
+		pack.Changelog = &models.Changelog{
 			Contents: "",
 			Method:   models.FailedToFindVersionInChangelog,
 		}
@@ -1046,7 +1046,7 @@ func (o *debian) parseChangelog(changelog, name, ver string, confidence models.C
 		Method:   confidence.DetectionMethod,
 	}
 	pack := o.Packages[name]
-	pack.Changelog = clog
+	pack.Changelog = &clog
 
 	cves := []DetectedCveID{}
 	for _, id := range cveIDs {

--- a/scan/debian_test.go
+++ b/scan/debian_test.go
@@ -794,7 +794,7 @@ vlc (3.0.10-0+deb10u1) buster-security; urgency=medium`,
 			},
 			expect: expect{
 				cveIDs: []DetectedCveID{{"CVE-2020-13428", models.ChangelogExactMatch}},
-				pack: models.Package{Changelog: models.Changelog{
+				pack: models.Package{Changelog: &models.Changelog{
 					Contents: `vlc (3.0.11-0+deb10u1+rpt2) buster; urgency=medium
 
   * Add MMAL patch 19
@@ -837,7 +837,7 @@ vlc (3.0.11-0+deb10u1) buster-security; urgency=high
 			},
 			expect: expect{
 				cveIDs: []DetectedCveID{},
-				pack: models.Package{Changelog: models.Changelog{
+				pack: models.Package{Changelog: &models.Changelog{
 					Contents: `realvnc-vnc (6.7.2.42622) stable; urgency=low
 
   * Debian package for VNC Server


### PR DESCRIPTION
# What did you implement:

before 
```
 "packages": {
        "NetworkManager": {
            "name": "NetworkManager",
            "version": "1:1.26.0",
            "release": "9.el8_3",
            "newVersion": "1:1.26.0",
            "newRelease": "12.el8_3",
            "arch": "x86_64",
            "repository": "rhel-8-baseos-rhui-rpms",
            "changelog": {
                "contents": "",
                "method": ""
            },
            "AffectedProcs": [
                {
                    "pid": "830",
                    "name": "NetworkManager"
                }
            ]
        },
```

after 

```
    "packages": {
        "NetworkManager": {
            "name": "NetworkManager",
            "version": "1:1.26.0",
            "release": "9.el8_3",
            "newVersion": "1:1.26.0",
            "newRelease": "12.el8_3",
            "arch": "x86_64",
            "repository": "rhel-8-baseos-rhui-rpms",
            "AffectedProcs": [
                {
                    "pid": "830",
                    "name": "NetworkManager"
                }
            ]
        },
        ....
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

./vuls scan , ./vuls report, check json

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
