### PR TITLE
feat: Support Ubuntu21 ( #1230 )

### DIFF
--- a/oval/debian.go
+++ b/oval/debian.go
@@ -358,6 +358,47 @@ func (o Ubuntu) FillWithOval(r *models.ScanResult) (nCVEs int, err error) {
 			"linux",
 		}
 		return o.fillWithOval(r, kernelNamesInOval)
+	case "21":
+		kernelNamesInOval := []string{
+			"linux-aws",
+			"linux-base-sgx",
+			"linux-base",
+			"linux-cloud-tools-common",
+			"linux-cloud-tools-generic",
+			"linux-cloud-tools-lowlatency",
+			"linux-cloud-tools-virtual",
+			"linux-gcp",
+			"linux-generic",
+			"linux-gke",
+			"linux-headers-aws",
+			"linux-headers-gcp",
+			"linux-headers-gke",
+			"linux-headers-oracle",
+			"linux-image-aws",
+			"linux-image-extra-virtual",
+			"linux-image-gcp",
+			"linux-image-generic",
+			"linux-image-gke",
+			"linux-image-lowlatency",
+			"linux-image-oracle",
+			"linux-image-virtual",
+			"linux-lowlatency",
+			"linux-modules-extra-aws",
+			"linux-modules-extra-gcp",
+			"linux-modules-extra-gke",
+			"linux-oracle",
+			"linux-tools-aws",
+			"linux-tools-common",
+			"linux-tools-gcp",
+			"linux-tools-generic",
+			"linux-tools-gke",
+			"linux-tools-host",
+			"linux-tools-lowlatency",
+			"linux-tools-oracle",
+			"linux-tools-virtual",
+			"linux-virtual",
+		}
+		return o.fillWithOval(r, kernelNamesInOval)
 	}
 	return 0, fmt.Errorf("Ubuntu %s is not support for now", r.Release)
 }


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Support Ubuntu21
add kernelNamesInOval of Ubuntu21.

Fixes #1230

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
% vuls report -format-full-text
example (ubuntu21.04)
=======================
Total: 27 (Critical:5 High:27 Medium:0 Low:0 ?:0)
0/32 Fixed, 6 poc, 0 exploits, en: 0, ja: 0 alerts
1212 installed

+---------------+--------------------------------------------------------------+
| CVE-2016-1585 | UNFIXED                                                      |
+---------------+--------------------------------------------------------------+
| Max Score     | 9.8 CRITICAL (nvd)                                           |
| nvd           | 9.8/CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H CRITICAL    |
| jvn           | 9.8/CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H CRITICAL    |
| ubuntu        | 4.0-6.9 MEDIUM                                               |
| nvd           | 7.5/AV:N/AC:L/Au:N/C:P/I:P/A:P HIGH                          |
| jvn           | 7.5/AV:N/AC:L/Au:N/C:P/I:P/A:P HIGH                          |
| Summary       | AppArmor におけるセキュリティ機能に関する脆弱性 AppArmor     |
|               | には、セキュリティ機能に関する脆弱性が存在します。           |
| Primary Src   | https://nvd.nist.gov/vuln/detail/CVE-2016-1585               |
| Primary Src   | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-1585  |
| Primary Src   | https://jvndb.jvn.jp/ja/contents/2016/JVNDB-2016-009327.html |
| Affected Pkg  | apparmor-3.0.0-0ubuntu7 -> Not fixed yet                     |
| Confidence    | 100 / OvalMatch                                              |
| CWE           | CWE-254: セキュリティ機能(CWE-254) (nvd)                     |
| CWE           | http://jvndb.jvn.jp/ja/cwe/CWE-254.html                      |
+---------------+--------------------------------------------------------------+

+----------------+------------------------------------------------------------------------------------+
| CVE-2018-20839 | UNFIXED                                                                            |
+----------------+------------------------------------------------------------------------------------+
| Max Score      | 9.8 CRITICAL (nvd)                                                                 |
| redhat_api     | 6.4/CVSS:3.0/AV:P/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H MODERATE                          |
| nvd            | 9.8/CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H CRITICAL                          |
| jvn            | 9.8/CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H CRITICAL                          |
| ubuntu         | 4.0-6.9 MEDIUM                                                                     |
| nvd            | 5.0/AV:N/AC:L/Au:N/C:P/I:N/A:N MEDIUM                                              |
| jvn            | 5.0/AV:N/AC:L/Au:N/C:P/I:N/A:N MEDIUM                                              |
| Summary        | systemd における証明書・パスワードの管理に関する脆弱性 systemd                     |
|                | には、証明書・パスワードの管理に関する脆弱性が存在します。                         |
| Primary Src    | https://nvd.nist.gov/vuln/detail/CVE-2018-20839                                    |
| Primary Src    | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20839                       |
| Primary Src    | https://jvndb.jvn.jp/ja/contents/2018/JVNDB-2018-015481.html                       |
| Patch          | https://github.com/systemd/systemd/commit/9725f1a10f80f5e0ae7d9b60547458622aeb322f |
| Affected Pkg   | systemd-247.3-3ubuntu3 -> Not fixed yet                                            |
| Confidence     | 100 / OvalMatch                                                                    |
| CWE            | [CWE Top4] CWE-200: 情報漏えい(CWE-200) (redhat_api)                               |
| CWE            | http://jvndb.jvn.jp/ja/cwe/CWE-200.html                                            |
| CWE Top25      | https://cwe.mitre.org/top25/archive/2019/2019_cwe_top25.html                       |
+----------------+------------------------------------------------------------------------------------+

（以下略）
```

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

