### PR TITLE
fix(log): output the version of vuls to log for debugging purpose

### DIFF
--- a/cmd/vuls/main.go
+++ b/cmd/vuls/main.go
@@ -29,7 +29,7 @@ func main() {
 	flag.Parse()
 
 	if *v {
-		fmt.Printf("vuls %s %s\n", config.Version, config.Revision)
+		fmt.Printf("vuls-%s-%s\n", config.Version, config.Revision)
 		os.Exit(int(subcommands.ExitSuccess))
 	}
 

--- a/scan/alpine.go
+++ b/scan/alpine.go
@@ -32,19 +32,16 @@ func newAlpine(c config.ServerInfo) *alpine {
 
 // Alpine
 // https://github.com/mizzy/specinfra/blob/master/lib/specinfra/helper/detect_os/alpine.rb
-func detectAlpine(c config.ServerInfo) (itsMe bool, os osTypeInterface) {
-	os = newAlpine(c)
-
+func detectAlpine(c config.ServerInfo) (bool, osTypeInterface) {
 	if r := exec(c, "ls /etc/alpine-release", noSudo); !r.isSuccess() {
-		return false, os
+		return false, nil
 	}
-
 	if r := exec(c, "cat /etc/alpine-release", noSudo); r.isSuccess() {
+		os := newAlpine(c)
 		os.setDistro(config.Alpine, strings.TrimSpace(r.Stdout))
 		return true, os
 	}
-
-	return false, os
+	return false, nil
 }
 
 func (o *alpine) checkScanMode() error {

--- a/scan/freebsd.go
+++ b/scan/freebsd.go
@@ -31,15 +31,14 @@ func newBsd(c config.ServerInfo) *bsd {
 }
 
 //https://github.com/mizzy/specinfra/blob/master/lib/specinfra/helper/detect_os/freebsd.rb
-func detectFreebsd(c config.ServerInfo) (itsMe bool, bsd osTypeInterface) {
-	bsd = newBsd(c)
-
+func detectFreebsd(c config.ServerInfo) (bool, osTypeInterface) {
 	// Prevent from adding `set -o pipefail` option
 	c.Distro = config.Distro{Family: config.FreeBSD}
 
 	if r := exec(c, "uname", noSudo); r.isSuccess() {
 		if strings.Contains(strings.ToLower(r.Stdout), config.FreeBSD) == true {
 			if b := exec(c, "freebsd-version", noSudo); b.isSuccess() {
+				bsd := newBsd(c)
 				rel := strings.TrimSpace(b.Stdout)
 				bsd.setDistro(config.FreeBSD, rel)
 				return true, bsd
@@ -47,7 +46,7 @@ func detectFreebsd(c config.ServerInfo) (itsMe bool, bsd osTypeInterface) {
 		}
 	}
 	util.Log.Debugf("Not FreeBSD. servernam: %s", c.ServerName)
-	return false, bsd
+	return false, nil
 }
 
 func (o *bsd) checkScanMode() error {

--- a/scan/pseudo.go
+++ b/scan/pseudo.go
@@ -12,9 +12,12 @@ type pseudo struct {
 }
 
 func detectPseudo(c config.ServerInfo) (itsMe bool, pseudo osTypeInterface, err error) {
-	p := newPseudo(c)
-	p.setDistro(config.ServerTypePseudo, "")
-	return c.Type == config.ServerTypePseudo, p, nil
+	if c.Type == config.ServerTypePseudo {
+		p := newPseudo(c)
+		p.setDistro(config.ServerTypePseudo, "")
+		return true, p, nil
+	}
+	return false, nil, nil
 }
 
 func newPseudo(c config.ServerInfo) *pseudo {

--- a/util/logutil.go
+++ b/util/logutil.go
@@ -86,8 +86,9 @@ func NewCustomLogger(server config.ServerInfo) *logrus.Entry {
 		}
 	}
 
-	fields := logrus.Fields{"prefix": whereami}
-	return log.WithFields(fields)
+	entry := log.WithFields(logrus.Fields{"prefix": whereami})
+	entry.Infof("vuls-%s-%s", config.Version, config.Revision)
+	return entry
 }
 
 // GetDefaultLogDir returns default log directory


### PR DESCRIPTION
# What did you implement:

```
✗  ubuntu@dev  ~│g│s│g│f│vuls  ⎇ master~  ./vuls scan vulsdoc
[Feb  4 07:37:27] ERROR Failed to create log file. path: /var/log/vuls/localhost.log, err: open /var/log/vuls/localhost.log: permission denied
[Feb  4 07:37:27]  INFO [localhost] vuls-v0.15.6-build-20210204_073220_64a6222
[Feb  4 07:37:27]  INFO [localhost] Start scanning
...
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES