### PR TITLE
feat(github): display GitHub Security Advisory details

### DIFF
--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strings"
 	"time"
 
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
@@ -58,7 +59,7 @@ func (v CveContents) PrimarySrcURLs(lang, myFamily, cveID string) (values []CveC
 		}
 	}
 
-	order := CveContentTypes{Nvd, NewCveContentType(myFamily)}
+	order := CveContentTypes{Nvd, NewCveContentType(myFamily), GitHub}
 	for _, ctype := range order {
 		if cont, found := v[ctype]; found {
 			if cont.SourceLink == "" {
@@ -74,7 +75,7 @@ func (v CveContents) PrimarySrcURLs(lang, myFamily, cveID string) (values []CveC
 		}
 	}
 
-	if len(values) == 0 {
+	if len(values) == 0 && strings.HasPrefix(cveID, "CVE") {
 		return []CveContentStr{{
 			Type:  Nvd,
 			Value: "https://nvd.nist.gov/vuln/detail/" + cveID,
@@ -252,6 +253,8 @@ func NewCveContentType(name string) CveContentType {
 		return Amazon
 	case "trivy":
 		return Trivy
+	case "GitHub":
+		return Trivy
 	default:
 		return Unknown
 	}
@@ -297,6 +300,9 @@ const (
 	// Trivy is Trivy
 	Trivy CveContentType = "trivy"
 
+	// GitHub is GitHub Security Alerts
+	GitHub CveContentType = "github"
+
 	// Unknown is Unknown
 	Unknown CveContentType = "unknown"
 )
@@ -317,6 +323,7 @@ var AllCveContetTypes = CveContentTypes{
 	DebianSecurityTracker,
 	WpScan,
 	Trivy,
+	GitHub,
 }
 
 // Except returns CveContentTypes except for given args

--- a/report/tui.go
+++ b/report/tui.go
@@ -150,8 +150,6 @@ func keybindings(g *gocui.Gui) (err error) {
 	//  errs = append(errs, g.SetKeybinding("msg", gocui.KeyEnter, gocui.ModNone, delMsg))
 	//  errs = append(errs, g.SetKeybinding("detail", gocui.KeyEnter, gocui.ModNone, showMsg))
 
-	//TODO Help Ctrl-h
-
 	errs = append(errs, g.SetKeybinding("", gocui.KeyCtrlC, gocui.ModNone, quit))
 	//  errs = append(errs, g.SetKeybinding("side", gocui.KeyEnter, gocui.ModNone, getLine))
 	//  errs = append(errs, g.SetKeybinding("msg", gocui.KeyEnter, gocui.ModNone, delMsg))

--- a/scan/redhatbase.go
+++ b/scan/redhatbase.go
@@ -374,12 +374,6 @@ func (o *redhatBase) parseUpdatablePacksLines(stdout string) (models.Packages, e
 	updatable := models.Packages{}
 	lines := strings.Split(stdout, "\n")
 	for _, line := range lines {
-		// TODO remove
-		// if strings.HasPrefix(line, "Obsoleting") ||
-		// strings.HasPrefix(line, "Security:") {
-		// // see https://github.com/future-architect/vuls/issues/165
-		// continue
-		// }
 		if len(strings.TrimSpace(line)) == 0 {
 			continue
 		} else if strings.HasPrefix(line, "Loading") {


### PR DESCRIPTION
# What did you implement:

GHSA detail information is now displayed when reporting with GitHub integration.

- CVE

![image](https://user-images.githubusercontent.com/534611/105617614-df1c3980-5e22-11eb-9261-875b44d5259e.png)

- non-CVE
![image](https://user-images.githubusercontent.com/534611/105617767-4f778a80-5e24-11eb-93ed-b6f67137e3d3.png)

For detail about GHSA integration, see [Usage: Integrate with GitHub Security Alerts](https://vuls.io/docs/en/usage-scan-non-os-packages.html#usage-integrate-with-github-security-alerts)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

./vuls report

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
