### PR TITLE
fix(report): prioritize env vars over config.toml

### DIFF
--- a/config/azureconf.go
+++ b/config/azureconf.go
@@ -20,18 +20,25 @@ type AzureConf struct {
 	Enabled bool `toml:"-" json:"-"`
 }
 
+const (
+	azureAccount = "AZURE_STORAGE_ACCOUNT"
+	azureKey     = "AZURE_STORAGE_ACCESS_KEY"
+)
+
 // Validate configuration
 func (c *AzureConf) Validate() (errs []error) {
 	if !c.Enabled {
 		return
 	}
-	if c.AccountName == "" {
-		c.AccountName = os.Getenv("AZURE_STORAGE_ACCOUNT")
+
+	// overwrite if env var is not empty
+	if os.Getenv(azureAccount) != "" {
+		c.AccountName = os.Getenv(azureAccount)
+	}
+	if os.Getenv(azureKey) != "" {
+		c.AccountKey = os.Getenv(azureKey)
 	}
 
-	if c.AccountKey == "" {
-		c.AccountKey = os.Getenv("AZURE_STORAGE_ACCESS_KEY")
-	}
 	if c.ContainerName == "" {
 		errs = append(errs, xerrors.Errorf("Azure storage container name is required"))
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -134,7 +134,7 @@ func (c Config) checkSSHKeyExist() (errs []error) {
 }
 
 // ValidateOnReport validates configuration
-func (c Config) ValidateOnReport() bool {
+func (c *Config) ValidateOnReport() bool {
 	errs := []error{}
 
 	if len(c.ResultsDir) != 0 {

--- a/config/httpconf.go
+++ b/config/httpconf.go
@@ -12,28 +12,21 @@ type HTTPConf struct {
 	Enabled bool   `toml:"-" json:"-"`
 }
 
+const httpKey = "VULS_HTTP_URL"
+
 // Validate validates configuration
 func (c *HTTPConf) Validate() (errs []error) {
 	if !c.Enabled {
 		return nil
 	}
 
+	// overwrite if env var is not empty
+	if os.Getenv(httpKey) != "" {
+		c.URL = os.Getenv(httpKey)
+	}
+
 	if _, err := govalidator.ValidateStruct(c); err != nil {
 		errs = append(errs, err)
 	}
 	return errs
-}
-
-const httpKey = "VULS_HTTP_URL"
-
-// Init set options with the following priority.
-// 1. Environment variable
-// 2. config.toml
-func (c *HTTPConf) Init(url string) {
-	if os.Getenv(httpKey) != "" {
-		c.URL = os.Getenv(httpKey)
-	}
-	if url != "" {
-		c.URL = url
-	}
 }

--- a/reporter/http.go
+++ b/reporter/http.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	c "github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/models"
 	"golang.org/x/xerrors"
 )
@@ -20,7 +20,7 @@ func (w HTTPRequestWriter) Write(rs ...models.ScanResult) (err error) {
 		if err := json.NewEncoder(b).Encode(r); err != nil {
 			return err
 		}
-		_, err = http.Post(c.Conf.HTTP.URL, "application/json; charset=utf-8", b)
+		_, err = http.Post(config.Conf.HTTP.URL, "application/json; charset=utf-8", b)
 		if err != nil {
 			return err
 		}

--- a/subcmds/report.go
+++ b/subcmds/report.go
@@ -39,8 +39,6 @@ type ReportCmd struct {
 	toS3        bool
 	toAzureBlob bool
 	toHTTP      bool
-
-	toHTTPURL string
 }
 
 // Name return subcommand name
@@ -162,8 +160,6 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&p.gzip, "gzip", false, "gzip compression")
 	f.BoolVar(&c.Conf.Pipe, "pipe", false, "Use args passed via PIPE")
 
-	f.StringVar(&p.toHTTPURL, "http", "", "-to-http http://vuls-report")
-
 	f.StringVar(&c.Conf.TrivyCacheDBDir, "trivy-cachedb-dir",
 		utils.DefaultCacheDir(), "/path/to/dir")
 }
@@ -185,9 +181,6 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	c.Conf.AWS.Enabled = p.toS3
 	c.Conf.Azure.Enabled = p.toAzureBlob
 	c.Conf.HTTP.Enabled = p.toHTTP
-
-	//TODO refactor
-	c.Conf.HTTP.Init(p.toHTTPURL)
 
 	if c.Conf.Diff {
 		c.Conf.DiffPlus, c.Conf.DiffMinus = true, true


### PR DESCRIPTION
# What did you implement:

Use env var if not empty.

- VULS_HTTP_URL
- AZURE_STORAGE_ACCOUNT
- AZURE_STORAGE_ACCESS_KEY

Remove -http-url command line option from report subcmd.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

