### PR TITLE
fix(report): set severity in Red Hat OVAL to both CVSS v3 and v2 #1146

### DIFF
--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -173,17 +173,15 @@ func (o RedHatBase) convertToModel(cveID string, def *ovalmodels.Definition) *mo
 		score2, vec2 := o.parseCvss2(cve.Cvss2)
 		score3, vec3 := o.parseCvss3(cve.Cvss3)
 
-		severity := def.Advisory.Severity
+		sev2, sev3, severity := "", "", def.Advisory.Severity
 		if cve.Impact != "" {
 			severity = cve.Impact
 		}
-
-		sev2, sev3 := "", ""
-		if score2 == 0 {
-			sev2 = severity
-		}
-		if score3 == 0 {
+		if severity != "None" {
 			sev3 = severity
+			if score2 != 0 {
+				sev2 = severity
+			}
 		}
 
 		// CWE-ID in RedHat OVAL may have multiple cweIDs separated by space


### PR DESCRIPTION
# What did you implement:

Fixes #1146 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

$ ./vuls report

```
                "redhat": {
                    "type": "redhat",
                    "cveID": "CVE-2019-10906",
                    "title": "RHSA-2019:1152: python-jinja2 security update (Important)",
                    "summary": "snip",
                    "cvss2Score": 0,
                    "cvss2Vector": "",
                    "cvss2Severity": "",
                    "cvss3Score": 9,
                    "cvss3Vector": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
                    "cvss3Severity": "Important",
                     ...snip...
                },
```


# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
