### PR TITLE
TLS insecure option adding

### DIFF
--- a/config/smtpconf.go
+++ b/config/smtpconf.go
@@ -7,15 +7,16 @@ import (
 
 // SMTPConf is smtp config
 type SMTPConf struct {
-	SMTPAddr      string   `toml:"smtpAddr,omitempty" json:"-"`
-	SMTPPort      string   `toml:"smtpPort,omitempty" valid:"port" json:"-"`
-	User          string   `toml:"user,omitempty" json:"-"`
-	Password      string   `toml:"password,omitempty" json:"-"`
-	From          string   `toml:"from,omitempty" json:"-"`
-	To            []string `toml:"to,omitempty" json:"-"`
-	Cc            []string `toml:"cc,omitempty" json:"-"`
-	SubjectPrefix string   `toml:"subjectPrefix,omitempty" json:"-"`
-	Enabled       bool     `toml:"-" json:"-"`
+	SMTPAddr              string   `toml:"smtpAddr,omitempty" json:"-"`
+	SMTPPort              string   `toml:"smtpPort,omitempty" valid:"port" json:"-"`
+	TLSInsecureSkipVerify bool     `toml:"tlsInsecureSkipVerify,omitempty" json:"-"`
+	User                  string   `toml:"user,omitempty" json:"-"`
+	Password              string   `toml:"password,omitempty" json:"-"`
+	From                  string   `toml:"from,omitempty" json:"-"`
+	To                    []string `toml:"to,omitempty" json:"-"`
+	Cc                    []string `toml:"cc,omitempty" json:"-"`
+	SubjectPrefix         string   `toml:"subjectPrefix,omitempty" json:"-"`
+	Enabled               bool     `toml:"-" json:"-"`
 }
 
 func checkEmails(emails []string) (errs []error) {

--- a/reporter/email.go
+++ b/reporter/email.go
@@ -179,19 +179,7 @@ func (e *emailSender) Send(subject, body string) (err error) {
 	for k, v := range headers {
 		header += fmt.Sprintf("%s: %s\r\n", k, v)
 	}
-	message := fmt.Sprintf("%s\r\n%s", header, body)
-
-	smtpServer := net.JoinHostPort(emailConf.SMTPAddr, emailConf.SMTPPort)
-
-	if emailConf.User != "" && emailConf.Password != "" {
-		err = e.sendMail(smtpServer, message)
-		if err != nil {
-			return xerrors.Errorf("Failed to send emails: %w", err)
-		}
-		return nil
-	}
-	err = e.sendMail(smtpServer, message)
-	if err != nil {
+	if err := e.sendMail(net.JoinHostPort(emailConf.SMTPAddr, emailConf.SMTPPort), fmt.Sprintf("%s\r\n%s", header, body)); err != nil {
 		return xerrors.Errorf("Failed to send emails: %w", err)
 	}
 	return nil

--- a/reporter/email.go
+++ b/reporter/email.go
@@ -94,7 +94,8 @@ func (e *emailSender) sendMail(smtpServerAddr, message string) (err error) {
 	emailConf := e.conf
 	//TLS Config
 	tlsConfig := &tls.Config{
-		ServerName: emailConf.SMTPAddr,
+		ServerName:         emailConf.SMTPAddr,
+		InsecureSkipVerify: emailConf.TLSInsecureSkipVerify,
 	}
 	switch emailConf.SMTPPort {
 	case "465":

--- a/subcmds/discover.go
+++ b/subcmds/discover.go
@@ -125,14 +125,15 @@ func printConfigToml(ips []string) (err error) {
 
 # https://vuls.io/docs/en/config.toml.html#email-section
 #[email]
-#smtpAddr      = "smtp.example.com"
-#smtpPort      = "587"
-#user          = "username"
-#password      = "password"
-#from          = "from@example.com"
-#to            = ["to@example.com"]
-#cc            = ["cc@example.com"]
-#subjectPrefix = "[vuls]"
+#smtpAddr              = "smtp.example.com"
+#smtpPort              = "587"
+#tlsInsecureSkipVerify = false
+#user                  = "username"
+#password              = "password"
+#from                  = "from@example.com"
+#to                    = ["to@example.com"]
+#cc                    = ["cc@example.com"]
+#subjectPrefix         = "[vuls]"
 
 # https://vuls.io/docs/en/config.toml.html#http-section
 #[http]


### PR DESCRIPTION
# What did you implement:

TLSInsecureSkipVerify added to SMTPConf struct
```
TLSInsecureSkipVerify bool `toml:"tlsInsecureSkipVerify,omitempty" json:"-"`
```

InsecureSkipVerify added to tlsConfig in sendMail
```
tlsConfig := &tls.Config {
    ServerName:         emailConf.SMTPAddr,
    InsecureSkipVerify: emailConf.TLSInsecureSkipVerify,
}
```
Fixes #1219 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## setup
```console
$ wget https://raw.githubusercontent.com/rnwood/smtp4dev/master/docker-compose.yml

# set Implicit TLS Mode in docker-compose.yml
11c11
<       - '25:25'
---
>       - '465:465'
66a67,68
>       - ServerOptions__Port=465
>       - ServerOptions__TlsMode=ImplicitTls

$ docker compose up -d

$ cat config.toml
[cveDict]
type = "sqlite3"
sqlite3Path = "/data/vulsctl/docker/cve.sqlite3"

[ovalDict]
type = "sqlite3"

[gost]
type = "sqlite3"

[exploit]
type = "sqlite3"

[metasploit]
type = "sqlite3"

[kevuln]
type = "sqlite3"

[cti]
type = "sqlite3"

[email]
smtpAddr      = "127.0.0.1"
smtpPort      = "465"
tlsInsecureSkipVerify = true
user          = "vulsio"
password      = "password"
from          = "from@address.com"
to            = ["to@address.com"]
cc            = ["cc@address.com"]
subjectPrefix = "[vuls]"

[servers]

[servers.pseudo]
type = "pseudo"
cpeNames = [
    "cpe:/o:fortinet:fortios:5.6.2",
]
```

## before
```console
$ vuls report -to-email
[Apr  5 11:17:07]  INFO [localhost] vuls-v0.25.2-build-20240405_111247_5d5dcd5
...
| CVE-2021-43206 |  4.3 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+

[Apr  5 11:17:07] ERROR [localhost] Failed to report. err: Failed to send emails:
    github.com/future-architect/vuls/reporter.(*emailSender).Send
        /home/mainek00n/github/github.com/MaineK00n/vuls/reporter/email.go:188
  - Failed to create TLS connection to SMTP server:
    github.com/future-architect/vuls/reporter.(*emailSender).sendMail
        /home/mainek00n/github/github.com/MaineK00n/vuls/reporter/email.go:104
  - tls: failed to verify certificate: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs
```

## after
```console
$ vuls report -to-email
[Apr  5 11:18:03]  INFO [localhost] vuls-v0.25.2-build-20240405_111507_e2690e5
...
| CVE-2021-43206 |  4.3 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
```

smtp server log(by 127.0.0.1:5000)
```log
220 smtp4dev smtp4dev ready
EHLO localhost
250-Nice to meet you.
250-8BITMIME
250-SIZE
250-SMTPUTF8
250-AUTH=CRAM-MD5 PLAIN LOGIN ANONYMOUS
250 AUTH CRAM-MD5 PLAIN LOGIN ANONYMOUS
AUTH PLAIN AHZ1bHNpbwBwYXNzd29yZA==
235 Authenticated OK
MAIL FROM:<from@address.com> BODY=8BITMIME
250 New message started
RCPT TO:<to@address.com>
250 Recipient accepted
DATA
354 End message with period
From: from@address.com
To: to@address.com
Cc: cc@address.com
Subject: [vuls]pseudo (pseudo) Total: 48 (Critical:3 High:16 Medium:29 Low:0 ?:0)
Date: Fri, 05 Apr 2024 11:18:03 +0900
Content-Type: text/plain; charset=utf-8

pseudo (pseudo)
===============
Total: 48 (Critical:3 High:16 Medium:29 Low:0 ?:0)
0/0 Fixed, 4 poc, 0 exploits, cisa: 5, uscert: 0, jpcert: 0 alerts
0 installed

+----------------+------+--------+-----+-----------+---------+-------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |           PACKAGES            |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2020-12812 |  9.8 |  AV:N  |     |      CISA |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2022-42475 |  9.8 |  AV:N  | POC |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2018-13382 |  9.1 |  AV:N  | POC |      CISA |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2018-13371 |  8.8 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2018-13374 |  8.8 |  AV:N  | POC |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2021-24018 |  8.8 |  AV:A  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2021-26103 |  8.8 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2018-9185  |  8.1 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2021-26110 |  7.8 |  AV:L  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2021-44168 |  7.8 |  AV:L  |     |      CISA |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2022-22299 |  7.8 |  AV:L  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2018-13376 |  7.5 |  AV:N  | POC |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2018-13381 |  7.5 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2019-15703 |  7.5 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2019-15705 |  7.5 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2019-17655 |  7.5 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2020-15938 |  7.5 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2021-26108 |  7.5 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2017-17544 |  7.2 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2021-42757 |  6.7 |  AV:L  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2018-13383 |  6.5 |  AV:N  |     |      CISA |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2019-17656 |  6.5 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2019-5587  |  6.5 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2019-5591  |  6.5 |  AV:A  |     |      CISA |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2019-6693  |  6.5 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2020-6648  |  6.5 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2023-33305 |  6.5 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2017-14187 |  6.2 |  AV:L  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2017-14190 |  6.1 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2018-13380 |  6.1 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2018-13384 |  6.1 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2019-5586  |  6.1 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2019-6696  |  6.1 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2021-26092 |  6.1 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2022-23438 |  6.1 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2021-36169 |  6.0 |  AV:L  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2018-9195  |  5.9 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2019-5593  |  5.5 |  AV:L  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2017-14186 |  5.4 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2017-14185 |  5.3 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2018-13365 |  5.3 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2018-13366 |  5.3 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2018-13367 |  5.3 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2020-12818 |  5.3 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2021-32600 |  5.0 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2020-15936 |  4.5 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2021-42755 |  4.3 |  AV:A  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
| CVE-2021-43206 |  4.3 |  AV:N  |     |           |         | cpe:/o:fortinet:fortios:5.6.2 |
+----------------+------+--------+-----+-----------+---------+-------------------------------+
.
250 Mail accepted
QUIT
221 Goodbye
```

# Checklist:

- [x] Format your source code by `make fmt`

***Is this ready for review?:*** YES  

