### PR TITLE
fix(report): set created_at and updated_at of trivy to json

### DIFF
--- a/contrib/trivy/parser/parser.go
+++ b/contrib/trivy/parser/parser.go
@@ -57,12 +57,24 @@ func Parse(vulnJSON []byte, scanResult *models.ScanResult) (result *models.ScanR
 				return references[i].Link < references[j].Link
 			})
 
+			var published time.Time
+			if vuln.PublishedDate != nil {
+				published = *vuln.PublishedDate
+			}
+
+			var lastModified time.Time
+			if vuln.LastModifiedDate != nil {
+				lastModified = *vuln.LastModifiedDate
+			}
+
 			vulnInfo.CveContents = models.CveContents{
 				models.Trivy: models.CveContent{
 					Cvss3Severity: vuln.Severity,
 					References:    references,
 					Title:         vuln.Title,
 					Summary:       vuln.Description,
+					Published:     published,
+					LastModified:  lastModified,
 				},
 			}
 			// do only if image type is Vuln


### PR DESCRIPTION
# What did you implement:

```
 ubuntu@dev  ~│g│s│g│f│vuls  ⎇ trivy-time~  ./trivy -q image -f=json ubuntu | ./trivy-to-vuls parse --stdin
      "CVE-2018-20839": {
         "cveID": "CVE-2018-20839",
         "confidences": [
            {
               "score": 100,
               "detectionMethod": "TrivyMatch"
            }
         ],
         "affectedPackages": [
            {
               "name": "libsystemd0",
               "notFixedYet": true,
               "fixState": "Affected"
            },
            {
               "name": "libudev1",
               "notFixedYet": true,
               "fixState": "Affected"
            }
         ],
         "cveContents": {
            "trivy": {
               "type": "",
               "cveID": "",
               "title": "systemd: mishandling of the current keyboard mode check leading to passwords being disclosed in cleartext to attacker",
               "summary": "systemd 242 changes the VT1 mode upon a logout, which allows attackers to read cleartext passwords in certain circumstances, such as watching a shutdown, or using Ctrl-Alt-F1 and Ctrl-Alt-F2. This occurs because the KDGKBMODE (aka current keyboard mode) check is mishandled.",
               "cvss2Score": 0,
               "cvss2Vector": "",
               "cvss2Severity": "",
               "cvss3Score": 0,
               "cvss3Vector": "",
               "cvss3Severity": "MEDIUM",
               "sourceLink": "",
               "references": [
                  {
                     "link": "http://www.securityfocus.com/bid/108389",
                     "source": "trivy"
                  },
                  {
                     "link": "https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1803993",
                     "source": "trivy"
                  },
                  {
                     "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20839",
                     "source": "trivy"
                  },
                  {
                     "link": "https://github.com/systemd/systemd/commit/9725f1a10f80f5e0ae7d9b60547458622aeb322f",
                     "source": "trivy"
                  },
                  {
                     "link": "https://github.com/systemd/systemd/pull/12378",
                     "source": "trivy"
                  },
                  {
                     "link": "https://github.com/systemd/systemd/pull/13109",
                     "source": "trivy"
                  },
                  {
                     "link": "https://security.netapp.com/advisory/ntap-20190530-0002/",
                     "source": "trivy"
                  }
               ],
               "published": "2019-05-17T04:29:00Z",
               "lastModified": "2020-08-24T17:37:00Z"
            }
         },
         "alertDict": {
            "ja": null,
            "en": null
         }
      },
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 
