### PR TITLE
fix(scan): Avoid panic when SSH connection refused

### DIFF
--- a/scanner/debian.go
+++ b/scanner/debian.go
@@ -48,7 +48,7 @@ func detectDebian(c config.ServerInfo) (bool, osTypeInterface, error) {
 			return false, nil, nil
 		}
 		if r.ExitStatus == 255 {
-			deb := newDebian(c) // Panic occor when return value 2 is nil and 3 is non-nil
+			deb := newDebian(c) // Panic occur when return value 2 is nil and 3 is non-nil
 			return false, deb, xerrors.Errorf("Unable to connect via SSH. Scan with -vvv option to print SSH debugging messages and check SSH settings. If you have never SSH to the host to be scanned, SSH to the host before scanning in order to add the HostKey. %s@%s port: %s\n%s", c.User, c.Host, c.Port, r)
 		}
 		logging.Log.Debugf("Not Debian like Linux. %s", r)

--- a/scanner/debian.go
+++ b/scanner/debian.go
@@ -48,7 +48,8 @@ func detectDebian(c config.ServerInfo) (bool, osTypeInterface, error) {
 			return false, nil, nil
 		}
 		if r.ExitStatus == 255 {
-			return false, nil, xerrors.Errorf("Unable to connect via SSH. Scan with -vvv option to print SSH debugging messages and check SSH settings. If you have never SSH to the host to be scanned, SSH to the host before scanning in order to add the HostKey. %s@%s port: %s\n%s", c.User, c.Host, c.Port, r)
+			deb := newDebian(c) // Panic occor when return value 2 is nil and 3 is non-nil
+			return false, deb, xerrors.Errorf("Unable to connect via SSH. Scan with -vvv option to print SSH debugging messages and check SSH settings. If you have never SSH to the host to be scanned, SSH to the host before scanning in order to add the HostKey. %s@%s port: %s\n%s", c.User, c.Host, c.Port, r)
 		}
 		logging.Log.Debugf("Not Debian like Linux. %s", r)
 		return false, nil, nil


### PR DESCRIPTION
# What did you implement:

Vuls stop due to panic when SSH connection refused as below.

- vuls scan when SSH connection refused
```bash
$ vuls scan
[May 11 16:41:46]  INFO [localhost] vuls-v0.15.11-build-20210418_144724_27b3e17
[May 11 16:41:46]  INFO [localhost] Start scanning
[May 11 16:41:46]  INFO [localhost] config: /home/$USER/config.toml

...

[May 11 16:41:46]  INFO [localhost] Validating config...
[May 11 16:41:46]  INFO [localhost] Detecting Server/Container OS...
[May 11 16:41:46]  INFO [localhost] Detecting OS of servers...
[May 11 16:45:45] DEBUG [localhost] Executing... ls /etc/debian_version
[May 11 16:45:45] DEBUG [localhost] execResult: servername: err
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/%USER/.vuls/controlmaster-%r-err.%p -o Controlpersist=10m root@localhost -p 22 -i /home/$USER/.ssh/id_rsa.pub -o PasswordAuthentication=no stty cols 1000; ls /etc/debian_version
  exitstatus: 255
  stdout:
  stderr:
  err: %!s(<nil>)
[May 11 16:45:45] DEBUG [localhost] Panic: runtime error: invalid memory address or nil pointer dereference on err
```

- config.toml

```toml
...
# https://vuls.io/docs/en/config.toml.html#servers-section
[servers]

[servers.err]
host         = "localhost"
port         = "22"
user        = "root"
keyPath     = "/home/$USER/.ssh/id_rsa.pub"

...
```

So avoid panic and run vuls ...

```bash
...

[May 11 16:48:57]  INFO [localhost] Validating config...
[May 11 16:48:57]  INFO [localhost] Detecting Server/Container OS...
[May 11 16:48:57]  INFO [localhost] Detecting OS of servers...
[May 11 16:48:57] DEBUG [localhost] Executing... ls /etc/debian_version
[May 11 16:48:57] DEBUG [localhost] execResult: servername: err
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/$USER/.vuls/controlmaster-%r-err.%p -o Controlpersist=10m root@localhost -p 22 -i /home/$USER/.ssh/id_rsa.pub -o PasswordAuthentication=no stty cols 1000; ls /etc/debian_version
  exitstatus: 255
  stdout:
  stderr:
  err: %!s(<nil>)
[May 11 16:48:57] ERROR [localhost] (1/1) Failed: err, err: [Failed to detect OS:
    github.com/future-architect/vuls/scanner.Scanner.detectOS
        /home/$USER/go/src/github.com/tttfrfr2/vuls_debug/vuls/scanner/serverapi.go:448
  - Unable to connect via SSH. Scan with -vvv option to print SSH debugging messages and check SSH settings. If you have never SSH to the host to be scanned, SSH to the host before scanning in order to add the HostKey. root@localhost port: 22
    execResult: servername: err
      cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/$USER/.vuls/controlmaster-%r-err.%p -o Controlpersist=10m root@localhost -p 22 -i /home/$USER/.ssh/id_rsa.pub -o PasswordAuthentication=no stty cols 1000; ls /etc/debian_version
      exitstatus: 255
      stdout:
      stderr:
      err: %!s(<nil>):
    github.com/future-architect/vuls/scanner.detectDebian
        /home/$USER/go/src/github.com/tttfrfr2/vuls_debug/vuls/scanner/debian.go:52]
[May 11 16:48:57] ERROR [localhost] Failed to scan: Failed to init servers. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/$USER/go/src/github.com/tttfrfr2/vuls_debug/vuls/scanner/serverapi.go:86
  - No scannable host OS:
    github.com/future-architect/vuls/scanner.Scanner.initServers
        /home/$USER/go/src/github.com/tttfrfr2/vuls_debug/vuls/scanner/serverapi.go:235
Process 17864 has exited with status 1                                                                                                
(dlv)  
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run vuls as below with config A and B

- config A (refuse SSH connection)

```toml
...

# https://vuls.io/docs/en/config.toml.html#servers-section
[servers]

[servers.ubuntu]
host         = "localhost"
port         = "22"
user        = "root"
keyPath     = "/home/$USER/.ssh/id_rsa"

[servers.err]
host         = "localhost"
port         = "22"
user        = "root"
keyPath     = "/home/$USER/.ssh/id_rsa.pub" # public key 

...
```

- Run vuls
```bash
$ dlv debug cmd/vuls/main.go -- scan
Type 'help' for list of commands.
(dlv) c
[May 11 17:03:43]  INFO [localhost] vuls-`make build` or `make install` will show the version-
[May 11 17:03:43]  INFO [localhost] Start scanning
[May 11 17:03:43]  INFO [localhost] config: /home/$USER/go/src/github.com/tttfrfr2/vuls_debug/vuls/config.toml
[May 11 17:03:43]  INFO [localhost] Validating config...
[May 11 17:03:43]  INFO [localhost] Detecting Server/Container OS...
[May 11 17:03:43]  INFO [localhost] Detecting OS of servers...
[May 11 17:03:43] ERROR [localhost] (1/2) Failed: err, err: [Failed to detect OS:
    github.com/future-architect/vuls/scanner.Scanner.detectOS
        /home/$USER/go/src/github.com/tttfrfr2/vuls_debug/vuls/scanner/serverapi.go:448
  - Unable to connect via SSH. Scan with -vvv option to print SSH debugging messages and check SSH settings. If you have never SSH to the host to be scanned, SSH to the host before scanning in order to add the HostKey. root@localhost port: 22
    execResult: servername: err
      cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/$USER/.vuls/controlmaster-%r-err.%p -o Controlpersist=10m root@localhost -p 22 -i /home/$USER/.ssh/id_rsa.pub -o PasswordAuthentication=no stty cols 1000; ls /etc/debian_version
      exitstatus: 255
      stdout:
      stderr:
      err: %!s(<nil>):
    github.com/future-architect/vuls/scanner.detectDebian
        /home/$USER/go/src/github.com/tttfrfr2/vuls_debug/vuls/scanner/debian.go:52]
[May 11 17:03:43]  INFO [localhost] (2/2) Detected: ubuntu: ubuntu 20.04
[May 11 17:03:43]  INFO [localhost] Detecting OS of containers...
[May 11 17:03:43]  INFO [localhost] Checking Scan Modes...
[May 11 17:03:43]  INFO [localhost] Detecting Platforms...
[May 11 17:03:44]  INFO [localhost] (1/1) ubuntu is running on other
[May 11 17:03:44]  INFO [ubuntu] Scanning OS pkg in fast mode
[May 11 17:03:44]  INFO [ubuntu] Scanning listen port...
[May 11 17:03:44]  WARN [localhost] Some warnings occurred during scanning on err. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family:  Release: `]


Scan Summary
================
ubuntu  ubuntu20.04     1430 installed
err     Error                           Use configtest subcommand or scan with --debug to view the details

Warning: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family:  Release: `]
[May 11 17:03:44] ERROR [localhost] Failed to scan: Failed to scan. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/$USER/go/src/github.com/tttfrfr2/vuls_debug/vuls/scanner/serverapi.go:103
  - An error occurred on [err]
Process 18473 has exited with status 1
```


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes  

