### PR TITLE
feat(oval): goval-dictionary update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/knqyf263/gost v0.1.11-0.20210615205949-22120a6441d8
 	github.com/kotakanbe/go-cve-dictionary v0.15.14
 	github.com/kotakanbe/go-pingscanner v0.1.0
-	github.com/kotakanbe/goval-dictionary v0.3.6-0.20210429000733-6db1754b1d87
+	github.com/kotakanbe/goval-dictionary v0.3.6-0.20210625044258-9be85404d7dd
 	github.com/kotakanbe/logrus-prefixed-formatter v0.0.0-20180123152602-928f7356cb96
 	github.com/lib/pq v1.10.2 // indirect
 	github.com/mattn/go-isatty v0.0.13 // indirect
@@ -54,14 +54,13 @@ require (
 	github.com/spf13/viper v1.8.0 // indirect
 	github.com/takuzoo3868/go-msfdb v0.1.5
 	github.com/vulsio/go-exploitdb v0.1.7
-	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
+	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71 // indirect
+	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
-	gorm.io/driver/mysql v1.1.0 // indirect
-	gorm.io/driver/postgres v1.1.0 // indirect
+	gorm.io/driver/mysql v1.1.1 // indirect
 	gorm.io/gorm v1.21.11 // indirect
 	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009
 )

--- a/go.sum
+++ b/go.sum
@@ -931,8 +931,8 @@ github.com/kotakanbe/go-cve-dictionary v0.15.14 h1:9NY5p9on+zLy1qBJuVxSEzJdkwXyR
 github.com/kotakanbe/go-cve-dictionary v0.15.14/go.mod h1:E/CipfNDV31W39MH9QtgkA12JFBMe/3CELxXVvPRphQ=
 github.com/kotakanbe/go-pingscanner v0.1.0 h1:VG4/9l0i8WeToXclj7bIGoAZAu7a07Z3qmQiIfU0gT0=
 github.com/kotakanbe/go-pingscanner v0.1.0/go.mod h1:/761QZzuZFcfN8h/1QuawUA+pKukp3qcNj5mxJCOiAk=
-github.com/kotakanbe/goval-dictionary v0.3.6-0.20210429000733-6db1754b1d87 h1:rkyT7u1aUfcQY6yelIaNkKww0iAg9XZx3tYV0L3iTE8=
-github.com/kotakanbe/goval-dictionary v0.3.6-0.20210429000733-6db1754b1d87/go.mod h1:69e5kFTZEAcT5Lqq8NRlKUjXm0ZNxvT8d3yS/iqFJjs=
+github.com/kotakanbe/goval-dictionary v0.3.6-0.20210625044258-9be85404d7dd h1:hnkOzwlknmNU64P5UaQzAZcyNnuSsCz/PIt/P/ZPKYg=
+github.com/kotakanbe/goval-dictionary v0.3.6-0.20210625044258-9be85404d7dd/go.mod h1:9BRxYJUgRVDpz4gXkpqReJG3l4bP1oI/eYr6Ok2jzWU=
 github.com/kotakanbe/logrus-prefixed-formatter v0.0.0-20180123152602-928f7356cb96 h1:xNVK0mQJdQjw+QYeaMM4G6fvucWr8rTGGIhlPakx1wU=
 github.com/kotakanbe/logrus-prefixed-formatter v0.0.0-20180123152602-928f7356cb96/go.mod h1:ljq48H1V+0Vh0u7ucA3LjR4AfkAeCpxrf7LaaCk8Vmo=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -1535,8 +1535,9 @@ golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a h1:kr2P4QFmQr29mSLA43kwrOcgcReGTfbE9N577tCTuBc=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
+golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e h1:gsTQYXdTw2Gq7RBsWvlQ91b+aEQ6bXFUngBGuR8sPpI=
+golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1632,7 +1633,6 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210220033124-5f55cee0dc0d/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -1770,8 +1770,9 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71 h1:X/2sJAybVknnUnV7AD2HdT6rm2p5BP6eH2j+igduWgk=
-golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -2083,8 +2084,9 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/mysql v1.0.6/go.mod h1:KdrTanmfLPPyAOeYGyG+UpDys7/7eeWT1zCq+oekYnU=
-gorm.io/driver/mysql v1.1.0 h1:3PgFPJlFq5Xt/0WRiRjxIVaXjeHY+2TQ5feXgpSpEC4=
 gorm.io/driver/mysql v1.1.0/go.mod h1:KdrTanmfLPPyAOeYGyG+UpDys7/7eeWT1zCq+oekYnU=
+gorm.io/driver/mysql v1.1.1 h1:yr1bpyqiwuSPJ4aGGUX9nu46RHXlF8RASQVb1QQNcvo=
+gorm.io/driver/mysql v1.1.1/go.mod h1:KdrTanmfLPPyAOeYGyG+UpDys7/7eeWT1zCq+oekYnU=
 gorm.io/driver/postgres v1.0.8/go.mod h1:4eOzrI1MUfm6ObJU/UcmbXyiHSs8jSwH95G5P5dxcAg=
 gorm.io/driver/postgres v1.1.0 h1:afBljg7PtJ5lA6YUWluV2+xovIPhS+YiInuL3kUjrbk=
 gorm.io/driver/postgres v1.1.0/go.mod h1:hXQIwafeRjJvUm+OMxcFWyswJ/vevcpPLlGocwAwuqw=
@@ -2093,6 +2095,7 @@ gorm.io/driver/sqlite v1.1.4/go.mod h1:mJCeTFr7+crvS+TRnWc5Z3UvwxUN1BGBLMrf5LA9D
 gorm.io/gorm v1.20.7/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
 gorm.io/gorm v1.20.12/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
 gorm.io/gorm v1.21.9/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
+gorm.io/gorm v1.21.10/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
 gorm.io/gorm v1.21.11 h1:CxkXW6Cc+VIBlL8yJEHq+Co4RYXdSLiMKNvgoZPjLK4=
 gorm.io/gorm v1.21.11/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/oval/oval.go
+++ b/oval/oval.go
@@ -83,7 +83,10 @@ func (b Base) CheckIfOvalFresh(osFamily, release string) (ok bool, err error) {
 				logging.Log.Errorf("Failed to close DB. err: %+v", err)
 			}
 		}()
-		lastModified = driver.GetLastModified(ovalFamily, release)
+		lastModified, err = driver.GetLastModified(ovalFamily, release)
+		if err != nil {
+			return false, xerrors.Errorf("Failed to GetLastModified: %w", err)
+		}
 	} else {
 		url, _ := util.URLPathJoin(config.Conf.OvalDict.URL, "lastmodified", ovalFamily, release)
 		resp, body, errs := gorequest.New().Timeout(10 * time.Second).Get(url).End()


### PR DESCRIPTION
# What did you implement:
Version up the goval-dictionary.
Refs https://github.com/kotakanbe/goval-dictionary/pull/136

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```console
$ vuls scan && vuls report
[Jun 25 13:31:43]  INFO [localhost] vuls-v0.15.11-build-20210625_132356_3086e27
[Jun 25 13:31:43]  INFO [localhost] Start scanning
[Jun 25 13:31:43]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Jun 25 13:31:43]  INFO [localhost] Validating config...
[Jun 25 13:31:43]  INFO [localhost] Detecting Server/Container OS... 
[Jun 25 13:31:43]  INFO [localhost] Detecting OS of servers... 
[Jun 25 13:31:43]  INFO [localhost] (1/1) Detected: localhost: ubuntu 20.04
[Jun 25 13:31:43]  INFO [localhost] Detecting OS of containers... 
[Jun 25 13:31:43]  INFO [localhost] Checking Scan Modes... 
[Jun 25 13:31:43]  INFO [localhost] Detecting Platforms... 
[Jun 25 13:31:44]  INFO [localhost] (1/1) localhost is running on other
[Jun 25 13:31:44]  INFO [localhost] Scanning OS pkg in fast mode


Scan Summary
================
localhost	ubuntu20.04	2697 installed





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
[Jun 25 13:31:44]  INFO [localhost] vuls-v0.15.11-build-20210625_132356_3086e27
[Jun 25 13:31:44]  INFO [localhost] Validating config...
[Jun 25 13:31:44]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Jun 25 13:31:44]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/oval.gormv2.sqlite3
[Jun 25 13:31:44]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/gost.sqlite3
[Jun 25 13:31:44]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Jun 25 13:31:44]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Jun 25 13:31:44]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2021-06-25T13:31:44+09:00
[Jun 25 13:31:44]  INFO [localhost] OVAL ubuntu 20.04 found. defs: 8001
[Jun 25 13:31:44]  INFO [localhost] OVAL ubuntu 20.04 is fresh. lastModified: 2021-06-25T13:17:06+09:00
[Jun 25 13:31:44]  WARN [localhost] The OVAL name of the running kernel image {Release:5.8.0-59-generic Version: RebootRequired:false} is not found. So vulns of `linux` wll be detected. server: localhost
[Jun 25 13:31:46]  INFO [localhost] localhost: 271 CVEs are detected with OVAL
[Jun 25 13:31:46]  INFO [localhost] localhost: 0 unfixed CVEs are detected with gost
[Jun 25 13:31:46]  INFO [localhost] localhost: 0 CVEs are detected with CPE
[Jun 25 13:31:46]  INFO [localhost] localhost: 4 PoC are detected
[Jun 25 13:31:46]  INFO [localhost] localhost: 0 exploits are detected


One Line Summary
================
localhost	Total: 271 (Critical:11 High:72 Medium:141 Low:47 ?:0)	5/271 Fixed	2697 installed	88 poc	0 exploits	en: 2, ja: 0 alerts
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

