### PR TITLE
fix(scan): yum-ps warning `Failed to find the package`

### DIFF
--- a/models/packages.go
+++ b/models/packages.go
@@ -63,13 +63,13 @@ func (ps Packages) FindOne(f func(Package) bool) (string, Package, bool) {
 }
 
 // FindByFQPN search a package by Fully-Qualified-Package-Name
-func (ps Packages) FindByFQPN(nameVerRelArc string) (*Package, error) {
+func (ps Packages) FindByFQPN(nameVerRel string) (*Package, error) {
 	for _, p := range ps {
-		if nameVerRelArc == p.FQPN() {
+		if nameVerRel == p.FQPN() {
 			return &p, nil
 		}
 	}
-	return nil, xerrors.Errorf("Failed to find the package: %s", nameVerRelArc)
+	return nil, xerrors.Errorf("Failed to find the package: %s", nameVerRel)
 }
 
 // Package has installed binary packages.
@@ -95,9 +95,6 @@ func (p Package) FQPN() string {
 	}
 	if p.Release != "" {
 		fqpn += fmt.Sprintf("-%s", p.Release)
-	}
-	if p.Arch != "" {
-		fqpn += fmt.Sprintf(".%s", p.Arch)
 	}
 	return fqpn
 }


### PR DESCRIPTION
# What did you implement:

This warning could occur when multiple installations of the same package (different architectures) installed.

```
[root@ip-192-168-0-154 ~]# rpm -qa | grep glibc-2
glibc-2.17-322.el7_9.x86_64
glibc-2.17-322.el7_9.i686
```

```
Scan Summary
================
c7      centos7.7.1908  303 installed, 134 updatable
Warning: [Failed to execute yum-ps:
    github.com/future-architect/vuls/scan.(*redhatBase).postScan
        /home/ubuntu/go/src/github.com/future-architect/vuls/scan/redhatbase.go:177
  - Failed to find the package: glibc-2.17-322.el7_9.x86_64:
    github.com/future-architect/vuls/models.Packages.FindByFQPN
        /home/ubuntu/go/src/github.com/future-architect/vuls/models/packages.go:72]
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The warning described above is not output.

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
