### PR TITLE
fix Ubuntu 20.10 End of Life on July 22 2021 (#1255)

### DIFF
--- a/config/os.go
+++ b/config/os.go
@@ -132,10 +132,10 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 				StandardSupportUntil: time.Date(2025, 4, 1, 23, 59, 59, 0, time.UTC),
 			},
 			"20.10": {
-				StandardSupportUntil: time.Date(2021, 7, 1, 23, 59, 59, 0, time.UTC),
+				StandardSupportUntil: time.Date(2021, 7, 22, 23, 59, 59, 0, time.UTC),
 			},
 			"21.04": {
-				StandardSupportUntil: time.Date(2022, 1, 1, 23, 59, 59, 0, time.UTC),
+				StandardSupportUntil: time.Date(2022, 1, 22, 23, 59, 59, 0, time.UTC),
 			},
 			"21.10": {
 				StandardSupportUntil: time.Date(2022, 7, 1, 23, 59, 59, 0, time.UTC),


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Correct Ubuntu 20.10 EOL's date July 1 to July 22.
see also https://lists.ubuntu.com/archives/ubuntu-announce/2021-June/000269.html

PS
Ubuntu 21.04 was released on April **22**, I guessed 21.04 EOL is January **22**, too :-)

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes #1255

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

