### PR TITLE
refactor(git-conf): Specifing ignoreGitHubDismissed per repository

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -260,7 +260,7 @@ func (cnf WordPressConf) IsZero() bool {
 // GitHubConf is used for GitHub Security Alerts
 type GitHubConf struct {
 	Token                 string `json:"-"`
-	IgnoreGitHubDismissed bool   `json:"IgnoreGitHubDismissed,omitempty"`
+	IgnoreGitHubDismissed bool   `json:"ignoreGitHubDismissed,omitempty"`
 }
 
 // GetServerName returns ServerName if this serverInfo is about host.

--- a/config/config.go
+++ b/config/config.go
@@ -260,7 +260,7 @@ func (cnf WordPressConf) IsZero() bool {
 // GitHubConf is used for GitHub Security Alerts
 type GitHubConf struct {
 	Token                 string `json:"-"`
-	IgnoreGitHubDismissed bool   `json:"ignore_git_hub_dismissed,omitempty"`
+	IgnoreGitHubDismissed bool   `json:"IgnoreGitHubDismissed,omitempty"`
 }
 
 // GetServerName returns ServerName if this serverInfo is about host.

--- a/config/config.go
+++ b/config/config.go
@@ -79,9 +79,6 @@ type ReportOpts struct {
 	DiffMinus          bool    `json:"diffMinus,omitempty"`
 	Diff               bool    `json:"diff,omitempty"`
 	Lang               string  `json:"lang,omitempty"`
-
-	//TODO move to GitHubConf
-	IgnoreGitHubDismissed bool `json:"ignore_git_hub_dismissed,omitempty"`
 }
 
 // ValidateOnConfigtest validates
@@ -262,7 +259,8 @@ func (cnf WordPressConf) IsZero() bool {
 
 // GitHubConf is used for GitHub Security Alerts
 type GitHubConf struct {
-	Token string `json:"-"`
+	Token                 string `json:"-"`
+	IgnoreGitHubDismissed bool   `json:"ignore_git_hub_dismissed,omitempty"`
 }
 
 // GetServerName returns ServerName if this serverInfo is about host.

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -70,7 +70,7 @@ func Detect(rs []models.ScanResult, dir string) ([]models.ScanResult, error) {
 		}
 
 		repos := config.Conf.Servers[r.ServerName].GitHubRepos
-		if err := DetectGitHubCves(&r, repos, config.Conf.IgnoreGitHubDismissed); err != nil {
+		if err := DetectGitHubCves(&r, repos); err != nil {
 			return nil, xerrors.Errorf("Failed to detect GitHub Cves: %w", err)
 		}
 
@@ -219,7 +219,7 @@ func DetectPkgCves(r *models.ScanResult, ovalCnf config.GovalDictConf, gostCnf c
 }
 
 // DetectGitHubCves fetches CVEs from GitHub Security Alerts
-func DetectGitHubCves(r *models.ScanResult, githubConfs map[string]config.GitHubConf, ignoreDismissed bool) error {
+func DetectGitHubCves(r *models.ScanResult, githubConfs map[string]config.GitHubConf) error {
 	if len(githubConfs) == 0 {
 		return nil
 	}
@@ -229,7 +229,7 @@ func DetectGitHubCves(r *models.ScanResult, githubConfs map[string]config.GitHub
 			return xerrors.Errorf("Failed to parse GitHub owner/repo: %s", ownerRepo)
 		}
 		owner, repo := ss[0], ss[1]
-		n, err := DetectGitHubSecurityAlerts(r, owner, repo, setting.Token, ignoreDismissed)
+		n, err := DetectGitHubSecurityAlerts(r, owner, repo, setting.Token, setting.IgnoreGitHubDismissed)
 		if err != nil {
 			return xerrors.Errorf("Failed to access GitHub Security Alerts: %w", err)
 		}

--- a/subcmds/report.go
+++ b/subcmds/report.go
@@ -63,7 +63,6 @@ func (*ReportCmd) Usage() string {
 		[-diff-plus]
 		[-ignore-unscored-cves]
 		[-ignore-unfixed]
-		[-ignore-github-dismissed]
 		[-to-email]
 		[-to-http]
 		[-to-slack]
@@ -130,9 +129,6 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 
 	f.BoolVar(&config.Conf.IgnoreUnfixed, "ignore-unfixed", false,
 		"Don't report the unfixed CVEs")
-
-	f.BoolVar(&config.Conf.IgnoreGitHubDismissed, "ignore-github-dismissed", false,
-		"Don't report the dismissed CVEs on GitHub Security Alerts")
 
 	f.StringVar(
 		&config.Conf.HTTPProxy, "http-proxy", "",


### PR DESCRIPTION
# What did you implement:

To specify config, [Ignore github dismissed](https://vuls.io/docs/en/usage-scan-non-os-packages.html#usage-integrate-with-github-security-alerts), per a repository, chaged the specifiation of config.toml like bellow.

```toml
[servers]

[servers.tttfrfr2]
type = "pseudo"

[servers.tttfrfr2.githubs."owner/REPO_1"]
token = "********************************************"
ignoreGitHubDismissed = true # or false
```

For addition, removed program argument "-ignore-github-dismissed" when report

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

debug vuls with delve and use config.toml like bellow (hidden token and repository name).

- debug
```bash
$ dlv debug cmd/vuls/main.go -- report
Type 'help' for list of commands.
(dlv) b detector/detector.go:222
Breakpoint 1 (enabled) set at 0x138a771 for github.com/future-architect/vuls/detector.DetectGitHubCves() ./detector/detector.go:222
(dlv) c
[Apr 23 14:19:49]  INFO [localhost] vuls-`make build` or `make install` will show the version-
[Apr 23 14:19:49]  INFO [localhost] Validating config...
[Apr 23 14:19:49]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/home/otuki/cve.sqlite3
[Apr 23 14:19:49]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/otuki/oval.sqlite3
[Apr 23 14:19:49]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/home/otuki/gost.sqlite3
[Apr 23 14:19:49]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/home/otuki/go-exploitdb.sqlite3
[Apr 23 14:19:49]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/home/otuki/go-msfdb.sqlite3
[Apr 23 14:19:49]  INFO [localhost] Loaded: /home/otuki/git/vuls/results/2021-04-23T14:19:17+09:00
[Apr 23 14:19:49]  INFO [localhost] pseudo type. Skip OVAL and gost detection
[Apr 23 14:19:49]  INFO [localhost] tttfrfr2: 0 CVEs are detected with CPE
> github.com/future-architect/vuls/detector.DetectGitHubCves() ./detector/detector.go:222 (hits goroutine(1):1 total:1) (PC: 0x138a771)
   217:	
   218:		return nil
   219:	}
   220:	
   221:	// DetectGitHubCves fetches CVEs from GitHub Security Alerts
=> 222:	func DetectGitHubCves(r *models.ScanResult, githubConfs map[string]config.GitHubConf) error {
   223:		if len(githubConfs) == 0 {
   224:			return nil
   225:		}
   226:		for ownerRepo, setting := range githubConfs {
   227:			ss := strings.Split(ownerRepo, "/")
(dlv) p githubConfs
map[string]github.com/future-architect/vuls/config.GitHubConf [
	"tttfrfr2/REPO_1": {
		Token: "**************************************************",
		IgnoreGitHubDismissed: false,}, 
	"tttfrfr2/REPO_2": {
		Token: "**************************************************",
		IgnoreGitHubDismissed: false,}, 
	"tttfrfr2/REPO_3": {
		Token: "**************************************************",
		IgnoreGitHubDismissed: true,}, 
]
(dlv) 
```

- config.toml
```toml
...

# https://vuls.io/docs/en/config.toml.html#servers-section
[servers]

[servers.tttfrfr2]
type = "pseudo"

[servers.tttfrfr2.githubs."tttfrfr2/REPO_1"]
token = "**************************************************"

[servers.tttfrfr2.githubs."tttfrfr2/REPO_2"]
token = "**************************************************"
ignoreGitHubDismissed = false

[servers.tttfrfr2.githubs."tttfrfr2/REPO_3"]
token = "**************************************************"
ignoreGitHubDismissed = true

...
```

To check removed program argument "-ignore-github-dismissed", 
```bash
$ go run cmd/vuls/main.go report -ignore-github-dismissed
flag provided but not defined: -ignore-github-dismissed
report:
	report
		[-lang=en|ja]
		[-config=/path/to/config.toml]
		[-results-dir=/path/to/results]
		[-log-to-file]
		[-log-dir=/path/to/log]
		[-refresh-cve]
		[-cvss-over=7]
		[-diff]
		[-diff-minus]
		[-diff-plus]
		[-ignore-unscored-cves]
		[-ignore-unfixed]
		[-to-email]
		[-to-http]
		[-to-slack]
		[-to-chatwork]
		[-to-telegram]
		[-to-localfile]
		[-to-s3]
		[-to-azure-blob]
		[-format-json]
		[-format-one-email]
		[-format-one-line-text]
		[-format-list]
		[-format-full-text]
		[-gzip]
		[-http-proxy=http://192.168.0.1:8080]
		[-debug]
		[-debug-sql]
		[-quiet]
		[-no-progress]
		[-pipe]
		[-http="http://vuls-report-server"]
		[-trivy-cachedb-dir=/path/to/dir]

		[RFC3339 datetime format under results dir]
  -config string
    	/path/to/toml (default "/home/otuki/git/vuls/config.toml")
  -cvss-over float
    	-cvss-over=6.5 means reporting CVSS Score 6.5 and over (default: 0 (means report all))
  -debug
    	debug mode
  -debug-sql
    	SQL debug mode
  -diff
    	Plus & Minus Difference between previous result and current result
  -diff-minus
    	Minus Difference between previous result and current result
  -diff-plus
    	Plus Difference between previous result and current result
  -format-csv
    	CSV format
  -format-full-text
    	Detail report in plain text
  -format-json
    	JSON format
  -format-list
    	Display as list format
  -format-one-email
    	Send all the host report via only one EMail (Specify with -to-email)
  -format-one-line-text
    	One line summary in plain text
  -gzip
    	gzip compression
  -http-proxy string
    	http://proxy-url:port (default: empty)
  -ignore-unfixed
    	Don't report the unfixed CVEs
  -ignore-unscored-cves
    	Don't report the unscored CVEs
  -lang string
    	[en|ja] (default "en")
  -log-dir string
    	/path/to/log (default "/var/log/vuls")
  -log-to-file
    	Output log to file
  -no-progress
    	Suppress progress bar
  -pipe
    	Use args passed via PIPE
  -quiet
    	Quiet mode. No output on stdout
  -refresh-cve
    	Refresh CVE information in JSON file under results dir
  -results-dir string
    	/path/to/results (default "/home/otuki/git/vuls/results")
  -to-azure-blob
    	Write report to Azure Storage blob (container/yyyyMMdd_HHmm/servername.json/txt)
  -to-chatwork
    	Send report via chatwork
  -to-email
    	Send report via Email
  -to-http
    	Send report via HTTP POST
  -to-localfile
    	Write report to localfile
  -to-s3
    	Write report to S3 (bucket/yyyyMMdd_HHmm/servername.json/txt)
  -to-slack
    	Send report via Slack
  -to-syslog
    	Send report via Syslog
  -to-telegram
    	Send report via Telegram
  -trivy-cachedb-dir string
    	/path/to/dir (default "/home/otuki/.cache/trivy")
exit status 2
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

