### PR TITLE
fix(scan): fix yum-ps warning `Failed to exec which -bash`

### DIFF
--- a/scan/base.go
+++ b/scan/base.go
@@ -888,6 +888,7 @@ func (l *base) parseGrepProcMap(stdout string) (soPaths []string) {
 	scanner := bufio.NewScanner(strings.NewReader(stdout))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
+		line = strings.Split(line, ";")[0]
 		soPaths = append(soPaths, line)
 	}
 	return soPaths

--- a/scan/base_test.go
+++ b/scan/base_test.go
@@ -218,12 +218,14 @@ func Test_base_parseGrepProcMap(t *testing.T) {
 			args: args{
 				`/etc/selinux/targeted/contexts/files/file_contexts.bin
 /etc/selinux/targeted/contexts/files/file_contexts.homedirs.bin
-/usr/lib64/libdl-2.28.so`,
+/usr/lib64/libdl-2.28.so
+				/usr/lib64/libnss_files-2.17.so;601ccbf3`,
 			},
 			wantSoPaths: []string{
 				"/etc/selinux/targeted/contexts/files/file_contexts.bin",
 				"/etc/selinux/targeted/contexts/files/file_contexts.homedirs.bin",
 				"/usr/lib64/libdl-2.28.so",
+				`/usr/lib64/libnss_files-2.17.so`,
 			},
 		},
 	}


### PR DESCRIPTION
# What did you implement:

```
[Feb  6 06:40:31]  WARN [c7] Failed to exec which -bash: execResult: servername: c7
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/ubuntu/.vuls/controlmaster-%r-c7.%p -o Controlpersist=10m centos@54.199.215.61 -p 22 -i /home/ubuntu/.ssh/stg.pem -o PasswordAuthentication=no stty cols 1000; sudo -S LANGUAGE=en_US.UTF-8 which -bash
  exitstatus: 255
  stdout: which: invalid option -- 'b'
which: invalid option -- 's'
which: invalid option -- 'h'
Usage: which [options] [--] COMMAND [...]
Write the full path of COMMAND(s) to standard output.
  --version, -[vV] Print version and exit successfully.
  --help,          Print this help and exit successfully.
  --skip-dot       Skip directories in PATH that start with a dot.
  --skip-tilde     Skip directories in PATH that start with a tilde.
  --show-dot       Don't expand a dot to current directory in output.
  --show-tilde     Output a tilde for HOME directory for non-root.
  --tty-only       Stop processing options on the right if not on tty.
  --all, -a        Print all matches in PATH, not just the first
  --read-alias, -i Read list of aliases from stdin.
  --skip-alias     Ignore option --read-alias; don't read stdin.
  --read-functions Read shell functions from stdin.
  --skip-functions Ignore option --read-functions; don't read stdin.
Recommended use is to write the output of (alias; declare -f) to standard
input, so that which can show aliases and shell functions. See which(1) for
examples.
If the options --read-alias and/or --read-functions are specified then the
output can be a full alias or function definition, optionally followed by
the full path of each command used inside of those.
Report bugs to <which-bugs@gnu.org>.
  stderr:
  err: %!s(<nil>)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

./vuls scan --debug centos7 with no warning

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
