### PR TITLE
fix(report): Avoid http reports error when add program argument "-to-http"

### DIFF
--- a/reporter/http.go
+++ b/reporter/http.go
@@ -11,7 +11,7 @@ import (
 
 // HTTPRequestWriter writes results to HTTP request
 type HTTPRequestWriter struct {
-	Proxy string
+	URL string
 }
 
 // Write sends results as HTTP response
@@ -21,7 +21,7 @@ func (w HTTPRequestWriter) Write(rs ...models.ScanResult) (err error) {
 		if err := json.NewEncoder(b).Encode(r); err != nil {
 			return err
 		}
-		_, err = http.Post(w.Proxy, "application/json; charset=utf-8", b)
+		_, err = http.Post(w.URL, "application/json; charset=utf-8", b)
 		if err != nil {
 			return err
 		}

--- a/subcmds/report.go
+++ b/subcmds/report.go
@@ -283,7 +283,7 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	}
 
 	if p.toHTTP {
-		reports = append(reports, reporter.HTTPRequestWriter{Proxy: config.Conf.HTTPProxy})
+		reports = append(reports, reporter.HTTPRequestWriter{URL: config.Conf.HTTP.URL})
 	}
 
 	if p.toLocalFile {


### PR DESCRIPTION
# What did you implement:

The error occurs due to use of incorrect values like bellow.
```go
reports = append(reports, reporter.HTTPRequestWriter{Proxy: config.Conf.HTTPProxy})
```

So, replace these values to correct values as supposed and rename HTTPProxyWriter's member, Proxy, into URL like bellow.

```go
reports = append(reports, reporter.HTTPRequestWriter{URL: config.Conf.HTTP.URL})
```


Fixes #1213 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

After changed, run program with bellow and confirmed exit success.

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes 

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

