### PR TITLE
fix(report): panic when closing db connection of gost

### DIFF
--- a/gost/gost.go
+++ b/gost/gost.go
@@ -30,6 +30,9 @@ type Base struct {
 }
 
 func (b Base) CloseDB() error {
+	if b.DBDriver.DB == nil {
+		return nil
+	}
 	return b.DBDriver.DB.CloseDB()
 }
 


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xe157e2]
goroutine 1 [running]:
github.com/future-architect/vuls/gost.Base.CloseDB(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/ubuntu/go/src/github.com/future-architect/vuls/gost/gost.go:33 +0x22
github.com/future-architect/vuls/detector.detectPkgsCvesWithGost.func1(0x150b1d0, 0xc00042a5c0)
        /home/ubuntu/go/src/github.com/future-architect/vuls/detector/detector.go:373 +0x35
github.com/future-architect/vuls/detector.detectPkgsCvesWithGost(0x12a8dfa, 0x4, 0xc0005405f0, 0x7, 0x0, 0x0, 0xc000040390, 0x28, 0x0, 0xc000b94600, ...)
        /home/ubuntu/go/src/github.com/future-architect/vuls/detector/detector.go:384 +0x3e5
github.com/future-architect/vuls/detector.DetectPkgCves(0xc000b94600, 0x12acb0d, 0x8, 0xc0005405a0, 0x7, 0x0, 0x0, 0xc000040330, 0x28, 0x0, ...)
        /home/ubuntu/go/src/github.com/future-architect/vuls/detector/detector.go:180 +0xb13
github.com/future-architect/vuls/detector.Detect(0xc000b93300, 0x1, 0x1, 0xc00026a480, 0x56, 0x1, 0x1, 0x0, 0x0, 0x0)
        /home/ubuntu/go/src/github.com/future-architect/vuls/detector/detector.go:64 +0xd18
github.com/future-architect/vuls/subcmds.(*TuiCmd).Execute(0xc000119f70, 0x15140f0, 0xc000130010, 0xc000091140, 0x0, 0x0, 0x0, 0xc000119f01)
        /home/ubuntu/go/src/github.com/future-architect/vuls/subcmds/tui.go:143 +0x54f
github.com/google/subcommands.(*Commander).Execute(0xc000169780, 0x15140f0, 0xc000130010, 0x0, 0x0, 0x0, 0xc0005404d8)
        /home/ubuntu/go/pkg/mod/github.com/google/subcommands@v1.2.0/subcommands.go:209 +0x347
github.com/google/subcommands.Execute(...)
        /home/ubuntu/go/pkg/mod/github.com/google/subcommands@v1.2.0/subcommands.go:492
main.main()
        /home/ubuntu/go/src/github.com/future-architect/vuls/cmd/vuls/main.go:37 +0x396```
