### PR TITLE
fix(scan): warning if lsof command not found

### DIFF
--- a/scan/base.go
+++ b/scan/base.go
@@ -322,7 +322,7 @@ func (l *base) detectPlatform() {
 
 var dsFingerPrintPrefix = "AgentStatus.agentCertHash: "
 
-func (l *base) detectDeepSecurity() (fingerprint string, err error) {
+func (l *base) detectDeepSecurity() (string, error) {
 	// only work root user
 	if l.getServerInfo().Mode.IsFastRoot() {
 		if r := l.exec("test -f /opt/ds_agent/dsa_query", sudo); r.isSuccess() {
@@ -621,7 +621,7 @@ func (d *DummyFileInfo) IsDir() bool { return false }
 //Sys is
 func (d *DummyFileInfo) Sys() interface{} { return nil }
 
-func (l *base) scanWordPress() (err error) {
+func (l *base) scanWordPress() error {
 	if l.ServerInfo.WordPress.IsZero() || l.ServerInfo.Type == config.ServerTypePseudo {
 		return nil
 	}
@@ -835,7 +835,7 @@ func (l *base) findPortTestSuccessOn(listenIPPorts []string, searchListenPort mo
 	return addrs
 }
 
-func (l *base) ps() (stdout string, err error) {
+func (l *base) ps() (string, error) {
 	cmd := `LANGUAGE=en_US.UTF-8 ps --no-headers --ppid 2 -p 2 --deselect -o pid,comm`
 	r := l.exec(util.PrependProxyEnv(cmd), noSudo)
 	if !r.isSuccess() {
@@ -858,7 +858,7 @@ func (l *base) parsePs(stdout string) map[string]string {
 	return pidNames
 }
 
-func (l *base) lsProcExe(pid string) (stdout string, err error) {
+func (l *base) lsProcExe(pid string) (string, error) {
 	cmd := fmt.Sprintf("ls -l /proc/%s/exe", pid)
 	r := l.exec(util.PrependProxyEnv(cmd), sudo)
 	if !r.isSuccess() {
@@ -875,7 +875,7 @@ func (l *base) parseLsProcExe(stdout string) (string, error) {
 	return ss[10], nil
 }
 
-func (l *base) grepProcMap(pid string) (stdout string, err error) {
+func (l *base) grepProcMap(pid string) (string, error) {
 	cmd := fmt.Sprintf(`cat /proc/%s/maps 2>/dev/null | grep -v " 00:00 " | awk '{print $6}' | sort -n | uniq`, pid)
 	r := l.exec(util.PrependProxyEnv(cmd), sudo)
 	if !r.isSuccess() {
@@ -893,10 +893,10 @@ func (l *base) parseGrepProcMap(stdout string) (soPaths []string) {
 	return soPaths
 }
 
-func (l *base) lsOfListen() (stdout string, err error) {
-	cmd := `lsof -i -P -n | grep LISTEN`
+func (l *base) lsOfListen() (string, error) {
+	cmd := `lsof -i -P -n`
 	r := l.exec(util.PrependProxyEnv(cmd), sudo)
-	if !r.isSuccess(0, 1) {
+	if !r.isSuccess() {
 		return "", xerrors.Errorf("Failed to lsof: %s", r)
 	}
 	return r.Stdout, nil
@@ -906,7 +906,11 @@ func (l *base) parseLsOf(stdout string) map[string][]string {
 	portPids := map[string][]string{}
 	scanner := bufio.NewScanner(strings.NewReader(stdout))
 	for scanner.Scan() {
-		ss := strings.Fields(scanner.Text())
+		line := scanner.Text()
+		if !strings.Contains(line, "LISTEN") {
+			continue
+		}
+		ss := strings.Fields(line)
 		if len(ss) < 10 {
 			continue
 		}

--- a/scan/base_test.go
+++ b/scan/base_test.go
@@ -255,6 +255,7 @@ sshd        644            root    4u  IPv6  16716      0t0  TCP *:22 (LISTEN)
 squid       959           proxy   11u  IPv6  16351      0t0  TCP *:3128 (LISTEN)
 node       1498          ubuntu   21u  IPv6  20132      0t0  TCP *:35401 (LISTEN)
 node       1498          ubuntu   22u  IPv6  20133      0t0  TCP *:44801 (LISTEN)
+rpcbind   568    rpc    7u  IPv6  15149      0t0  UDP *:111
 docker-pr  9135            root    4u  IPv6 297133      0t0  TCP *:6379 (LISTEN)`,
 			},
 			wantPortPid: map[string][]string{

--- a/scan/debian.go
+++ b/scan/debian.go
@@ -1297,7 +1297,8 @@ func (o *debian) dpkgPs() error {
 	pidListenPorts := map[string][]models.PortStat{}
 	stdout, err = o.lsOfListen()
 	if err != nil {
-		return xerrors.Errorf("Failed to ls of: %w", err)
+		// warning only, continue scanning
+		o.log.Warnf("Failed to lsof: %+v", err)
 	}
 	portPids := o.parseLsOf(stdout)
 	for ipPort, pids := range portPids {
@@ -1332,7 +1333,8 @@ func (o *debian) dpkgPs() error {
 		for _, n := range pkgNames {
 			p, ok := o.Packages[n]
 			if !ok {
-				return xerrors.Errorf("pkg not found %s", n)
+				o.log.Warnf("Failed to FindByFQPN: %+v", err)
+				continue
 			}
 			p.AffectedProcs = append(p.AffectedProcs, proc)
 			o.Packages[p.Name] = p


### PR DESCRIPTION
# What did you implement:

```
[Feb  6 08:27:21] DEBUG [c7] Executing... lsof -i -P -n | grep LISTEN                                                                        
[Feb  6 08:27:21] DEBUG [c7] execResult: servername: c7                                                                                                       
cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/ubuntu/.vuls/controlmaster-%r-c7.%p -o Controlpersist=10m centos@54.199.215.61 -p 22 -i /home/ubuntu/.ssh/stg.pem -o PasswordAuthentication=no stty cols 1000; sudo -S lsof -i -P -n | grep LISTEN                                                                                                                     
exitstatus: 1                                                                                                                                               
stdout: sudo: lsof: command not found                                                                                                                                                                                                                                                                                   
stderr:                                                                                                                                                     err: %!s(<nil>)                                                                                                                                           
```

#863 changed to debug message when grep count is zero, and debug message when lsof command is not found(It was error before).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
^C⏎                                                                                                                                                                                                                                                                                                                                                                                                    ✗  ubuntu@dev  ~│g│s│g│f│vuls  ⎇ lsof-err-handle~  ./vuls scan c7
[Feb  7 07:20:00] ERROR Failed to create log file. path: /var/log/vuls/localhost.log, err: open /var/log/vuls/localhost.log: permission denied
[Feb  7 07:20:00]  INFO [localhost] vuls-v0.15.6-build-20210207_070958_cd67220
[Feb  7 07:20:00]  INFO [localhost] Start scanning
[Feb  7 07:20:00]  INFO [localhost] config: /home/ubuntu/go/src/github.com/future-architect/vuls/config.toml
[Feb  7 07:20:00]  INFO [localhost] Validating config...
[Feb  7 07:20:00]  INFO [localhost] Detecting Server/Container OS... 
[Feb  7 07:20:00]  INFO [localhost] Detecting OS of servers... 
[Feb  7 07:20:00] ERROR Failed to create log file. path: /var/log/vuls/c7.log, err: open /var/log/vuls/c7.log: permission denied
[Feb  7 07:20:00]  INFO [c7] vuls-v0.15.6-build-20210207_070958_cd67220
[Feb  7 07:20:00]  INFO [localhost] (1/1) Detected: c7: centos 7.7.1908
[Feb  7 07:20:00]  INFO [localhost] Detecting OS of containers... 
[Feb  7 07:20:00]  INFO [localhost] Checking Scan Modes... 
[Feb  7 07:20:00]  INFO [localhost] Detecting Platforms... 
[Feb  7 07:20:01]  INFO [localhost] (1/1) c7 is running on aws
[Feb  7 07:20:01]  INFO [localhost] Detecting IPS identifiers... 
[Feb  7 07:20:01]  INFO [localhost] (1/1) c7 has 0 IPS integration
[Feb  7 07:20:01]  INFO [c7] Scanning OS pkg in fast-root mode
[Feb  7 07:20:08]  WARN [c7] Failed to lsof: Failed to lsof: execResult: servername: c7
      cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/ubuntu/.vuls/controlmaster-%r-c7.%p -o Controlpersist=10m centos@54.199.215.61 -p 22 -i /home/ubuntu/.ssh/stg.pem -o PasswordAuthentication=no stty cols 1000; sudo -S lsof -i -P -n
      exitstatus: 1
      stdout: sudo: lsof: command not found
    
      stderr: 
      err: %!s(<nil>):
    github.com/future-architect/vuls/scan.(*base).lsOfListen
        /home/ubuntu/go/src/github.com/future-architect/vuls/scan/base.go:900
[Feb  7 07:20:14]  INFO [c7] Scanning listen port...


Scan Summary
================
c7      centos7.7.1908  303 installed, 134 updatable
```

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
