### PR TITLE
fix: support for missing files in the results or results directory

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -99,7 +99,9 @@ diff:
 	# ln -s oldvuls vuls.old
 	# make int
     # (ex. test 10 times: for i in `seq 10`; do make int ARGS=-quiet ; done)
+ifneq ($(shell ls -U1 ${BASE_DIR} | wc -l), 0)
 	mv ${BASE_DIR}/* /tmp
+endif
 	mkdir -p ${NOW_JSON_DIR}
 	cp integration/data/*.json ${NOW_JSON_DIR}
 	./vuls.old report --format-json --refresh-cve --results-dir=${BASE_DIR} -config=./integration/int-config.toml $(ARGS)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -124,7 +124,9 @@ diff-redis:
 	# ln -s vuls vuls.new
 	# ln -s oldvuls vuls.old
 	# make int-redis
+ifneq ($(shell ls -U1 ${BASE_DIR} | wc -l), 0)
 	mv ${BASE_DIR}/* /tmp
+endif
 	mkdir -p ${NOW_JSON_DIR}
 	cp integration/data/*.json ${NOW_JSON_DIR}
 	./vuls.old report --format-json --refresh-cve --results-dir=${BASE_DIR} -config=./integration/int-redis-config.toml 
@@ -137,7 +139,9 @@ diff-redis:
 	echo "old: ${NOW_JSON_DIR} , new: ${ONE_SEC_AFTER_JSON_DIR}"
 
 diff-rdb-redis:
+ifneq ($(shell ls -U1 ${BASE_DIR} | wc -l), 0)
 	mv ${BASE_DIR}/* /tmp
+endif
 	mkdir -p ${NOW_JSON_DIR}
 	cp integration/data/*.json ${NOW_JSON_DIR}
 	./vuls.new report --format-json --refresh-cve --results-dir=${BASE_DIR} -config=./integration/int-config.toml 


### PR DESCRIPTION
# What did you implement:

In the initial state, there are no results under the integration directory, and make diff will generate an error. Therefore, we need to add directory and file checks.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I deleted the `integration/results` file and ran `make diff`, and confirmed that it succeeded.
```terminal
$ rm -rf integration/results/
$ make diff
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference
- https://vuls.io/docs/en/testing.html