### PR TITLE
Pass packInOVAL.Version through centOSVersionToRHEL() to remove the "…

### DIFF
--- a/oval/util.go
+++ b/oval/util.go
@@ -399,7 +399,7 @@ func lessThan(family, newVer string, packInOVAL ovalmodels.Package) (bool, error
 	case config.RedHat,
 		config.CentOS:
 		vera := rpmver.NewVersion(centOSVersionToRHEL(newVer))
-		verb := rpmver.NewVersion(packInOVAL.Version)
+		verb := rpmver.NewVersion(centOSVersionToRHEL(packInOVAL.Version))
 		return vera.LessThan(verb), nil
 
 	default:


### PR DESCRIPTION
…_<point release>" portion so that packInOVAL.Version strings like 1.8.23-10.el7_9.1 become 1.8.23-10.el7.1 (same behavior as newVer, which now allows packInOVAL.Version and newVer to be directly compared).


# What did you implement:

Currently, vuls strips `_<point release>` and `.centos` from the newVer variable (holds the presently installed package version), but does not strip these tags from the packInOVAL.Version variable (holds the version that fixes the particular vulnerability).  

This means that if the installed, latest version of a package resolves a CVE, and that version has a `_<point release>` tag, it will not match:

`sudo-1.8.23-10.el7_9.1` is the currently installed package (newVer)
`sudo-1.8.23-10.el7_9.1` is also the package which resolves the CVE (packInOVAL.Version)

When the two are compared:

newVer is `1.8.23-10.el7.1` but packInOVAL.Version is `1.8.23-10.el7_9.1`

With this PR, packInOVAL.Version is transformed the same was as newVer, so both are `1.8.23-10.el7.1`

Fixes https://github.com/future-architect/vuls/issues/1171

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Issue https://github.com/future-architect/vuls/issues/1171 describes how I found the issue.

To test, I ran a scan on a system that was recently updated so should have all published patches installed.  I found several packages which were marked as "Fixed" but vulnerable on my system in vulsRepo.  Pulling up the CveID details for several "Fixed" CVEs, I compared the installed package version and release with the FixedIn version and saw that the correct version was installed, but wasn't matching.

After running packInOVAL.Version through centOSVersionToRHEL() and re-running the scan, these packages no longer reported as false positives.

If I get chance, I'll write a test tomorrow and submit a PR for it, also (or update this one).

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [X] Check that there aren't other open pull requests for the same issue/feature
- [X] Format your source code by `make fmt`
- [X] Pass the test by `make test`
- [X] Provide verification config / commands
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** Yes

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

