### PR TITLE
fix(vet): go vet err of `make build-scanner`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -32,13 +32,13 @@ build: ./cmd/vuls/main.go pretest fmt
 b: ./cmd/vuls/main.go 
 	$(GO) build -a -ldflags "$(LDFLAGS)" -o vuls ./cmd/vuls
 
-install: ./cmd/vuls/main.go pretest fmt
+install: ./cmd/vuls/main.go
 	$(GO) install -ldflags "$(LDFLAGS)" ./cmd/vuls
 
-build-scanner: ./cmd/scanner/main.go pretest fmt
+build-scanner: ./cmd/scanner/main.go 
 	$(CGO_UNABLED) build -tags=scanner -a -ldflags "$(LDFLAGS)" -o vuls ./cmd/scanner
 
-install-scanner: ./cmd/scanner/main.go pretest fmt
+install-scanner: ./cmd/scanner/main.go 
 	$(CGO_UNABLED) install -tags=scanner -ldflags "$(LDFLAGS)" ./cmd/scanner
 
 lint:

--- a/detector/github.go
+++ b/detector/github.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package detector
 
 import (

--- a/detector/library.go
+++ b/detector/library.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package detector
 
 import (

--- a/detector/util.go
+++ b/detector/util.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package detector
 
 import (

--- a/detector/wordpress.go
+++ b/detector/wordpress.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package detector
 
 import (

--- a/detector/wordpress_test.go
+++ b/detector/wordpress_test.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package detector
 
 import (

--- a/gost/debian_test.go
+++ b/gost/debian_test.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package gost
 
 import "testing"

--- a/gost/gost_test.go
+++ b/gost/gost_test.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package gost
 
 import (

--- a/gost/redhat_test.go
+++ b/gost/redhat_test.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package gost
 
 import (

--- a/gost/util.go
+++ b/gost/util.go
@@ -1,3 +1,5 @@
+// +build !scanner
+
 package gost
 
 import (

--- a/oval/empty.go
+++ b/oval/empty.go
@@ -1,1 +1,0 @@
-package oval

--- a/scanner/base.go
+++ b/scanner/base.go
@@ -623,6 +623,7 @@ func (l *base) scanLibraries() (err error) {
 	return nil
 }
 
+// AnalyzeLibraries : detects libs defined in lockfile
 func AnalyzeLibraries(ctx context.Context, libFilemap map[string][]byte) (libraryScanners []models.LibraryScanner, err error) {
 	disabledAnalyzers := []analyzer.Type{
 		analyzer.TypeAlpine,


### PR DESCRIPTION
```
 ubuntu@dev  ~│g│s│g│f│vuls  ⎇ master~  CGO_ENABLED=0 make build-scanner
GO111MODULE=off go get -u golang.org/x/lint/golint
golint github.com/future-architect/vuls/cache github.com/future-architect/vuls/cmd/scanner github.com/future-architect/vuls/cmd/vuls github.com/future-architect/vuls/config github.com/future-architect/vuls/constant github.com/future-architect/vuls/contrib/future-vuls/cmd github.com/future-architect/vuls/contrib/owasp-dependency-check/parser github.com/future-architect/vuls/contrib/trivy/cmd github.com/future-architect/vuls/contrib/trivy/parser github.com/future-architect/vuls/cwe github.com/future-architect/vuls/detector github.com/future-architect/vuls/errof github.com/future-architect/vuls/gost github.com/future-architect/vuls/logging github.com/future-architect/vuls/models github.com/future-architect/vuls/oval github.com/future-architect/vuls/reporter github.com/future-architect/vuls/saas github.com/future-architect/vuls/scanner github.com/future-architect/vuls/server github.com/future-architect/vuls/subcmds github.com/future-architect/vuls/tui github.com/future-architect/vuls/util
/home/ubuntu/go/src/github.com/future-architect/vuls/scanner/base.go:626:1: comment on exported function AnalyzeLibraries should be of the form "AnalyzeLibraries ..."
echo github.com/future-architect/vuls/cache github.com/future-architect/vuls/cmd/scanner github.com/future-architect/vuls/cmd/vuls github.com/future-architect/vuls/config github.com/future-architect/vuls/constant github.com/future-architect/vuls/contrib/future-vuls/cmd github.com/future-architect/vuls/contrib/owasp-dependency-check/parser github.com/future-architect/vuls/contrib/trivy/cmd github.com/future-architect/vuls/contrib/trivy/parser github.com/future-architect/vuls/cwe github.com/future-architect/vuls/detector github.com/future-architect/vuls/errof github.com/future-architect/vuls/gost github.com/future-architect/vuls/logging github.com/future-architect/vuls/models github.com/future-architect/vuls/oval github.com/future-architect/vuls/reporter github.com/future-architect/vuls/saas github.com/future-architect/vuls/scanner github.com/future-architect/vuls/server github.com/future-architect/vuls/subcmds github.com/future-architect/vuls/tui github.com/future-architect/vuls/util | xargs env GO111MODULE=on go vet || exit;
# github.com/kotakanbe/goval-dictionary/db/rdb
../../../../pkg/mod/github.com/kotakanbe/goval-dictionary@v0.3.6-0.20210429000733-6db1754b1d87/db/rdb/rdb.go:113:16: undefined: sqlite3.Error
../../../../pkg/mod/github.com/kotakanbe/goval-dictionary@v0.3.6-0.20210429000733-6db1754b1d87/db/rdb/rdb.go:114:9: undefined: sqlite3.ErrLocked
../../../../pkg/mod/github.com/kotakanbe/goval-dictionary@v0.3.6-0.20210429000733-6db1754b1d87/db/rdb/rdb.go:114:28: undefined: sqlite3.ErrBusy
# github.com/knqyf263/gost/db
../../../../pkg/mod/github.com/knqyf263/gost@v0.1.10/db/rdb.go:43:16: undefined: sqlite3.Error
../../../../pkg/mod/github.com/knqyf263/gost@v0.1.10/db/rdb.go:44:9: undefined: sqlite3.ErrLocked
../../../../pkg/mod/github.com/knqyf263/gost@v0.1.10/db/rdb.go:44:28: undefined: sqlite3.ErrBusy
# github.com/takuzoo3868/go-msfdb/db
../../../../pkg/mod/github.com/takuzoo3868/go-msfdb@v0.1.5/db/rdb.go:46:16: undefined: sqlite3.Error
../../../../pkg/mod/github.com/takuzoo3868/go-msfdb@v0.1.5/db/rdb.go:47:9: undefined: sqlite3.ErrLocked
../../../../pkg/mod/github.com/takuzoo3868/go-msfdb@v0.1.5/db/rdb.go:47:28: undefined: sqlite3.ErrBusy
# github.com/kotakanbe/go-cve-dictionary/db
../../../../pkg/mod/github.com/kotakanbe/go-cve-dictionary@v0.5.12/db/rdb.go:66:16: undefined: sqlite3.Error
../../../../pkg/mod/github.com/kotakanbe/go-cve-dictionary@v0.5.12/db/rdb.go:67:9: undefined: sqlite3.ErrLocked
../../../../pkg/mod/github.com/kotakanbe/go-cve-dictionary@v0.5.12/db/rdb.go:67:28: undefined: sqlite3.ErrBusy
# github.com/vulsio/go-exploitdb/db
../../../../pkg/mod/github.com/vulsio/go-exploitdb@v0.1.7/db/rdb.go:45:16: undefined: sqlite3.Error
../../../../pkg/mod/github.com/vulsio/go-exploitdb@v0.1.7/db/rdb.go:46:9: undefined: sqlite3.ErrLocked
../../../../pkg/mod/github.com/vulsio/go-exploitdb@v0.1.7/db/rdb.go:46:28: undefined: sqlite3.ErrBusy
```
