### PR TITLE
feat(os) : support Alma Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Vuls is a tool created to solve the problems listed above. It has the following 
 
 [Supports major Linux/FreeBSD](https://vuls.io/docs/en/supported-os.html)
 
-- Alpine, Amazon Linux, CentOS, Rocky Linux, Debian, Oracle Linux, Raspbian, RHEL, SUSE Enterprise Linux, and Ubuntu
+- Alpine, Amazon Linux, CentOS, Rocky Linux, Alma Linux, Debian, Oracle Linux, Raspbian, RHEL, SUSE Enterprise Linux, and Ubuntu
 - FreeBSD
 - Cloud, on-premise, Running Docker Container
 
@@ -101,15 +101,15 @@ Vuls is a tool created to solve the problems listed above. It has the following 
 
 - Scan without root privilege, no dependencies
 - Almost no load on the scan target server
-- Offline mode scan with no internet access. (CentOS, Rocky Linux, Debian, Oracle Linux, Red Hat, and Ubuntu)
+- Offline mode scan with no internet access. (CentOS, Rocky Linux, Alma Linux, Debian, Oracle Linux, Red Hat, and Ubuntu)
 
 [Fast Root Scan](https://vuls.io/docs/en/architecture-fast-root-scan.html)
 
 - Scan with root privilege
 - Almost no load on the scan target server
-- Detect processes affected by update using yum-ps (Amazon Linux, CentOS, Rocky Linux, Oracle Linux, and RedHat)
+- Detect processes affected by update using yum-ps (Amazon Linux, CentOS, Rocky Linux, Alma Linux, Oracle Linux, and RedHat)
 - Detect processes which updated before but not restarting yet using checkrestart of debian-goodies (Debian and Ubuntu)
-- Offline mode scan with no internet access. (CentOS, Rocky Linux, Debian, Oracle Linux, Red Hat, and Ubuntu)
+- Offline mode scan with no internet access. (CentOS, Rocky Linux, Alma Linux, Debian, Oracle Linux, Red Hat, and Ubuntu)
 
 ### [Remote, Local scan mode, Server mode](https://vuls.io/docs/en/architecture-remote-local.html)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Vuls is a tool created to solve the problems listed above. It has the following 
 
 [Supports major Linux/FreeBSD](https://vuls.io/docs/en/supported-os.html)
 
-- Alpine, Amazon Linux, CentOS, Rocky Linux, Alma Linux, Debian, Oracle Linux, Raspbian, RHEL, SUSE Enterprise Linux, and Ubuntu
+- Alpine, Amazon Linux, CentOS, Alma Linux, Rocky Linux, Debian, Oracle Linux, Raspbian, RHEL, SUSE Enterprise Linux, and Ubuntu
 - FreeBSD
 - Cloud, on-premise, Running Docker Container
 
@@ -101,15 +101,15 @@ Vuls is a tool created to solve the problems listed above. It has the following 
 
 - Scan without root privilege, no dependencies
 - Almost no load on the scan target server
-- Offline mode scan with no internet access. (CentOS, Rocky Linux, Alma Linux, Debian, Oracle Linux, Red Hat, and Ubuntu)
+- Offline mode scan with no internet access. (CentOS, Alma Linux, Rocky Linux, Debian, Oracle Linux, Red Hat, and Ubuntu)
 
 [Fast Root Scan](https://vuls.io/docs/en/architecture-fast-root-scan.html)
 
 - Scan with root privilege
 - Almost no load on the scan target server
-- Detect processes affected by update using yum-ps (Amazon Linux, CentOS, Rocky Linux, Alma Linux, Oracle Linux, and RedHat)
+- Detect processes affected by update using yum-ps (Amazon Linux, CentOS, Alma Linux, Rocky Linux, Oracle Linux, and RedHat)
 - Detect processes which updated before but not restarting yet using checkrestart of debian-goodies (Debian and Ubuntu)
-- Offline mode scan with no internet access. (CentOS, Rocky Linux, Alma Linux, Debian, Oracle Linux, Red Hat, and Ubuntu)
+- Offline mode scan with no internet access. (CentOS, Alma Linux, Rocky Linux, Debian, Oracle Linux, Red Hat, and Ubuntu)
 
 ### [Remote, Local scan mode, Server mode](https://vuls.io/docs/en/architecture-remote-local.html)
 

--- a/config/config.go
+++ b/config/config.go
@@ -230,7 +230,7 @@ type ServerInfo struct {
 	GitHubRepos        map[string]GitHubConf       `toml:"githubs" json:"githubs,omitempty"` // key: owner/repo
 	UUIDs              map[string]string           `toml:"uuids,omitempty" json:"uuids,omitempty"`
 	Memo               string                      `toml:"memo,omitempty" json:"memo,omitempty"`
-	Enablerepo         []string                    `toml:"enablerepo,omitempty" json:"enablerepo,omitempty"` // For CentOS, Rocky, Alma, RHEL, Amazon
+	Enablerepo         []string                    `toml:"enablerepo,omitempty" json:"enablerepo,omitempty"` // For CentOS, Alma, Rocky, RHEL, Amazon
 	Optional           map[string]interface{}      `toml:"optional,omitempty" json:"optional,omitempty"`     // Optional key-value set that will be outputted to JSON
 	Lockfiles          []string                    `toml:"lockfiles,omitempty" json:"lockfiles,omitempty"`   // ie) path/to/package-lock.json
 	FindLock           bool                        `toml:"findLock,omitempty" json:"findLock,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -230,7 +230,7 @@ type ServerInfo struct {
 	GitHubRepos        map[string]GitHubConf       `toml:"githubs" json:"githubs,omitempty"` // key: owner/repo
 	UUIDs              map[string]string           `toml:"uuids,omitempty" json:"uuids,omitempty"`
 	Memo               string                      `toml:"memo,omitempty" json:"memo,omitempty"`
-	Enablerepo         []string                    `toml:"enablerepo,omitempty" json:"enablerepo,omitempty"` // For CentOS, Rocky, RHEL, Amazon
+	Enablerepo         []string                    `toml:"enablerepo,omitempty" json:"enablerepo,omitempty"` // For CentOS, Rocky, Alma, RHEL, Amazon
 	Optional           map[string]interface{}      `toml:"optional,omitempty" json:"optional,omitempty"`     // Optional key-value set that will be outputted to JSON
 	Lockfiles          []string                    `toml:"lockfiles,omitempty" json:"lockfiles,omitempty"`   // ie) path/to/package-lock.json
 	FindLock           bool                        `toml:"findLock,omitempty" json:"findLock,omitempty"`

--- a/config/os.go
+++ b/config/os.go
@@ -79,6 +79,10 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 		eol, found = map[string]EOL{
 			"8": {StandardSupportUntil: time.Date(2029, 5, 31, 23, 59, 59, 0, time.UTC)},
 		}[major(release)]
+	case constant.Alma:
+		eol, found = map[string]EOL{
+			"8": {StandardSupportUntil: time.Date(2029, 5, 31, 23, 59, 59, 0, time.UTC)},
+		}[major(release)]
 	case constant.Oracle:
 		eol, found = map[string]EOL{
 			// Source:

--- a/config/os.go
+++ b/config/os.go
@@ -75,13 +75,13 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 			"7": {StandardSupportUntil: time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC)},
 			"8": {StandardSupportUntil: time.Date(2021, 12, 31, 23, 59, 59, 0, time.UTC)},
 		}[major(release)]
-	case constant.Rocky:
-		eol, found = map[string]EOL{
-			"8": {StandardSupportUntil: time.Date(2029, 5, 31, 23, 59, 59, 0, time.UTC)},
-		}[major(release)]
 	case constant.Alma:
 		eol, found = map[string]EOL{
 			"8": {StandardSupportUntil: time.Date(2029, 12, 31, 23, 59, 59, 0, time.UTC)},
+		}[major(release)]
+	case constant.Rocky:
+		eol, found = map[string]EOL{
+			"8": {StandardSupportUntil: time.Date(2029, 5, 31, 23, 59, 59, 0, time.UTC)},
 		}[major(release)]
 	case constant.Oracle:
 		eol, found = map[string]EOL{

--- a/config/os.go
+++ b/config/os.go
@@ -81,7 +81,7 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 		}[major(release)]
 	case constant.Alma:
 		eol, found = map[string]EOL{
-			"8": {StandardSupportUntil: time.Date(2029, 5, 31, 23, 59, 59, 0, time.UTC)},
+			"8": {StandardSupportUntil: time.Date(2029, 12, 31, 23, 59, 59, 0, time.UTC)},
 		}[major(release)]
 	case constant.Oracle:
 		eol, found = map[string]EOL{

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -111,31 +111,6 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			extEnded: false,
 			found:    false,
 		},
-		// Rocky
-		{
-			name:     "Rocky Linux 8 supported",
-			fields:   fields{family: Rocky, release: "8"},
-			now:      time.Date(2021, 7, 2, 23, 59, 59, 0, time.UTC),
-			stdEnded: false,
-			extEnded: false,
-			found:    true,
-		},
-		{
-			name:     "Rocky Linux 8 EOL",
-			fields:   fields{family: Rocky, release: "8"},
-			now:      time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
-			stdEnded: false,
-			extEnded: false,
-			found:    true,
-		},
-		{
-			name:     "Rocky Linux 9 Not Found",
-			fields:   fields{family: Rocky, release: "9"},
-			now:      time.Date(2021, 7, 2, 23, 59, 59, 0, time.UTC),
-			stdEnded: false,
-			extEnded: false,
-			found:    false,
-		},
 		// Alma
 		{
 			name:     "Alma Linux 8 supported",
@@ -156,6 +131,31 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 		{
 			name:     "Alma Linux 9 Not Found",
 			fields:   fields{family: Alma, release: "9"},
+			now:      time.Date(2021, 7, 2, 23, 59, 59, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    false,
+		},
+		// Rocky
+		{
+			name:     "Rocky Linux 8 supported",
+			fields:   fields{family: Rocky, release: "8"},
+			now:      time.Date(2021, 7, 2, 23, 59, 59, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    true,
+		},
+		{
+			name:     "Rocky Linux 8 EOL",
+			fields:   fields{family: Rocky, release: "8"},
+			now:      time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    true,
+		},
+		{
+			name:     "Rocky Linux 9 Not Found",
+			fields:   fields{family: Rocky, release: "9"},
 			now:      time.Date(2021, 7, 2, 23, 59, 59, 0, time.UTC),
 			stdEnded: false,
 			extEnded: false,

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -136,6 +136,31 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			extEnded: false,
 			found:    false,
 		},
+		// Alma
+		{
+			name:     "Alma Linux 8 supported",
+			fields:   fields{family: Alma, release: "8"},
+			now:      time.Date(2021, 7, 2, 23, 59, 59, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    true,
+		},
+		{
+			name:     "Alma Linux 8 EOL",
+			fields:   fields{family: Alma, release: "8"},
+			now:      time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    true,
+		},
+		{
+			name:     "Alma Linux 9 Not Found",
+			fields:   fields{family: Alma, release: "9"},
+			now:      time.Date(2021, 7, 2, 23, 59, 59, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    false,
+		},
 		//Oracle
 		{
 			name:     "Oracle Linux 7 supported",

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -148,7 +148,7 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 		{
 			name:     "Alma Linux 8 EOL",
 			fields:   fields{family: Alma, release: "8"},
-			now:      time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+			now:      time.Date(2029, 2, 1, 0, 0, 0, 0, time.UTC),
 			stdEnded: false,
 			extEnded: false,
 			found:    true,

--- a/constant/constant.go
+++ b/constant/constant.go
@@ -23,9 +23,6 @@ const (
 	// Alma is
 	Alma = "alma"
 
-	// Rocky is
-	Rocky = "rocky"
-
 	// Fedora is
 	// Fedora = "fedora"
 

--- a/constant/constant.go
+++ b/constant/constant.go
@@ -23,6 +23,9 @@ const (
 	// Alma is
 	Alma = "alma"
 
+	// Rocky is
+	Rocky = "rocky"
+
 	// Fedora is
 	// Fedora = "fedora"
 

--- a/constant/constant.go
+++ b/constant/constant.go
@@ -17,11 +17,11 @@ const (
 	// CentOS is
 	CentOS = "centos"
 
-	// Rocky is
-	Rocky = "rocky"
-
 	// Alma is
 	Alma = "alma"
+
+	// Rocky is
+	Rocky = "rocky"
 
 	// Fedora is
 	// Fedora = "fedora"

--- a/constant/constant.go
+++ b/constant/constant.go
@@ -20,6 +20,9 @@ const (
 	// Rocky is
 	Rocky = "rocky"
 
+	// Alma is
+	Alma = "alma"
+
 	// Fedora is
 	// Fedora = "fedora"
 

--- a/gost/gost.go
+++ b/gost/gost.go
@@ -65,7 +65,7 @@ func NewClient(cnf config.GostConf, family string) (Client, error) {
 	driver := DBDriver{DB: db, Cnf: &cnf}
 
 	switch family {
-	case constant.RedHat, constant.CentOS, constant.Rocky:
+	case constant.RedHat, constant.CentOS, constant.Rocky, constant.Alma:
 		return RedHat{Base{DBDriver: driver}}, nil
 	case constant.Debian, constant.Raspbian:
 		return Debian{Base{DBDriver: driver}}, nil

--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -233,7 +233,7 @@ func NewCveContentType(name string) CveContentType {
 		return Nvd
 	case "jvn":
 		return Jvn
-	case "redhat", "centos", "rocky":
+	case "redhat", "centos", "rocky", "alma":
 		return RedHat
 	case "oracle":
 		return Oracle

--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -233,7 +233,7 @@ func NewCveContentType(name string) CveContentType {
 		return Nvd
 	case "jvn":
 		return Jvn
-	case "redhat", "centos", "rocky", "alma":
+	case "redhat", "centos", "alma", "rocky":
 		return RedHat
 	case "oracle":
 		return Oracle

--- a/models/scanresults_test.go
+++ b/models/scanresults_test.go
@@ -58,12 +58,12 @@ func TestIsDisplayUpdatableNum(t *testing.T) {
 		},
 		{
 			mode:     []byte{config.Fast},
-			family:   constant.Rocky,
+			family:   constant.Alma,
 			expected: true,
 		},
 		{
 			mode:     []byte{config.Fast},
-			family:   constant.Alma,
+			family:   constant.Rocky,
 			expected: true,
 		},
 		{

--- a/models/scanresults_test.go
+++ b/models/scanresults_test.go
@@ -63,6 +63,11 @@ func TestIsDisplayUpdatableNum(t *testing.T) {
 		},
 		{
 			mode:     []byte{config.Fast},
+			family:   constant.Alma,
+			expected: true,
+		},
+		{
+			mode:     []byte{config.Fast},
 			family:   constant.Amazon,
 			expected: true,
 		},

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -14,7 +14,7 @@ import (
 	ovalmodels "github.com/kotakanbe/goval-dictionary/models"
 )
 
-// RedHatBase is the base struct for RedHat, CentOS and Rocky
+// RedHatBase is the base struct for RedHat, CentOS, Alma and Rocky
 type RedHatBase struct {
 	Base
 }
@@ -155,7 +155,7 @@ func (o RedHatBase) update(r *models.ScanResult, defPacks defPacks) (nCVEs int) 
 func (o RedHatBase) convertToDistroAdvisory(def *ovalmodels.Definition) *models.DistroAdvisory {
 	advisoryID := def.Title
 	switch o.family {
-	case constant.RedHat, constant.CentOS, constant.Rocky, constant.Oracle:
+	case constant.RedHat, constant.CentOS, constant.Rocky, constant.Alma, constant.Oracle:
 		if def.Title != "" {
 			ss := strings.Fields(def.Title)
 			advisoryID = strings.TrimSuffix(ss[0], ":")
@@ -335,6 +335,24 @@ func NewRocky(cnf config.VulnDictInterface) Rocky {
 		RedHatBase{
 			Base{
 				family: constant.Rocky,
+				Cnf:    cnf,
+			},
+		},
+	}
+}
+
+// Alma is the interface for RedhatBase OVAL
+type Alma struct {
+	// Base
+	RedHatBase
+}
+
+// NewAlma creates OVAL client for Alma Linux
+func NewAlma(cnf config.VulnDictInterface) Alma {
+	return Alma{
+		RedHatBase{
+			Base{
+				family: constant.Alma,
 				Cnf:    cnf,
 			},
 		},

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -358,4 +358,3 @@ func NewRocky(cnf config.VulnDictInterface) Rocky {
 		},
 	}
 }
-

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -155,7 +155,7 @@ func (o RedHatBase) update(r *models.ScanResult, defPacks defPacks) (nCVEs int) 
 func (o RedHatBase) convertToDistroAdvisory(def *ovalmodels.Definition) *models.DistroAdvisory {
 	advisoryID := def.Title
 	switch o.family {
-	case constant.RedHat, constant.CentOS, constant.Rocky, constant.Alma, constant.Oracle:
+	case constant.RedHat, constant.CentOS, constant.Alma, constant.Rocky, constant.Oracle:
 		if def.Title != "" {
 			ss := strings.Fields(def.Title)
 			advisoryID = strings.TrimSuffix(ss[0], ":")
@@ -323,6 +323,24 @@ func NewAmazon(cnf config.VulnDictInterface) Amazon {
 	}
 }
 
+// Alma is the interface for RedhatBase OVAL
+type Alma struct {
+	// Base
+	RedHatBase
+}
+
+// NewAlma creates OVAL client for Alma Linux
+func NewAlma(cnf config.VulnDictInterface) Alma {
+	return Alma{
+		RedHatBase{
+			Base{
+				family: constant.Alma,
+				Cnf:    cnf,
+			},
+		},
+	}
+}
+
 // Rocky is the interface for RedhatBase OVAL
 type Rocky struct {
 	// Base
@@ -341,20 +359,3 @@ func NewRocky(cnf config.VulnDictInterface) Rocky {
 	}
 }
 
-// Alma is the interface for RedhatBase OVAL
-type Alma struct {
-	// Base
-	RedHatBase
-}
-
-// NewAlma creates OVAL client for Alma Linux
-func NewAlma(cnf config.VulnDictInterface) Alma {
-	return Alma{
-		RedHatBase{
-			Base{
-				family: constant.Alma,
-				Cnf:    cnf,
-			},
-		},
-	}
-}

--- a/oval/util.go
+++ b/oval/util.go
@@ -337,7 +337,7 @@ func isOvalDefAffected(def ovalmodels.Definition, req request, family string, ru
 
 		if running.Release != "" {
 			switch family {
-			case constant.RedHat, constant.CentOS, constant.Rocky, constant.Alma, constant.Oracle:
+			case constant.RedHat, constant.CentOS, constant.Alma, constant.Rocky, constant.Oracle:
 				// For kernel related packages, ignore OVAL information with different major versions
 				if _, ok := kernelRelatedPackNames[ovalPack.Name]; ok {
 					if util.Major(ovalPack.Version) != util.Major(running.Release) {
@@ -377,7 +377,7 @@ func isOvalDefAffected(def ovalmodels.Definition, req request, family string, ru
 				return true, false, ovalPack.Version, nil
 			}
 
-			// But CentOS/Rocky/Alma can't judge whether fixed or unfixed.
+			// But CentOS/Alma/Rocky can't judge whether fixed or unfixed.
 			// Because fixed state in RHEL OVAL is different.
 			// So, it have to be judged version comparison.
 
@@ -464,10 +464,10 @@ func NewOVALClient(family string, cnf config.GovalDictConf) (Client, error) {
 		return NewRedhat(&cnf), nil
 	case constant.CentOS:
 		return NewCentOS(&cnf), nil
-	case constant.Rocky:
-		return NewRocky(&cnf), nil
 	case constant.Alma:
 		return NewAlma(&cnf), nil
+	case constant.Rocky:
+		return NewRocky(&cnf), nil
 	case constant.Oracle:
 		return NewOracle(&cnf), nil
 	case constant.SUSEEnterpriseServer:
@@ -490,14 +490,14 @@ func NewOVALClient(family string, cnf config.GovalDictConf) (Client, error) {
 }
 
 // GetFamilyInOval returns the OS family name in OVAL
-// For example, CentOS/Rocky/Alma uses Red Hat's OVAL, so return 'redhat'
+// For example, CentOS/Alma/Rocky uses Red Hat's OVAL, so return 'redhat'
 func GetFamilyInOval(familyInScanResult string) (string, error) {
 	switch familyInScanResult {
 	case constant.Debian, constant.Raspbian:
 		return constant.Debian, nil
 	case constant.Ubuntu:
 		return constant.Ubuntu, nil
-	case constant.RedHat, constant.CentOS, constant.Rocky, constant.Alma:
+	case constant.RedHat, constant.CentOS, constant.Alma, constant.Rocky:
 		return constant.RedHat, nil
 	case constant.Oracle:
 		return constant.Oracle, nil

--- a/oval/util.go
+++ b/oval/util.go
@@ -337,7 +337,7 @@ func isOvalDefAffected(def ovalmodels.Definition, req request, family string, ru
 
 		if running.Release != "" {
 			switch family {
-			case constant.RedHat, constant.CentOS, constant.Rocky, constant.Oracle:
+			case constant.RedHat, constant.CentOS, constant.Rocky, constant.Alma, constant.Oracle:
 				// For kernel related packages, ignore OVAL information with different major versions
 				if _, ok := kernelRelatedPackNames[ovalPack.Name]; ok {
 					if util.Major(ovalPack.Version) != util.Major(running.Release) {
@@ -377,7 +377,7 @@ func isOvalDefAffected(def ovalmodels.Definition, req request, family string, ru
 				return true, false, ovalPack.Version, nil
 			}
 
-			// But CentOS/Rocky can't judge whether fixed or unfixed.
+			// But CentOS/Rocky/Alma can't judge whether fixed or unfixed.
 			// Because fixed state in RHEL OVAL is different.
 			// So, it have to be judged version comparison.
 
@@ -436,6 +436,7 @@ func lessThan(family, newVer string, packInOVAL ovalmodels.Package) (bool, error
 
 	case constant.RedHat,
 		constant.CentOS,
+		constant.Alma,
 		constant.Rocky:
 		vera := rpmver.NewVersion(rhelDownStreamOSVersionToRHEL(newVer))
 		verb := rpmver.NewVersion(rhelDownStreamOSVersionToRHEL(packInOVAL.Version))
@@ -446,7 +447,7 @@ func lessThan(family, newVer string, packInOVAL ovalmodels.Package) (bool, error
 	}
 }
 
-var rhelDownStreamOSVerPattern = regexp.MustCompile(`\.[es]l(\d+)(?:_\d+)?(?:\.(centos|rocky))?`)
+var rhelDownStreamOSVerPattern = regexp.MustCompile(`\.[es]l(\d+)(?:_\d+)?(?:\.(centos|rocky|alma))?`)
 
 func rhelDownStreamOSVersionToRHEL(ver string) string {
 	return rhelDownStreamOSVerPattern.ReplaceAllString(ver, ".el$1")
@@ -465,6 +466,8 @@ func NewOVALClient(family string, cnf config.GovalDictConf) (Client, error) {
 		return NewCentOS(&cnf), nil
 	case constant.Rocky:
 		return NewRocky(&cnf), nil
+	case constant.Alma:
+		return NewAlma(&cnf), nil
 	case constant.Oracle:
 		return NewOracle(&cnf), nil
 	case constant.SUSEEnterpriseServer:
@@ -487,14 +490,14 @@ func NewOVALClient(family string, cnf config.GovalDictConf) (Client, error) {
 }
 
 // GetFamilyInOval returns the OS family name in OVAL
-// For example, CentOS/Rocky uses Red Hat's OVAL, so return 'redhat'
+// For example, CentOS/Rocky/Alma uses Red Hat's OVAL, so return 'redhat'
 func GetFamilyInOval(familyInScanResult string) (string, error) {
 	switch familyInScanResult {
 	case constant.Debian, constant.Raspbian:
 		return constant.Debian, nil
 	case constant.Ubuntu:
 		return constant.Ubuntu, nil
-	case constant.RedHat, constant.CentOS, constant.Rocky:
+	case constant.RedHat, constant.CentOS, constant.Rocky, constant.Alma:
 		return constant.RedHat, nil
 	case constant.Oracle:
 		return constant.Oracle, nil

--- a/scanner/alma.go
+++ b/scanner/alma.go
@@ -1,0 +1,118 @@
+package scanner
+
+import (
+	"github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/logging"
+	"github.com/future-architect/vuls/models"
+)
+
+// inherit OsTypeInterface
+type alma struct {
+	redhatBase
+}
+
+// NewAmazon is constructor
+func newAlma(c config.ServerInfo) *alma {
+	r := &alma{
+		redhatBase{
+			base: base{
+				osPackages: osPackages{
+					Packages:  models.Packages{},
+					VulnInfos: models.VulnInfos{},
+				},
+			},
+			sudo: rootPrivAlma{},
+		},
+	}
+	r.log = logging.NewNormalLogger()
+	r.setServerInfo(c)
+	return r
+}
+
+func (o *alma) checkScanMode() error {
+	return nil
+}
+
+func (o *alma) checkDeps() error {
+	if o.getServerInfo().Mode.IsFast() {
+		return o.execCheckDeps(o.depsFast())
+	} else if o.getServerInfo().Mode.IsFastRoot() {
+		return o.execCheckDeps(o.depsFastRoot())
+	} else {
+		return o.execCheckDeps(o.depsDeep())
+	}
+}
+
+func (o *alma) depsFast() []string {
+	if o.getServerInfo().Mode.IsOffline() {
+		return []string{}
+	}
+
+	// repoquery
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma
+	return []string{"yum-utils"}
+}
+
+func (o *alma) depsFastRoot() []string {
+	if o.getServerInfo().Mode.IsOffline() {
+		return []string{}
+	}
+
+	// repoquery
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma
+	return []string{"yum-utils"}
+}
+
+func (o *alma) depsDeep() []string {
+	return o.depsFastRoot()
+}
+
+func (o *alma) checkIfSudoNoPasswd() error {
+	if o.getServerInfo().Mode.IsFast() {
+		return o.execCheckIfSudoNoPasswd(o.sudoNoPasswdCmdsFast())
+	} else if o.getServerInfo().Mode.IsFastRoot() {
+		return o.execCheckIfSudoNoPasswd(o.sudoNoPasswdCmdsFastRoot())
+	} else {
+		return o.execCheckIfSudoNoPasswd(o.sudoNoPasswdCmdsDeep())
+	}
+}
+
+func (o *alma) sudoNoPasswdCmdsFast() []cmd {
+	return []cmd{}
+}
+
+func (o *alma) sudoNoPasswdCmdsFastRoot() []cmd {
+	if !o.ServerInfo.IsContainer() {
+		return []cmd{
+			{"repoquery -h", exitStatusZero},
+			{"needs-restarting", exitStatusZero},
+			{"which which", exitStatusZero},
+			{"stat /proc/1/exe", exitStatusZero},
+			{"ls -l /proc/1/exe", exitStatusZero},
+			{"cat /proc/1/maps", exitStatusZero},
+			{"lsof -i -P", exitStatusZero},
+		}
+	}
+	return []cmd{
+		{"repoquery -h", exitStatusZero},
+		{"needs-restarting", exitStatusZero},
+	}
+}
+
+func (o *alma) sudoNoPasswdCmdsDeep() []cmd {
+	return o.sudoNoPasswdCmdsFastRoot()
+}
+
+type rootPrivAlma struct{}
+
+func (o rootPrivAlma) repoquery() bool {
+	return false
+}
+
+func (o rootPrivAlma) yumMakeCache() bool {
+	return false
+}
+
+func (o rootPrivAlma) yumPS() bool {
+	return false
+}

--- a/scanner/alma.go
+++ b/scanner/alma.go
@@ -49,7 +49,7 @@ func (o *alma) depsFast() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma8, Rocky8
 	return []string{"yum-utils"}
 }
 
@@ -59,7 +59,7 @@ func (o *alma) depsFastRoot() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma8, Rocky8
 	return []string{"yum-utils"}
 }
 

--- a/scanner/alma.go
+++ b/scanner/alma.go
@@ -11,7 +11,7 @@ type alma struct {
 	redhatBase
 }
 
-// NewAmazon is constructor
+// NewAlma is constructor
 func newAlma(c config.ServerInfo) *alma {
 	r := &alma{
 		redhatBase{

--- a/scanner/centos.go
+++ b/scanner/centos.go
@@ -11,7 +11,7 @@ type centos struct {
 	redhatBase
 }
 
-// NewAmazon is constructor
+// NewCentOS is constructor
 func newCentOS(c config.ServerInfo) *centos {
 	r := &centos{
 		redhatBase{

--- a/scanner/centos.go
+++ b/scanner/centos.go
@@ -49,7 +49,7 @@ func (o *centos) depsFast() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky8
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma8, Rocky8
 	return []string{"yum-utils"}
 }
 
@@ -59,7 +59,7 @@ func (o *centos) depsFastRoot() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky8
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma8, Rocky8
 	return []string{"yum-utils"}
 }
 

--- a/scanner/oracle.go
+++ b/scanner/oracle.go
@@ -11,7 +11,7 @@ type oracle struct {
 	redhatBase
 }
 
-// NewAmazon is constructor
+// NewOracle is constructor
 func newOracle(c config.ServerInfo) *oracle {
 	r := &oracle{
 		redhatBase{

--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -62,6 +62,27 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 		}
 	}
 
+	if r := exec(c, "ls /etc/rocky-release", noSudo); r.isSuccess() {
+		if r := exec(c, "cat /etc/rocky-release", noSudo); r.isSuccess() {
+			re := regexp.MustCompile(`(.*) release (\d[\d\.]*)`)
+			result := re.FindStringSubmatch(strings.TrimSpace(r.Stdout))
+			if len(result) != 3 {
+				logging.Log.Warnf("Failed to parse Rocky version: %s", r)
+				return true, newRocky(c)
+			}
+
+			release := result[2]
+			switch strings.ToLower(result[1]) {
+			case "rocky", "rocky linux":
+				rocky := newRocky(c)
+				rocky.setDistro(constant.Rocky, release)
+				return true, rocky
+			default:
+				logging.Log.Warnf("Failed to parse Rocky: %s", r)
+			}
+		}
+	}
+
 	if r := exec(c, "ls /etc/almalinux-release", noSudo); r.isSuccess() {
 		if r := exec(c, "cat /etc/alma-release", noSudo); r.isSuccess() {
 			re := regexp.MustCompile(`(.*) release (\d[\d\.]*)`)

--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -73,7 +73,7 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 
 			release := result[2]
 			switch strings.ToLower(result[1]) {
-			case "alma", "AlmaLinux":
+			case "alma", "almalinux":
 				alma := newAlma(c)
 				alma.setDistro(constant.Alma, release)
 				return true, alma

--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -121,6 +121,10 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 				cent := newCentOS(c)
 				cent.setDistro(constant.CentOS, release)
 				return true, cent
+			case "alma", "almalinux":
+				alma := newAlma(c)
+				alma.setDistro(constant.Alma, release)
+				return true, alma
 			default:
 				logging.Log.Warnf("Failed to parse CentOS: %s", r)
 			}

--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -68,6 +68,27 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 		}
 	}
 
+	if r := exec(c, "ls /etc/almalinux-release", noSudo); r.isSuccess() {
+		if r := exec(c, "cat /etc/almalinux-release", noSudo); r.isSuccess() {
+			re := regexp.MustCompile(`(.*) release (\d[\d\.]*)`)
+			result := re.FindStringSubmatch(strings.TrimSpace(r.Stdout))
+			if len(result) != 3 {
+				logging.Log.Warnf("Failed to parse Alma version: %s", r)
+				return true, newAlma(c)
+			}
+
+			release := result[2]
+			switch strings.ToLower(result[1]) {
+			case "alma", "almalinux":
+				alma := newAlma(c)
+				alma.setDistro(constant.Alma, release)
+				return true, alma
+			default:
+				logging.Log.Warnf("Failed to parse Alma: %s", r)
+			}
+		}
+	}
+
 	if r := exec(c, "ls /etc/rocky-release", noSudo); r.isSuccess() {
 		if r := exec(c, "cat /etc/rocky-release", noSudo); r.isSuccess() {
 			re := regexp.MustCompile(`(.*) release (\d[\d\.]*)`)
@@ -85,27 +106,6 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 				return true, rocky
 			default:
 				logging.Log.Warnf("Failed to parse Rocky: %s", r)
-			}
-		}
-	}
-
-	if r := exec(c, "ls /etc/almalinux-release", noSudo); r.isSuccess() {
-		if r := exec(c, "cat /etc/alma-release", noSudo); r.isSuccess() {
-			re := regexp.MustCompile(`(.*) release (\d[\d\.]*)`)
-			result := re.FindStringSubmatch(strings.TrimSpace(r.Stdout))
-			if len(result) != 3 {
-				logging.Log.Warnf("Failed to parse Alma version: %s", r)
-				return true, newAlma(c)
-			}
-
-			release := result[2]
-			switch strings.ToLower(result[1]) {
-			case "alma", "almalinux":
-				alma := newAlma(c)
-				alma.setDistro(constant.Alma, release)
-				return true, alma
-			default:
-				logging.Log.Warnf("Failed to parse Alma: %s", r)
 			}
 		}
 	}
@@ -129,14 +129,14 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 				cent := newCentOS(c)
 				cent.setDistro(constant.CentOS, release)
 				return true, cent
-			case "rocky", "rocky linux":
-				rocky := newRocky(c)
-				rocky.setDistro(constant.Rocky, release)
-				return true, rocky
 			case "alma", "almalinux":
 				alma := newAlma(c)
 				alma.setDistro(constant.Alma, release)
 				return true, alma
+			case "rocky", "rocky linux":
+				rocky := newRocky(c)
+				rocky.setDistro(constant.Rocky, release)
+				return true, rocky
 			default:
 				// RHEL
 				rhel := newRHEL(c)
@@ -688,7 +688,7 @@ func (o *redhatBase) rpmQf() string {
 
 func (o *redhatBase) detectEnabledDnfModules() ([]string, error) {
 	switch o.Distro.Family {
-	case constant.RedHat, constant.CentOS, constant.Rocky:
+	case constant.RedHat, constant.CentOS, constant.Alma, constant.Rocky:
 		//TODO OracleLinux
 	default:
 		return nil, nil

--- a/scanner/rhel.go
+++ b/scanner/rhel.go
@@ -55,7 +55,7 @@ func (o *rhel) depsFastRoot() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky8
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma8, Rocky8
 	return []string{"yum-utils"}
 }
 

--- a/scanner/rocky.go
+++ b/scanner/rocky.go
@@ -49,7 +49,7 @@ func (o *rocky) depsFast() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky8
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma8, Rocky8
 	return []string{"yum-utils"}
 }
 
@@ -59,7 +59,7 @@ func (o *rocky) depsFastRoot() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky8
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma8, Rocky8
 	return []string{"yum-utils"}
 }
 

--- a/scanner/serverapi.go
+++ b/scanner/serverapi.go
@@ -217,6 +217,8 @@ func ParseInstalledPkgs(distro config.Distro, kernel models.Kernel, pkgList stri
 		osType = &rhel{redhatBase: redhatBase{base: base}}
 	case constant.CentOS:
 		osType = &centos{redhatBase: redhatBase{base: base}}
+	case constant.Alma:
+		osType = &alma{redhatBase: redhatBase{base: base}}
 	case constant.Rocky:
 		osType = &rocky{redhatBase: redhatBase{base: base}}
 	case constant.Oracle:

--- a/scanner/utils.go
+++ b/scanner/utils.go
@@ -26,7 +26,7 @@ func isRunningKernel(pack models.Package, family string, kernel models.Kernel) (
 		}
 		return false, false
 
-	case constant.RedHat, constant.Oracle, constant.CentOS, constant.Rocky, constant.Alma, constant.Amazon:
+	case constant.RedHat, constant.Oracle, constant.CentOS, constant.Alma, constant.Rocky, constant.Amazon:
 		switch pack.Name {
 		case "kernel", "kernel-devel", "kernel-core", "kernel-modules", "kernel-uek":
 			ver := fmt.Sprintf("%s-%s.%s", pack.Version, pack.Release, pack.Arch)

--- a/scanner/utils.go
+++ b/scanner/utils.go
@@ -26,7 +26,7 @@ func isRunningKernel(pack models.Package, family string, kernel models.Kernel) (
 		}
 		return false, false
 
-	case constant.RedHat, constant.Oracle, constant.CentOS, constant.Rocky, constant.Amazon:
+	case constant.RedHat, constant.Oracle, constant.CentOS, constant.Rocky, constant.Alma, constant.Amazon:
 		switch pack.Name {
 		case "kernel", "kernel-devel", "kernel-core", "kernel-modules", "kernel-uek":
 			ver := fmt.Sprintf("%s-%s.%s", pack.Version, pack.Release, pack.Arch)


### PR DESCRIPTION
# What did you implement:
support Alma Linux version 8.4.
https://almalinux.org/


on oval.
```
$vuls report #fast mode
[Jun 25 22:53:42]  INFO [localhost] vuls-v0.15.11-build-20210625_211447_8e6351a
[Jun 25 22:53:42]  INFO [localhost] Validating config...
[Jun 25 22:53:42]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/Users/a/vuls/cve.sqlite3
[Jun 25 22:53:42]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/Users/a/vuls/oval.sqlite3
[Jun 25 22:53:42]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/Users/a/vuls/gost.sqlite3
[Jun 25 22:53:42]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/Users/a/vuls/go-exploitdb.sqlite3
[Jun 25 22:53:42]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/Users/a/vuls/go-msfdb.sqlite3
[Jun 25 22:53:42]  INFO [localhost] Loaded: /Users/a/vuls/results/2021-06-25T22:53:11+09:00
[Jun 25 22:53:42]  INFO [localhost] OVAL redhat 8.4 found. defs: 598
[Jun 25 22:53:42]  INFO [localhost] OVAL redhat 8.4 is fresh. lastModified: 2021-06-25T18:54:00+09:00
[Jun 25 22:53:43]  INFO [localhost] [Reboot Required] alma: 2 CVEs are detected with OVAL
[Jun 25 22:53:43]  INFO [localhost] [Reboot Required] alma: 0 unfixed CVEs are detected with gost
[Jun 25 22:53:43]  INFO [localhost] [Reboot Required] alma: 0 CVEs are detected with CPE
[Jun 25 22:53:43]  INFO [localhost] [Reboot Required] alma: 0 PoC are detected
[Jun 25 22:53:43]  INFO [localhost] [Reboot Required] alma: 0 exploits are detected
[Reboot Required] alma (redhat8.4)
==================================
Total: 2 (Critical:0 High:2 Medium:0 Low:0 ?:0)
2/2 Fixed, 0 poc, 0 exploits, en: 0, ja: 0 alerts
368 installed

+---------------+------+--------+-----+------+---------+------------------------------------------------+
|    CVE-ID     | CVSS | ATTACK | POC | CERT |  FIXED  |                      NVD                       |
+---------------+------+--------+-----+------+---------+------------------------------------------------+
| CVE-2021-3501 |  8.9 |  AV:L  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3501 |
| CVE-2021-3543 |  8.9 |  AV:L  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3543 |
+---------------+------+--------+-----+------+---------+------------------------------------------------+


```

```
$vuls report # fast-root mode
[Jun 26 22:57:05]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/Users/a/vuls/go-exploitdb.sqlite3
[Jun 26 22:57:05]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/Users/a/vuls/go-msfdb.sqlite3
[Jun 26 22:57:05]  INFO [localhost] Loaded: /Users/a/vuls/results/2021-06-26T22:56:21+09:00
[Jun 26 22:57:05]  INFO [localhost] OVAL redhat 8.4 found. defs: 598
[Jun 26 22:57:05]  INFO [localhost] OVAL redhat 8.4 is fresh. lastModified: 2021-06-25T18:54:00+09:00
[Jun 26 22:57:06]  INFO [localhost] [Reboot Required] alma: 2 CVEs are detected with OVAL
[Jun 26 22:57:06]  INFO [localhost] [Reboot Required] alma: 0 unfixed CVEs are detected with gost
[Jun 26 22:57:06]  INFO [localhost] [Reboot Required] alma: 0 CVEs are detected with CPE
[Jun 26 22:57:06]  INFO [localhost] [Reboot Required] alma: 0 PoC are detected
[Jun 26 22:57:06]  INFO [localhost] [Reboot Required] alma: 0 exploits are detected
[Reboot Required] alma (redhat8.4)
==================================
Total: 2 (Critical:0 High:2 Medium:0 Low:0 ?:0)
2/2 Fixed, 0 poc, 0 exploits, en: 0, ja: 0 alerts
370 installed

+---------------+------+--------+-----+------+---------+------------------------------------------------+
|    CVE-ID     | CVSS | ATTACK | POC | CERT |  FIXED  |                      NVD                       |
+---------------+------+--------+-----+------+---------+------------------------------------------------+
| CVE-2021-3501 |  8.9 |  AV:L  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3501 |
| CVE-2021-3543 |  8.9 |  AV:L  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3543 |
+---------------+------+--------+-----+------+---------+------------------------------------------------+
```


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  
