### PR TITLE
fix(libscan): support empty LibraryFixedIn

### DIFF
--- a/models/library.go
+++ b/models/library.go
@@ -88,15 +88,13 @@ func (s LibraryScanner) getVulnDetail(tvuln types.DetectedVulnerability) (vinfo 
 
 	vinfo.CveID = tvuln.VulnerabilityID
 	vinfo.CveContents = getCveContents(tvuln.VulnerabilityID, vul)
-	if tvuln.FixedVersion != "" {
-		vinfo.LibraryFixedIns = []LibraryFixedIn{
-			{
-				Key:     s.GetLibraryKey(),
-				Name:    tvuln.PkgName,
-				FixedIn: tvuln.FixedVersion,
-				Path:    s.Path,
-			},
-		}
+	vinfo.LibraryFixedIns = []LibraryFixedIn{
+		{
+			Key:     s.GetLibraryKey(),
+			Name:    tvuln.PkgName,
+			FixedIn: tvuln.FixedVersion,
+			Path:    s.Path,
+		},
 	}
 	return vinfo, nil
 }


### PR DESCRIPTION
# What did you implement:

When scanning LockFile, there was a problem that AffectedPackages was empty when FixedIn was an empty character.

![image](https://user-images.githubusercontent.com/534611/122157199-638c5900-cea5-11eb-8b34-23596a9ae45c.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

check make diff output

# Checklist:

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
