### PR TITLE
feat(os) : support Rocky linux 

### DIFF
--- a/constant/constant.go
+++ b/constant/constant.go
@@ -17,6 +17,9 @@ const (
 	// CentOS is
 	CentOS = "centos"
 
+	// Rocky is
+	Rocky = "Rocky"
+
 	// Fedora is
 	// Fedora = "fedora"
 

--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -64,6 +64,27 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 		}
 	}
 
+	if r := exec(c, "ls /etc/rocky-release", noSudo); r.isSuccess() {
+		if r := exec(c, "cat /etc/rocky-release", noSudo); r.isSuccess() {
+			re := regexp.MustCompile(`(.*) release (\d[\d\.]*)`)
+			result := re.FindStringSubmatch(strings.TrimSpace(r.Stdout))
+			if len(result) != 3 {
+				logging.Log.Warnf("Failed to parse Rocky version: %s", r)
+				return true, newRocky(c)
+			}
+
+			release := result[2]
+			switch strings.ToLower(result[1]) {
+			case "rocky", "rocky linux":
+				rocky := newRocky(c)
+				rocky.setDistro(constant.Rocky, release)
+				return true, rocky 
+			default:
+				logging.Log.Warnf("Failed to parse Rocky: %s", r)
+			}
+		}
+	}
+
 	if r := exec(c, "ls /etc/redhat-release", noSudo); r.isSuccess() {
 		// https://www.rackaid.com/blog/how-to-determine-centos-or-red-hat-version/
 		// e.g.

--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -78,7 +78,7 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 			case "rocky", "rocky linux":
 				rocky := newRocky(c)
 				rocky.setDistro(constant.Rocky, release)
-				return true, rocky 
+				return true, rocky
 			default:
 				logging.Log.Warnf("Failed to parse Rocky: %s", r)
 			}

--- a/scanner/rocky.go
+++ b/scanner/rocky.go
@@ -21,7 +21,7 @@ func newRocky(c config.ServerInfo) *rocky {
 					VulnInfos: models.VulnInfos{},
 				},
 			},
-			sudo: rootPrivCentos{},
+			sudo: rootPrivRocky{},
 		},
 	}
 	r.log = logging.NewNormalLogger()
@@ -49,7 +49,7 @@ func (o *rocky) depsFast() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky
 	return []string{"yum-utils"}
 }
 
@@ -59,7 +59,7 @@ func (o *rocky) depsFastRoot() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky
 	return []string{"yum-utils"}
 }
 

--- a/scanner/rocky.go
+++ b/scanner/rocky.go
@@ -1,0 +1,118 @@
+package scanner
+
+import (
+	"github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/logging"
+	"github.com/future-architect/vuls/models"
+)
+
+// inherit OsTypeInterface
+type rocky struct {
+	redhatBase
+}
+
+// NewAmazon is constructor
+func newRocky(c config.ServerInfo) *rocky {
+	r := &rocky{
+		redhatBase{
+			base: base{
+				osPackages: osPackages{
+					Packages:  models.Packages{},
+					VulnInfos: models.VulnInfos{},
+				},
+			},
+			sudo: rootPrivCentos{},
+		},
+	}
+	r.log = logging.NewNormalLogger()
+	r.setServerInfo(c)
+	return r
+}
+
+func (o *rocky) checkScanMode() error {
+	return nil
+}
+
+func (o *rocky) checkDeps() error {
+	if o.getServerInfo().Mode.IsFast() {
+		return o.execCheckDeps(o.depsFast())
+	} else if o.getServerInfo().Mode.IsFastRoot() {
+		return o.execCheckDeps(o.depsFastRoot())
+	} else {
+		return o.execCheckDeps(o.depsDeep())
+	}
+}
+
+func (o *rocky) depsFast() []string {
+	if o.getServerInfo().Mode.IsOffline() {
+		return []string{}
+	}
+
+	// repoquery
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8
+	return []string{"yum-utils"}
+}
+
+func (o *rocky) depsFastRoot() []string {
+	if o.getServerInfo().Mode.IsOffline() {
+		return []string{}
+	}
+
+	// repoquery
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8
+	return []string{"yum-utils"}
+}
+
+func (o *rocky) depsDeep() []string {
+	return o.depsFastRoot()
+}
+
+func (o *rocky) checkIfSudoNoPasswd() error {
+	if o.getServerInfo().Mode.IsFast() {
+		return o.execCheckIfSudoNoPasswd(o.sudoNoPasswdCmdsFast())
+	} else if o.getServerInfo().Mode.IsFastRoot() {
+		return o.execCheckIfSudoNoPasswd(o.sudoNoPasswdCmdsFastRoot())
+	} else {
+		return o.execCheckIfSudoNoPasswd(o.sudoNoPasswdCmdsDeep())
+	}
+}
+
+func (o *rocky) sudoNoPasswdCmdsFast() []cmd {
+	return []cmd{}
+}
+
+func (o *rocky) sudoNoPasswdCmdsFastRoot() []cmd {
+	if !o.ServerInfo.IsContainer() {
+		return []cmd{
+			{"repoquery -h", exitStatusZero},
+			{"needs-restarting", exitStatusZero},
+			{"which which", exitStatusZero},
+			{"stat /proc/1/exe", exitStatusZero},
+			{"ls -l /proc/1/exe", exitStatusZero},
+			{"cat /proc/1/maps", exitStatusZero},
+			{"lsof -i -P", exitStatusZero},
+		}
+	}
+	return []cmd{
+		{"repoquery -h", exitStatusZero},
+		{"needs-restarting", exitStatusZero},
+	}
+}
+
+func (o *rocky) sudoNoPasswdCmdsDeep() []cmd {
+	return o.sudoNoPasswdCmdsFastRoot()
+}
+
+type rootPrivRocky struct{}
+
+func (o rootPrivRocky) repoquery() bool {
+	return false
+}
+
+func (o rootPrivRocky) yumMakeCache() bool {
+	return false
+}
+
+func (o rootPrivRocky) yumPS() bool {
+	return false
+}


### PR DESCRIPTION
support Rocky Linux verions 8.4
https://rockylinux.org/ja/


```
as-MacBook-Pro:vuls a$ vuls scan # fast mode on oval
[Jun 27 19:18:05]  INFO [localhost] vuls-v0.15.11-build-20210625_211447_8e6351a
[Jun 27 19:18:05]  INFO [localhost] Start scanning
[Jun 27 19:18:05]  INFO [localhost] config: /Users/a/vuls/config.toml
[Jun 27 19:18:05]  INFO [localhost] Validating config...
[Jun 27 19:18:05]  INFO [localhost] Detecting Server/Container OS... 
[Jun 27 19:18:05]  INFO [localhost] Detecting OS of servers... 
[Jun 27 19:18:06]  INFO [localhost] (1/1) Detected: rocky: redhat 8.4
[Jun 27 19:18:06]  INFO [localhost] Detecting OS of containers... 
[Jun 27 19:18:06]  INFO [localhost] Checking Scan Modes... 
[Jun 27 19:18:06]  INFO [localhost] Detecting Platforms... 
[Jun 27 19:18:07]  INFO [localhost] (1/1) rocky is running on other
[Jun 27 19:18:07]  INFO [rocky] Scanning OS pkg in fast mode
[Jun 27 19:18:10]  INFO [rocky] Scanning listen port...
[Jun 27 19:18:10]  INFO [rocky] Using Port Scanner: Vuls built-in Scanner


Scan Summary
================
rocky	redhat8.4	460 installed





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
as-MacBook-Pro:vuls a$ vuls report
[Jun 27 19:18:16]  INFO [localhost] vuls-v0.15.11-build-20210625_211447_8e6351a
[Jun 27 19:18:16]  INFO [localhost] Validating config...
[Jun 27 19:18:16]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/Users/a/vuls/cve.sqlite3
[Jun 27 19:18:16]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/Users/a/vuls/oval.sqlite3
[Jun 27 19:18:16]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/Users/a/vuls/gost.sqlite3
[Jun 27 19:18:16]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/Users/a/vuls/go-exploitdb.sqlite3
[Jun 27 19:18:16]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/Users/a/vuls/go-msfdb.sqlite3
[Jun 27 19:18:16]  INFO [localhost] Loaded: /Users/a/vuls/results/2021-06-27T19:18:07+09:00
[Jun 27 19:18:16]  INFO [localhost] OVAL redhat 8.4 found. defs: 598
[Jun 27 19:18:16]  INFO [localhost] OVAL redhat 8.4 is fresh. lastModified: 2021-06-25T18:54:00+09:00
[Jun 27 19:18:18]  INFO [localhost] rocky: 11 CVEs are detected with OVAL
[Jun 27 19:18:18]  INFO [localhost] rocky: 0 unfixed CVEs are detected with gost
[Jun 27 19:18:18]  INFO [localhost] rocky: 0 CVEs are detected with CPE
[Jun 27 19:18:18]  INFO [localhost] rocky: 0 PoC are detected
[Jun 27 19:18:18]  INFO [localhost] rocky: 0 exploits are detected
rocky (redhat8.4)
=================
Total: 11 (Critical:0 High:6 Medium:4 Low:1 ?:0)
11/11 Fixed, 0 poc, 0 exploits, en: 0, ja: 0 alerts
460 installed

+----------------+------+--------+-----+------+---------+-------------------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC | CERT |  FIXED  |                       NVD                       |
+----------------+------+--------+-----+------+---------+-------------------------------------------------+
| CVE-2020-8616  |  8.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8616  |
| CVE-2020-8617  |  8.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8617  |
| CVE-2020-8625  |  8.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8625  |
| CVE-2021-25215 |  8.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-25215 |
| CVE-2019-6477  |  7.5 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2019-6477  |
| CVE-2020-8623  |  7.5 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8623  |
| CVE-2020-8619  |  6.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8619  |
| CVE-2020-8622  |  6.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8622  |
| CVE-2020-8624  |  6.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8624  |
| CVE-2018-5745  |  4.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2018-5745  |
| CVE-2019-6465  |  3.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2019-6465  |
+----------------+------+--------+-----+------+---------+-------------------------------------------------+
```

```
as-MacBook-Pro:vuls a$ vuls scan && vuls report  #fast-root mode on oval
[Jun 27 19:37:04]  INFO [localhost] vuls-v0.15.11-build-20210625_211447_8e6351a
[Jun 27 19:37:04]  INFO [localhost] Start scanning
[Jun 27 19:37:04]  INFO [localhost] config: /Users/a/vuls/config.toml
[Jun 27 19:37:04]  INFO [localhost] Validating config...
[Jun 27 19:37:04]  INFO [localhost] Detecting Server/Container OS... 
[Jun 27 19:37:04]  INFO [localhost] Detecting OS of servers... 
[Jun 27 19:37:04]  INFO [localhost] (1/1) Detected: rocky: redhat 8.4
[Jun 27 19:37:04]  INFO [localhost] Detecting OS of containers... 
[Jun 27 19:37:04]  INFO [localhost] Checking Scan Modes... 
[Jun 27 19:37:04]  INFO [localhost] Detecting Platforms... 
[Jun 27 19:37:05]  INFO [localhost] (1/1) rocky is running on other
[Jun 27 19:37:06]  INFO [rocky] Scanning OS pkg in fast-root mode
[Jun 27 19:37:26]  INFO [rocky] Scanning listen port...
[Jun 27 19:37:26]  INFO [rocky] Using Port Scanner: Vuls built-in Scanner


Scan Summary
================
rocky	redhat8.4	460 installed, 1 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
[Jun 27 19:37:26]  INFO [localhost] vuls-v0.15.11-build-20210625_211447_8e6351a
[Jun 27 19:37:26]  INFO [localhost] Validating config...
[Jun 27 19:37:26]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/Users/a/vuls/cve.sqlite3
[Jun 27 19:37:26]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/Users/a/vuls/oval.sqlite3
[Jun 27 19:37:26]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/Users/a/vuls/gost.sqlite3
[Jun 27 19:37:26]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/Users/a/vuls/go-exploitdb.sqlite3
[Jun 27 19:37:26]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/Users/a/vuls/go-msfdb.sqlite3
[Jun 27 19:37:26]  INFO [localhost] Loaded: /Users/a/vuls/results/2021-06-27T19:37:05+09:00
[Jun 27 19:37:26]  INFO [localhost] OVAL redhat 8.4 found. defs: 598
[Jun 27 19:37:26]  INFO [localhost] OVAL redhat 8.4 is fresh. lastModified: 2021-06-25T18:54:00+09:00
[Jun 27 19:37:28]  INFO [localhost] rocky: 11 CVEs are detected with OVAL
[Jun 27 19:37:28]  INFO [localhost] rocky: 0 unfixed CVEs are detected with gost
[Jun 27 19:37:28]  INFO [localhost] rocky: 0 CVEs are detected with CPE
[Jun 27 19:37:28]  INFO [localhost] rocky: 0 PoC are detected
[Jun 27 19:37:28]  INFO [localhost] rocky: 0 exploits are detected
rocky (redhat8.4)
=================
Total: 11 (Critical:0 High:6 Medium:4 Low:1 ?:0)
11/11 Fixed, 0 poc, 0 exploits, en: 0, ja: 0 alerts
460 installed

+----------------+------+--------+-----+------+---------+-------------------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC | CERT |  FIXED  |                       NVD                       |
+----------------+------+--------+-----+------+---------+-------------------------------------------------+
| CVE-2020-8616  |  8.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8616  |
| CVE-2020-8617  |  8.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8617  |
| CVE-2020-8625  |  8.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8625  |
| CVE-2021-25215 |  8.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-25215 |
| CVE-2019-6477  |  7.5 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2019-6477  |
| CVE-2020-8623  |  7.5 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8623  |
| CVE-2020-8619  |  6.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8619  |
| CVE-2020-8622  |  6.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8622  |
| CVE-2020-8624  |  6.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-8624  |
| CVE-2018-5745  |  4.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2018-5745  |
| CVE-2019-6465  |  3.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2019-6465  |
+----------------+------+--------+-----+------+---------+-------------------------------------------------+

```


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

