### PR TITLE
fix(report): false positive for kernel-related CVE for RedHat, CentOS, Oracle and Amazon #1199

### DIFF
--- a/scanner/utils.go
+++ b/scanner/utils.go
@@ -28,7 +28,7 @@ func isRunningKernel(pack models.Package, family string, kernel models.Kernel) (
 
 	case constant.RedHat, constant.Oracle, constant.CentOS, constant.Amazon:
 		switch pack.Name {
-		case "kernel", "kernel-devel":
+		case "kernel", "kernel-devel", "kernel-core", "kernel-modules":
 			ver := fmt.Sprintf("%s-%s.%s", pack.Version, pack.Release, pack.Arch)
 			return true, kernel.Release == ver
 		}


### PR DESCRIPTION
# What did you implement:

Fixes #1199

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
./vuls server
```


```
 ubuntu@dev  │tmp  cat paquets.txt
grub2-common 1 2.02 90.el8 noarch
grub2-pc 1 2.02 90.el8 x86_64
grub2-pc-modules 1 2.02 90.el8 noarch
grub2-tools 1 2.02 90.el8 x86_64
grub2-tools-efi 1 2.02 90.el8 x86_64
grub2-tools-extra 1 2.02 90.el8 x86_64
grub2-tools-minimal 1 2.02 90.el8 x86_64
kernel 0 4.18.0 193.el8 x86_64
kernel 0 4.18.0 240.15.1.el8_3 x86_64
kernel-core 0 4.18.0 193.el8 x86_64
kernel-core 0 4.18.0 240.15.1.el8_3 x86_64
kernel-modules 0 4.18.0 193.el8 x86_64
kernel-modules 0 4.18.0 240.15.1.el8_3 x86_64
 ubuntu@dev  │tmp  cat paquets-2.txt
grub2-common 1 2.02 90.el8 noarch
grub2-pc 1 2.02 90.el8 x86_64
grub2-pc-modules 1 2.02 90.el8 noarch
grub2-tools 1 2.02 90.el8 x86_64
grub2-tools-efi 1 2.02 90.el8 x86_64
grub2-tools-extra 1 2.02 90.el8 x86_64
grub2-tools-minimal 1 2.02 90.el8 x86_64
kernel 0 4.18.0 240.15.1.el8_3 x86_64
kernel 0 4.18.0 193.el8 x86_64
kernel-core 0 4.18.0 240.15.1.el8_3 x86_64
kernel-core 0 4.18.0 193.el8 x86_64
kernel-modules 0 4.18.0 240.15.1.el8_3 x86_64
kernel-modules 0 4.18.0 193.el8 x86_64
 ✗  ubuntu@dev  │tmp  curl -s "http://127.0.0.1:5515/vuls?num=[0-10]" -H 'Content-type: text/plain' -H 'X-Vuls-OS-Family: redhat' -H 'X-Vuls-OS-Release: 8.2
' -H 'X-Vuls-Kernel-Release: 4.18.0-240.15.1.el8_3.x86_64' -H 'X-Vuls-Server-Name: VMrh8' --data-binary @paquets.txt | jq ".[0].scannedCves | length"
55
55
55
55
55
55
55
55
55
55
55
 ubuntu@dev  │tmp  curl -s "http://127.0.0.1:5515/vuls?num=[0-10]" -H 'Content-type: text/plain' -H 'X-Vuls-OS-Family: redhat' -H 'X-Vuls-OS-Release: 8.2' -H 'X-Vuls-Kernel-Release: 4.18.0-240.15.1.el8_3.x86_64' -H 'X-Vuls-Server-Name: VMrh8' --data-binary @paquets-2.txt | jq ".[0].scannedCves | length"
55
55
55
55
55
55
55
55
55
55
55
```


# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
