### PR TITLE
fix(report): set created_at and updated_at of wpscan.com to json

### DIFF
--- a/wordpress/wordpress.go
+++ b/wordpress/wordpress.go
@@ -32,11 +32,10 @@ type WpCveInfos struct {
 
 //WpCveInfo is for wpscan json
 type WpCveInfo struct {
-	ID        string `json:"id"`
-	Title     string `json:"title"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
-	// PublishedDate string     `json:"published_date"`
+	ID         string     `json:"id"`
+	Title      string     `json:"title"`
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
 	VulnType   string     `json:"vuln_type"`
 	References References `json:"references"`
 	FixedIn    string     `json:"fixed_in"`
@@ -198,10 +197,12 @@ func extractToVulnInfos(pkgName string, cves []WpCveInfo) (vinfos []models.VulnI
 				CveID: cveID,
 				CveContents: models.NewCveContents(
 					models.CveContent{
-						Type:       models.WpScan,
-						CveID:      cveID,
-						Title:      vulnerability.Title,
-						References: refs,
+						Type:         models.WpScan,
+						CveID:        cveID,
+						Title:        vulnerability.Title,
+						References:   refs,
+						Published:    vulnerability.CreatedAt,
+						LastModified: vulnerability.UpdatedAt,
 					},
 				),
 				VulnType: vulnerability.VulnType,


### PR DESCRIPTION
# What did you implement:

after 

```
                "wpscan": {
                    "type": "wpscan",
                    "cveID": "CVE-2013-5988",
                    "title": "All in One SEO Pack \u003c= 2.0.3 - XSS ",
                    "summary": "",
                    "cvss2Score": 0,
                    "cvss2Vector": "",
                    "cvss2Severity": "",
                    "cvss3Score": 0,
                    "cvss3Vector": "",
                    "cvss3Severity": "",
                    "sourceLink": "",
                    "references": [
                        {
                            "link": "https://packetstormsecurity.com/files/123490/"
                        },
                        {
                            "link": "https://www.securityfocus.com/bid/62784/"
                        },
                        {
                            "link": "https://seclists.org/bugtraq/2013/Oct/8"
                        }
                    ],
                    "published": "2014-08-01T10:59:02Z",
                    "lastModified": "2020-09-22T05:58:51Z"
                }
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

check the output json

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
