### PR TITLE
fix(report): wordrpess scanning skipped when package is empty

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -339,7 +339,7 @@ type AzureConf struct {
 
 // WpScanConf is wpscan.com config
 type WpScanConf struct {
-	Token          string `toml:"Token,omitempty" json:"-"`
+	Token          string `toml:"token,omitempty" json:"-"`
 	DetectInactive bool   `toml:"detectInactive,omitempty" json:"detectInactive,omitempty"`
 }
 

--- a/report/report.go
+++ b/report/report.go
@@ -227,7 +227,7 @@ func DetectGitHubCves(r *models.ScanResult, githubConfs map[string]c.GitHubConf)
 
 // DetectWordPressCves detects CVEs of WordPress
 func DetectWordPressCves(r *models.ScanResult, wpCnf *c.WpScanConf) error {
-	if len(r.Packages) == 0 {
+	if len(r.WordPressPackages) == 0 {
 		return nil
 	}
 	util.Log.Infof("Detect WordPress CVE. pkgs: %d ", len(r.WordPressPackages))


### PR DESCRIPTION
# What did you implement:

When in `scanModules = ["wordpress"]`, the os package will be empty. 
Fixed a bug that caused wordpress vulnerability detection to be skipped in this case.

```
[servers.kusanagi]
host = "xxx"
user = "kanbe"
keyPath = "/home/ubuntu/.ssh/id_rsa"
scanModules = ["wordpress"]

[servers.kusanagi.wordpress]
osUser = "kusanagi"
docRoot = "/home/kusanagi/xxx/DocumentRoot/"
cmdPath = "/usr/local/bin/wp"
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
