### PR TITLE
fix(report): detection logic bugs for Oracle Linux

### DIFF
--- a/oval/util.go
+++ b/oval/util.go
@@ -371,7 +371,8 @@ func isOvalDefAffected(def ovalmodels.Definition, req request, family string, ru
 				constant.SUSEEnterpriseServer,
 				constant.Debian,
 				constant.Ubuntu,
-				constant.Raspbian:
+				constant.Raspbian,
+				constant.Oracle:
 				// Use fixed state in OVAL for these distros.
 				return true, false, ovalPack.Version, nil
 			}

--- a/oval/util.go
+++ b/oval/util.go
@@ -306,7 +306,8 @@ func isOvalDefAffected(def ovalmodels.Definition, req request, family string, ru
 		switch family {
 		case constant.Oracle, constant.Amazon:
 			if ovalPack.Arch == "" {
-				return false, false, "", xerrors.Errorf("OVAL DB for %s is old. Please re-fetch the OVAL", family)
+				logging.Log.Infof("Arch is needed to detect Vulns for Amazon and Oracle Linux, but empty. You need refresh OVAL maybe. oval: %s, defID: %s", ovalPack, def.DefinitionID)
+				continue
 			}
 		}
 

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -1263,7 +1263,7 @@ func TestIsOvalDefAffected(t *testing.T) {
 			affected: true,
 			fixedIn:  "2.17-106.0.1",
 		},
-		// error when arch is empty for Oracle, Amazon linux
+		// arch is empty for Oracle, Amazon linux
 		{
 			in: in{
 				family: constant.Oracle,
@@ -1282,9 +1282,10 @@ func TestIsOvalDefAffected(t *testing.T) {
 					arch:           "x86_64",
 				},
 			},
-			wantErr: true,
+			wantErr: false,
+			fixedIn: "",
 		},
-		// error when arch is empty for Oracle, Amazon linux
+		// arch is empty for Oracle, Amazon linux
 		{
 			in: in{
 				family: constant.Amazon,
@@ -1303,7 +1304,8 @@ func TestIsOvalDefAffected(t *testing.T) {
 					arch:           "x86_64",
 				},
 			},
-			wantErr: true,
+			wantErr: false,
+			fixedIn: "",
 		},
 	}
 


### PR DESCRIPTION
`OVAL DB for oracle is old. Please re-fetch the OVAL`
TUI displays `Not Fixed Yet` when it should be `Fixed`.