### PR TITLE
fix(report): remove duplicated refreshing logic when report with -diff

### DIFF
--- a/report/report.go
+++ b/report/report.go
@@ -127,15 +127,9 @@ func FillCveInfos(dbclient DBClient, rs []models.ScanResult, dir string) ([]mode
 			return nil, err
 		}
 
-		diff, err := diff(rs, prevs)
+		rs, err = diff(rs, prevs)
 		if err != nil {
 			return nil, err
-		}
-		for i, r := range diff {
-			if err := fillCvesWithNvdJvn(dbclient.CveDB, &r); err != nil {
-				return nil, err
-			}
-			rs[i] = r
 		}
 	}
 

--- a/report/util.go
+++ b/report/util.go
@@ -504,7 +504,7 @@ func loadPrevious(currs models.ScanResults) (prevs models.ScanResults, err error
 			path := filepath.Join(dir, filename)
 			r, err := loadOneServerScanResult(path)
 			if err != nil {
-				util.Log.Errorf("%+v", err)
+				util.Log.Debugf("%+v", err)
 				continue
 			}
 			if r.Family == result.Family && r.Release == result.Release {

--- a/subcmds/report.go
+++ b/subcmds/report.go
@@ -96,7 +96,7 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 		"-cvss-over=6.5 means reporting CVSS Score 6.5 and over (default: 0 (means report all))")
 
 	f.BoolVar(&c.Conf.Diff, "diff", false,
-		"Difference between previous result and current result ")
+		"Difference between previous result and current result")
 
 	f.BoolVar(&c.Conf.IgnoreUnscoredCves, "ignore-unscored-cves", false,
 		"Don't report the unscored CVEs")


### PR DESCRIPTION
# What did you implement:

Removed duplicated logic since it has already been executed in this line, there is no need to execute it again.
https://github.com/future-architect/vuls/blob/master/report/report.go#L98

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

./vuls report -diff works fine.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
