### PR TITLE
chore: fix build-tags in .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,7 +31,8 @@ builds:
   main: ./cmd/scanner/main.go
   flags:
   - -a
-  - -tags=scanner
+  tags:
+  - scanner
   ldflags: 
   - -s -w -X github.com/future-architect/vuls/config.Version={{.Version}} -X github.com/future-architect/vuls/config.Revision={{.Commit}}-{{ .CommitDate }}
   binary: vuls-scanner
@@ -46,6 +47,8 @@ builds:
   - amd64
   - arm
   - arm64
+  tags:
+  - scanner
   main: ./contrib/trivy/cmd/main.go
   binary: trivy-to-vuls
 
@@ -61,7 +64,8 @@ builds:
   - arm64
   flags:
   - -a
-  - -tags=scanner
+  tags:
+  - scanner
   main: ./contrib/future-vuls/cmd/main.go
   binary: future-vuls
 


### PR DESCRIPTION
To fix the error
```
   ⨯ build failed after 115.56s error=failed to build for linux_386: # github.com/kotakanbe/goval-dictionary/db/rdb
../../../../pkg/mod/github.com/kotakanbe/goval-dictionary@v0.3.6-0.20210429000733-6db1754b1d87/db/rdb/rdb.go:113:16: undefined: sqlite3.Error
../../../../pkg/mod/github.com/kotakanbe/goval-dictionary@v0.3.6-0.20210429000733-6db1754b1d87/db/rdb/rdb.go:114:9: undefined: sqlite3.ErrLocked
../../../../pkg/mod/github.com/kotakanbe/goval-dictionary@v0.3.6-0.20210429000733-6db1754b1d87/db/rdb/rdb.go:114:28: undefined: sqlite3.ErrBusy
# github.com/kotakanbe/go-cve-dictionary/db
../../../../pkg/mod/github.com/kotakanbe/go-cve-dictionary@v0.5.12/db/rdb.go:66:16: undefined: sqlite3.Error
../../../../pkg/mod/github.com/kotakanbe/go-cve-dictionary@v0.5.12/db/rdb.go:67:9: undefined: sqlite3.ErrLocked
../../../../pkg/mod/github.com/kotakanbe/go-cve-dictionary@v0.5.12/db/rdb.go:67:28: undefined: sqlite3.ErrBusy
# github.com/takuzoo3868/go-msfdb/db
../../../../pkg/mod/github.com/takuzoo3868/go-msfdb@v0.1.5/db/rdb.go:46:16: undefined: sqlite3.Error
../../../../pkg/mod/github.com/takuzoo3868/go-msfdb@v0.1.5/db/rdb.go:47:9: undefined: sqlite3.ErrLocked
../../../../pkg/mod/github.com/takuzoo3868/go-msfdb@v0.1.5/db/rdb.go:47:28: undefined: sqlite3.ErrBusy
# github.com/knqyf263/gost/db
../../../../pkg/mod/github.com/knqyf263/gost@v0.1.10/db/rdb.go:43:16: undefined: sqlite3.Error
../../../../pkg/mod/github.com/knqyf263/gost@v0.1.10/db/rdb.go:44:9: undefined: sqlite3.ErrLocked
../../../../pkg/mod/github.com/knqyf263/gost@v0.1.10/db/rdb.go:44:28: undefined: sqlite3.ErrBusy
# github.com/vulsio/go-exploitdb/db
../../../../pkg/mod/github.com/vulsio/go-exploitdb@v0.1.7/db/rdb.go:45:16: undefined: sqlite3.Error
../../../../pkg/mod/github.com/vulsio/go-exploitdb@v0.1.7/db/rdb.go:46:9: undefined: sqlite3.ErrLocked
../../../../pkg/mod/github.com/vulsio/go-exploitdb@v0.1.7/db/rdb.go:46:28: undefined: sqlite3.ErrBusy
``` 
