### PR TITLE
Add test-case to verify proper version comparison in lessThan() 

### DIFF
--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -1210,8 +1210,8 @@ func Test_centOSVersionToRHEL(t *testing.T) {
 
 func Test_lessThan(t *testing.T) {
 	type args struct {
-		family string
-		newVer string
+		family        string
+		newVer        string
 		AffectedPacks ovalmodels.Package
 	}
 	tests := []struct {
@@ -1224,11 +1224,11 @@ func Test_lessThan(t *testing.T) {
 			args: args{
 				family: "centos",
 				newVer: "1.8.23-10.el7_9.1",
-				AffectedPacks: ovalmodels.Package {
-						Name:            "sudo",
-						Version:         "1.8.23-10.el7_9.1",
-						NotFixedYet:     false,
-					},
+				AffectedPacks: ovalmodels.Package{
+					Name:        "sudo",
+					Version:     "1.8.23-10.el7_9.1",
+					NotFixedYet: false,
+				},
 			},
 			want: false,
 		},
@@ -1237,11 +1237,11 @@ func Test_lessThan(t *testing.T) {
 			args: args{
 				family: "centos",
 				newVer: "1.8.23-10.el7_9.1",
-				AffectedPacks: ovalmodels.Package {
-						Name:            "sudo",
-						Version:         "1.8.23-10.el7.1",
-						NotFixedYet:     false,
-					},
+				AffectedPacks: ovalmodels.Package{
+					Name:        "sudo",
+					Version:     "1.8.23-10.el7.1",
+					NotFixedYet: false,
+				},
 			},
 			want: false,
 		},
@@ -1250,11 +1250,11 @@ func Test_lessThan(t *testing.T) {
 			args: args{
 				family: "centos",
 				newVer: "1.8.23-10.el7.1",
-				AffectedPacks: ovalmodels.Package {
-						Name:            "sudo",
-						Version:         "1.8.23-10.el7_9.1",
-						NotFixedYet:     false,
-					},
+				AffectedPacks: ovalmodels.Package{
+					Name:        "sudo",
+					Version:     "1.8.23-10.el7_9.1",
+					NotFixedYet: false,
+				},
 			},
 			want: false,
 		},
@@ -1263,19 +1263,19 @@ func Test_lessThan(t *testing.T) {
 			args: args{
 				family: "centos",
 				newVer: "1.8.23-10.el7.1",
-				AffectedPacks: ovalmodels.Package {
-						Name:            "sudo",
-						Version:         "1.8.23-10.el7.1",
-						NotFixedYet:     false,
-					},
+				AffectedPacks: ovalmodels.Package{
+					Name:        "sudo",
+					Version:     "1.8.23-10.el7.1",
+					NotFixedYet: false,
+				},
 			},
 			want: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := lessThan( tt.args.family, tt.args.newVer, tt.args.AffectedPacks )
-			if ( got != tt.want ) {
+			got, _ := lessThan(tt.args.family, tt.args.newVer, tt.args.AffectedPacks)
+			if got != tt.want {
 				t.Errorf("lessThan() = %t, want %t", got, tt.want)
 			}
 		})

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -1211,7 +1211,7 @@ func Test_centOSVersionToRHEL(t *testing.T) {
 func Test_lessThan(t *testing.T) {
 	type args struct {
 		family string
-		vera string
+		newVer string
 		AffectedPacks ovalmodels.Package
 	}
 	tests := []struct {
@@ -1223,7 +1223,7 @@ func Test_lessThan(t *testing.T) {
 			name: "newVer and ovalmodels.Package both have underscoreMinorversion.",
 			args: args{
 				family: "centos",
-				vera: "1.8.23-10.el7_9.1",
+				newVer: "1.8.23-10.el7_9.1",
 				AffectedPacks: ovalmodels.Package {
 						Name:            "sudo",
 						Version:         "1.8.23-10.el7_9.1",
@@ -1236,7 +1236,7 @@ func Test_lessThan(t *testing.T) {
 			name: "only newVer has underscoreMinorversion.",
 			args: args{
 				family: "centos",
-				vera: "1.8.23-10.el7_9.1",
+				newVer: "1.8.23-10.el7_9.1",
 				AffectedPacks: ovalmodels.Package {
 						Name:            "sudo",
 						Version:         "1.8.23-10.el7.1",
@@ -1249,7 +1249,7 @@ func Test_lessThan(t *testing.T) {
 			name: "only ovalmodels.Package has underscoreMinorversion.",
 			args: args{
 				family: "centos",
-				vera: "1.8.23-10.el7.1",
+				newVer: "1.8.23-10.el7.1",
 				AffectedPacks: ovalmodels.Package {
 						Name:            "sudo",
 						Version:         "1.8.23-10.el7_9.1",
@@ -1262,7 +1262,7 @@ func Test_lessThan(t *testing.T) {
 			name: "neither newVer nor ovalmodels.Package have underscoreMinorversion.",
 			args: args{
 				family: "centos",
-				vera: "1.8.23-10.el7.1",
+				newVer: "1.8.23-10.el7.1",
 				AffectedPacks: ovalmodels.Package {
 						Name:            "sudo",
 						Version:         "1.8.23-10.el7.1",
@@ -1274,7 +1274,7 @@ func Test_lessThan(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := lessThan( tt.args.family, tt.args.vera, tt.args.AffectedPacks )
+			got, _ := lessThan( tt.args.family, tt.args.newVer, tt.args.AffectedPacks )
 			if ( got != tt.want ) {
 				t.Errorf("lessThan() = %t, want %t", got, tt.want)
 			}

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -1207,3 +1207,77 @@ func Test_centOSVersionToRHEL(t *testing.T) {
 		})
 	}
 }
+
+func Test_lessThan(t *testing.T) {
+	type args struct {
+		family string
+		vera string
+		AffectedPacks ovalmodels.Package
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "newVer and ovalmodels.Package both have underscoreMinorversion.",
+			args: args{
+				family: "centos",
+				vera: "1.8.23-10.el7_9.1",
+				AffectedPacks: ovalmodels.Package {
+						Name:            "sudo",
+						Version:         "1.8.23-10.el7_9.1",
+						NotFixedYet:     false,
+					},
+			},
+			want: false,
+		},
+		{
+			name: "only newVer has underscoreMinorversion.",
+			args: args{
+				family: "centos",
+				vera: "1.8.23-10.el7_9.1",
+				AffectedPacks: ovalmodels.Package {
+						Name:            "sudo",
+						Version:         "1.8.23-10.el7.1",
+						NotFixedYet:     false,
+					},
+			},
+			want: false,
+		},
+		{
+			name: "only ovalmodels.Package has underscoreMinorversion.",
+			args: args{
+				family: "centos",
+				vera: "1.8.23-10.el7.1",
+				AffectedPacks: ovalmodels.Package {
+						Name:            "sudo",
+						Version:         "1.8.23-10.el7_9.1",
+						NotFixedYet:     false,
+					},
+			},
+			want: false,
+		},
+		{
+			name: "neither newVer nor ovalmodels.Package have underscoreMinorversion.",
+			args: args{
+				family: "centos",
+				vera: "1.8.23-10.el7.1",
+				AffectedPacks: ovalmodels.Package {
+						Name:            "sudo",
+						Version:         "1.8.23-10.el7.1",
+						NotFixedYet:     false,
+					},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := lessThan( tt.args.family, tt.args.vera, tt.args.AffectedPacks )
+			if ( got != tt.want ) {
+				t.Errorf("lessThan() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What did you implement:

Add test-case to verify proper version comparison when either/both/neither of newVer and ovalmodels.Package contain "_minorVersion"

Provides missing test-cases for https://github.com/future-architect/vuls/pull/1176 which fixed https://github.com/future-architect/vuls/issues/1171

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I ran `go test -v` within the oval directory.

With the code prior to #1176 , this new test fails any time that ovalmodels.Package contain "_minorVersion" (this is the expected and desired result) : 
```
[root@vuls-210209 oval]# go test -v
=== RUN   TestPackNamesOfUpdateDebian
--- PASS: TestPackNamesOfUpdateDebian (0.00s)
=== RUN   TestParseCvss2
--- PASS: TestParseCvss2 (0.00s)
=== RUN   TestParseCvss3
--- PASS: TestParseCvss3 (0.00s)
=== RUN   TestPackNamesOfUpdate
--- PASS: TestPackNamesOfUpdate (0.00s)
=== RUN   TestUpsert
--- PASS: TestUpsert (0.00s)
=== RUN   TestDefpacksToPackStatuses
--- PASS: TestDefpacksToPackStatuses (0.00s)
=== RUN   TestIsOvalDefAffected
--- PASS: TestIsOvalDefAffected (0.00s)
=== RUN   Test_centOSVersionToRHEL
=== RUN   Test_centOSVersionToRHEL/remove_centos.
=== RUN   Test_centOSVersionToRHEL/noop
--- PASS: Test_centOSVersionToRHEL (0.00s)
    --- PASS: Test_centOSVersionToRHEL/remove_centos. (0.00s)
    --- PASS: Test_centOSVersionToRHEL/noop (0.00s)
=== RUN   Test_lessThan
=== RUN   Test_lessThan/newVer_and_ovalmodels.Package_both_have_underscoreMinorversion.
    util_test.go:1272: lessThan() = true, want false
=== RUN   Test_lessThan/only_newVer_has_underscoreMinorversion.
=== RUN   Test_lessThan/only_ovalmodels.Package_has_underscoreMinorversion.
    util_test.go:1272: lessThan() = true, want false
=== RUN   Test_lessThan/neither_newVer_nor_ovalmodels.Package_have_underscoreMinorversion.
--- FAIL: Test_lessThan (0.00s)
    --- FAIL: Test_lessThan/newVer_and_ovalmodels.Package_both_have_underscoreMinorversion. (0.00s)
    --- PASS: Test_lessThan/only_newVer_has_underscoreMinorversion. (0.00s)
    --- FAIL: Test_lessThan/only_ovalmodels.Package_has_underscoreMinorversion. (0.00s)
    --- PASS: Test_lessThan/neither_newVer_nor_ovalmodels.Package_have_underscoreMinorversion. (0.00s)
FAIL
exit status 1
FAIL	github.com/future-architect/vuls/oval	0.012s
[root@vuls-210209 oval]#
```

With the code merged from #1176 , this new test passes with all variations of newVer and/or ovalmodels.Package containing or missing "_minorVersion" (this is the expected and desired result): 
```
[root@vuls-210209 oval]# go test -v
=== RUN   TestPackNamesOfUpdateDebian
--- PASS: TestPackNamesOfUpdateDebian (0.00s)
=== RUN   TestParseCvss2
--- PASS: TestParseCvss2 (0.00s)
=== RUN   TestParseCvss3
--- PASS: TestParseCvss3 (0.00s)
=== RUN   TestPackNamesOfUpdate
--- PASS: TestPackNamesOfUpdate (0.00s)
=== RUN   TestUpsert
--- PASS: TestUpsert (0.00s)
=== RUN   TestDefpacksToPackStatuses
--- PASS: TestDefpacksToPackStatuses (0.00s)
=== RUN   TestIsOvalDefAffected
--- PASS: TestIsOvalDefAffected (0.00s)
=== RUN   Test_centOSVersionToRHEL
=== RUN   Test_centOSVersionToRHEL/remove_centos.
=== RUN   Test_centOSVersionToRHEL/noop
--- PASS: Test_centOSVersionToRHEL (0.00s)
    --- PASS: Test_centOSVersionToRHEL/remove_centos. (0.00s)
    --- PASS: Test_centOSVersionToRHEL/noop (0.00s)
=== RUN   Test_lessThan
=== RUN   Test_lessThan/newVer_and_ovalmodels.Package_both_have_underscoreMinorversion.
=== RUN   Test_lessThan/only_newVer_has_underscoreMinorversion.
=== RUN   Test_lessThan/only_ovalmodels.Package_has_underscoreMinorversion.
=== RUN   Test_lessThan/neither_newVer_nor_ovalmodels.Package_have_underscoreMinorversion.
--- PASS: Test_lessThan (0.00s)
    --- PASS: Test_lessThan/newVer_and_ovalmodels.Package_both_have_underscoreMinorversion. (0.00s)
    --- PASS: Test_lessThan/only_newVer_has_underscoreMinorversion. (0.00s)
    --- PASS: Test_lessThan/only_ovalmodels.Package_has_underscoreMinorversion. (0.00s)
    --- PASS: Test_lessThan/neither_newVer_nor_ovalmodels.Package_have_underscoreMinorversion. (0.00s)
PASS
ok  	github.com/future-architect/vuls/oval	0.012s
[root@vuls-210209 oval]# 
```

# Checklist:
You don't have to satisfy all of the following.

- [X] Write tests
- [ ] Write documentation
- [X] Check that there aren't other open pull requests for the same issue/feature
- [X] Format your source code by `make fmt`
- [X] Pass the test by `make test`
- [X] Provide verification config / commands
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

