### PR TITLE
fix(rocky): fix Scan in Rocky Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Vuls is a tool created to solve the problems listed above. It has the following 
 
 [Supports major Linux/FreeBSD](https://vuls.io/docs/en/supported-os.html)
 
-- Alpine, Amazon Linux, CentOS, Debian, Oracle Linux, Raspbian, RHEL, SUSE Enterprise Linux, and Ubuntu
+- Alpine, Amazon Linux, CentOS, Rocky Linux, Debian, Oracle Linux, Raspbian, RHEL, SUSE Enterprise Linux, and Ubuntu
 - FreeBSD
 - Cloud, on-premise, Running Docker Container
 
@@ -100,15 +100,15 @@ Vuls is a tool created to solve the problems listed above. It has the following 
 
 - Scan without root privilege, no dependencies
 - Almost no load on the scan target server
-- Offline mode scan with no internet access. (CentOS, Debian, Oracle Linux, Red Hat, and Ubuntu)
+- Offline mode scan with no internet access. (CentOS, Rocky Linux, Debian, Oracle Linux, Red Hat, and Ubuntu)
 
 [Fast Root Scan](https://vuls.io/docs/en/architecture-fast-root-scan.html)
 
 - Scan with root privilege
 - Almost no load on the scan target server
-- Detect processes affected by update using yum-ps (Amazon Linux, CentOS, Oracle Linux, and RedHat)
+- Detect processes affected by update using yum-ps (Amazon Linux, CentOS, Rocky Linux, Oracle Linux, and RedHat)
 - Detect processes which updated before but not restarting yet using checkrestart of debian-goodies (Debian and Ubuntu)
-- Offline mode scan with no internet access. (CentOS, Debian, Oracle Linux, Red Hat, and Ubuntu)
+- Offline mode scan with no internet access. (CentOS, Rocky Linux, Debian, Oracle Linux, Red Hat, and Ubuntu)
 
 ### [Remote, Local scan mode, Server mode](https://vuls.io/docs/en/architecture-remote-local.html)
 

--- a/config/config.go
+++ b/config/config.go
@@ -230,7 +230,7 @@ type ServerInfo struct {
 	GitHubRepos        map[string]GitHubConf       `toml:"githubs" json:"githubs,omitempty"` // key: owner/repo
 	UUIDs              map[string]string           `toml:"uuids,omitempty" json:"uuids,omitempty"`
 	Memo               string                      `toml:"memo,omitempty" json:"memo,omitempty"`
-	Enablerepo         []string                    `toml:"enablerepo,omitempty" json:"enablerepo,omitempty"` // For CentOS, RHEL, Amazon
+	Enablerepo         []string                    `toml:"enablerepo,omitempty" json:"enablerepo,omitempty"` // For CentOS, Rocky, RHEL, Amazon
 	Optional           map[string]interface{}      `toml:"optional,omitempty" json:"optional,omitempty"`     // Optional key-value set that will be outputted to JSON
 	Lockfiles          []string                    `toml:"lockfiles,omitempty" json:"lockfiles,omitempty"`   // ie) path/to/package-lock.json
 	FindLock           bool                        `toml:"findLock,omitempty" json:"findLock,omitempty"`

--- a/config/os.go
+++ b/config/os.go
@@ -183,6 +183,7 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 			"10": {Ended: true},
 			"11": {StandardSupportUntil: time.Date(2021, 9, 30, 23, 59, 59, 0, time.UTC)},
 			"12": {StandardSupportUntil: time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC)},
+			"13": {StandardSupportUntil: time.Date(2026, 1, 31, 23, 59, 59, 0, time.UTC)},
 		}[major(release)]
 	}
 	return

--- a/config/os.go
+++ b/config/os.go
@@ -75,6 +75,10 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 			"7": {StandardSupportUntil: time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC)},
 			"8": {StandardSupportUntil: time.Date(2021, 12, 31, 23, 59, 59, 0, time.UTC)},
 		}[major(release)]
+	case constant.Rocky:
+		eol, found = map[string]EOL{
+			"8": {StandardSupportUntil: time.Date(2029, 5, 31, 23, 59, 59, 0, time.UTC)},
+		}[major(release)]
 	case constant.Oracle:
 		eol, found = map[string]EOL{
 			// Source:

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -111,6 +111,31 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			extEnded: false,
 			found:    false,
 		},
+		// Rocky
+		{
+			name:     "Rocky Linux 8 supported",
+			fields:   fields{family: Rocky, release: "8"},
+			now:      time.Date(2021, 7, 2, 23, 59, 59, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    true,
+		},
+		{
+			name:     "Rocky Linux 8 EOL",
+			fields:   fields{family: Rocky, release: "8"},
+			now:      time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    true,
+		},
+		{
+			name:     "Rocky Linux 9 Not Found",
+			fields:   fields{family: Rocky, release: "9"},
+			now:      time.Date(2021, 7, 2, 23, 59, 59, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    false,
+		},
 		//Oracle
 		{
 			name:     "Oracle Linux 7 supported",

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -309,6 +309,14 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			found:    true,
 		},
 		{
+			name:     "freebsd 13 supported",
+			fields:   fields{family: FreeBSD, release: "13"},
+			now:      time.Date(2021, 7, 2, 23, 59, 59, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    true,
+		},
+		{
 			name:     "freebsd 10 eol",
 			fields:   fields{family: FreeBSD, release: "10"},
 			now:      time.Date(2021, 1, 6, 23, 59, 59, 0, time.UTC),

--- a/constant/constant.go
+++ b/constant/constant.go
@@ -18,7 +18,7 @@ const (
 	CentOS = "centos"
 
 	// Rocky is
-	Rocky = "Rocky"
+	Rocky = "rocky"
 
 	// Fedora is
 	// Fedora = "fedora"

--- a/gost/gost.go
+++ b/gost/gost.go
@@ -65,7 +65,7 @@ func NewClient(cnf config.GostConf, family string) (Client, error) {
 	driver := DBDriver{DB: db, Cnf: &cnf}
 
 	switch family {
-	case constant.RedHat, constant.CentOS:
+	case constant.RedHat, constant.CentOS, constant.Rocky:
 		return RedHat{Base{DBDriver: driver}}, nil
 	case constant.Debian, constant.Raspbian:
 		return Debian{Base{DBDriver: driver}}, nil

--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -233,7 +233,7 @@ func NewCveContentType(name string) CveContentType {
 		return Nvd
 	case "jvn":
 		return Jvn
-	case "redhat", "centos":
+	case "redhat", "centos", "rocky":
 		return RedHat
 	case "oracle":
 		return Oracle

--- a/models/scanresults_test.go
+++ b/models/scanresults_test.go
@@ -58,6 +58,11 @@ func TestIsDisplayUpdatableNum(t *testing.T) {
 		},
 		{
 			mode:     []byte{config.Fast},
+			family:   constant.Rocky,
+			expected: true,
+		},
+		{
+			mode:     []byte{config.Fast},
 			family:   constant.Amazon,
 			expected: true,
 		},

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -155,7 +155,7 @@ func (o RedHatBase) update(r *models.ScanResult, defPacks defPacks) (nCVEs int) 
 func (o RedHatBase) convertToDistroAdvisory(def *ovalmodels.Definition) *models.DistroAdvisory {
 	advisoryID := def.Title
 	switch o.family {
-	case constant.RedHat, constant.CentOS, constant.Oracle:
+	case constant.RedHat, constant.CentOS, constant.Rocky, constant.Oracle:
 		if def.Title != "" {
 			ss := strings.Fields(def.Title)
 			advisoryID = strings.TrimSuffix(ss[0], ":")

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -14,7 +14,7 @@ import (
 	ovalmodels "github.com/kotakanbe/goval-dictionary/models"
 )
 
-// RedHatBase is the base struct for RedHat and CentOS
+// RedHatBase is the base struct for RedHat, CentOS and Rocky
 type RedHatBase struct {
 	Base
 }

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -322,3 +322,21 @@ func NewAmazon(cnf config.VulnDictInterface) Amazon {
 		},
 	}
 }
+
+// Rocky is the interface for RedhatBase OVAL
+type Rocky struct {
+	// Base
+	RedHatBase
+}
+
+// NewRocky creates OVAL client for Rocky Linux
+func NewRocky(cnf config.VulnDictInterface) Rocky {
+	return Rocky{
+		RedHatBase{
+			Base{
+				family: constant.Rocky,
+				Cnf:    cnf,
+			},
+		},
+	}
+}

--- a/oval/util.go
+++ b/oval/util.go
@@ -435,7 +435,8 @@ func lessThan(family, newVer string, packInOVAL ovalmodels.Package) (bool, error
 		return vera.LessThan(verb), nil
 
 	case constant.RedHat,
-		constant.CentOS:
+		constant.CentOS,
+		constant.Rocky:
 		vera := rpmver.NewVersion(rhelDownStreamOSVersionToRHEL(newVer))
 		verb := rpmver.NewVersion(rhelDownStreamOSVersionToRHEL(packInOVAL.Version))
 		return vera.LessThan(verb), nil

--- a/oval/util.go
+++ b/oval/util.go
@@ -377,7 +377,7 @@ func isOvalDefAffected(def ovalmodels.Definition, req request, family string, ru
 				return true, false, ovalPack.Version, nil
 			}
 
-			// But CentOS can't judge whether fixed or unfixed.
+			// But CentOS/Rocky can't judge whether fixed or unfixed.
 			// Because fixed state in RHEL OVAL is different.
 			// So, it have to be judged version comparison.
 
@@ -487,7 +487,7 @@ func NewOVALClient(family string, cnf config.GovalDictConf) (Client, error) {
 }
 
 // GetFamilyInOval returns the OS family name in OVAL
-// For example, CentOS uses Red Hat's OVAL, so return 'redhat'
+// For example, CentOS/Rocky uses Red Hat's OVAL, so return 'redhat'
 func GetFamilyInOval(familyInScanResult string) (string, error) {
 	switch familyInScanResult {
 	case constant.Debian, constant.Raspbian:

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -1078,6 +1078,472 @@ func TestIsOvalDefAffected(t *testing.T) {
 			notFixedYet: false,
 			fixedIn:     "3.1.0",
 		},
+		// Rocky Linux
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.el6.rocky.7",
+					newVersionRelease: "",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+			fixedIn:     "0:1.2.3-45.el6_7.8",
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6.rocky.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6.rocky.9",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.el6.rocky.6",
+					newVersionRelease: "0:1.2.3-45.el6.rocky.7",
+				},
+			},
+			affected:    true,
+			notFixedYet: true,
+			fixedIn:     "0:1.2.3-45.el6_7.8",
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.el6.rocky.6",
+					newVersionRelease: "0:1.2.3-45.el6.rocky.8",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+			fixedIn:     "0:1.2.3-45.el6_7.8",
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.el6.rocky.6",
+					newVersionRelease: "0:1.2.3-45.el6.rocky.9",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+			fixedIn:     "0:1.2.3-45.el6_7.8",
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6_7.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.sl6.7",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+			fixedIn:     "0:1.2.3-45.el6_7.8",
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.sl6.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.sl6.9",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.sl6.6",
+					newVersionRelease: "0:1.2.3-45.sl6.7",
+				},
+			},
+			affected:    true,
+			notFixedYet: true,
+			fixedIn:     "0:1.2.3-45.el6_7.8",
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.sl6.6",
+					newVersionRelease: "0:1.2.3-45.sl6.8",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+			fixedIn:     "0:1.2.3-45.el6_7.8",
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:          "b",
+					isSrcPack:         false,
+					versionRelease:    "0:1.2.3-45.sl6.6",
+					newVersionRelease: "0:1.2.3-45.sl6.9",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+			fixedIn:     "0:1.2.3-45.el6_7.8",
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6_7.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: "rocky",
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "a",
+							NotFixedYet: false,
+						},
+						{
+							Name:        "b",
+							NotFixedYet: false,
+							Version:     "0:1.2.3-45.el6.8",
+						},
+					},
+				},
+				req: request{
+					packName:       "b",
+					isSrcPack:      false,
+					versionRelease: "0:1.2.3-45.el6_7.8",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		// For kernel related packages, ignore OVAL with different major versions
+		{
+			in: in{
+				family: constant.Rocky,
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "kernel",
+							Version:     "4.1.0",
+							NotFixedYet: false,
+						},
+					},
+				},
+				req: request{
+					packName:          "kernel",
+					versionRelease:    "3.0.0",
+					newVersionRelease: "3.2.0",
+				},
+				kernel: models.Kernel{
+					Release: "3.0.0",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: constant.Rocky,
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:        "kernel",
+							Version:     "3.1.0",
+							NotFixedYet: false,
+						},
+					},
+				},
+				req: request{
+					packName:          "kernel",
+					versionRelease:    "3.0.0",
+					newVersionRelease: "3.2.0",
+				},
+				kernel: models.Kernel{
+					Release: "3.0.0",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+			fixedIn:     "3.1.0",
+		},
 		// dnf module
 		{
 			in: in{
@@ -1326,7 +1792,7 @@ func TestIsOvalDefAffected(t *testing.T) {
 	}
 }
 
-func Test_centOSVersionToRHEL(t *testing.T) {
+func Test_rhelDownStreamOSVersionToRHEL(t *testing.T) {
 	type args struct {
 		ver string
 	}
@@ -1341,6 +1807,13 @@ func Test_centOSVersionToRHEL(t *testing.T) {
 				ver: "grub2-tools-2.02-0.80.el7.centos.x86_64",
 			},
 			want: "grub2-tools-2.02-0.80.el7.x86_64",
+		},
+		{
+			name: "remove rocky.",
+			args: args{
+				ver: "platform-python-3.6.8-37.el8.rocky.x86_64",
+			},
+			want: "platform-python-3.6.8-37.el8.x86_64",
 		},
 		{
 			name: "noop",
@@ -1359,8 +1832,8 @@ func Test_centOSVersionToRHEL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := centOSVersionToRHEL(tt.args.ver); got != tt.want {
-				t.Errorf("centOSVersionToRHEL() = %v, want %v", got, tt.want)
+			if got := rhelDownStreamOSVersionToRHEL(tt.args.ver); got != tt.want {
+				t.Errorf("rhelDownStreamOSVersionToRHEL() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/scanner/centos.go
+++ b/scanner/centos.go
@@ -49,7 +49,7 @@ func (o *centos) depsFast() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky8
 	return []string{"yum-utils"}
 }
 
@@ -59,7 +59,7 @@ func (o *centos) depsFastRoot() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky8
 	return []string{"yum-utils"}
 }
 

--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -100,10 +100,14 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 
 			release := result[2]
 			switch strings.ToLower(result[1]) {
-			case "centos", "centos linux":
+			case "centos", "centos linux", "centos stream":
 				cent := newCentOS(c)
 				cent.setDistro(constant.CentOS, release)
 				return true, cent
+			case "rocky", "rocky linux":
+				rocky := newRocky(c)
+				rocky.setDistro(constant.Rocky, release)
+				return true, rocky
 			default:
 				// RHEL
 				rhel := newRHEL(c)
@@ -476,7 +480,7 @@ func (o *redhatBase) isExecNeedsRestarting() bool {
 		// TODO zypper ps
 		// https://github.com/future-architect/vuls/issues/696
 		return false
-	case constant.RedHat, constant.CentOS, constant.Oracle:
+	case constant.RedHat, constant.CentOS, constant.Rocky, constant.Oracle:
 		majorVersion, err := o.Distro.MajorVersion()
 		if err != nil || majorVersion < 6 {
 			o.log.Errorf("Not implemented yet: %s, err: %+v", o.Distro, err)
@@ -655,7 +659,7 @@ func (o *redhatBase) rpmQf() string {
 
 func (o *redhatBase) detectEnabledDnfModules() ([]string, error) {
 	switch o.Distro.Family {
-	case constant.RedHat, constant.CentOS:
+	case constant.RedHat, constant.CentOS, constant.Rocky:
 		//TODO OracleLinux
 	default:
 		return nil, nil

--- a/scanner/rhel.go
+++ b/scanner/rhel.go
@@ -55,7 +55,7 @@ func (o *rhel) depsFastRoot() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky8
 	return []string{"yum-utils"}
 }
 

--- a/scanner/rocky.go
+++ b/scanner/rocky.go
@@ -11,7 +11,7 @@ type rocky struct {
 	redhatBase
 }
 
-// NewAmazon is constructor
+// NewRocky is constructor
 func newRocky(c config.ServerInfo) *rocky {
 	r := &rocky{
 		redhatBase{
@@ -49,7 +49,7 @@ func (o *rocky) depsFast() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky8
 	return []string{"yum-utils"}
 }
 
@@ -59,7 +59,7 @@ func (o *rocky) depsFastRoot() []string {
 	}
 
 	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky
+	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Rocky8
 	return []string{"yum-utils"}
 }
 

--- a/scanner/serverapi.go
+++ b/scanner/serverapi.go
@@ -211,7 +211,7 @@ func ParseInstalledPkgs(distro config.Distro, kernel models.Kernel, pkgList stri
 
 	var osType osTypeInterface
 	switch distro.Family {
-	case constant.Debian, constant.Ubuntu:
+	case constant.Debian, constant.Ubuntu, constant.Raspbian:
 		osType = &debian{base: base}
 	case constant.RedHat:
 		osType = &rhel{redhatBase: redhatBase{base: base}}

--- a/scanner/serverapi.go
+++ b/scanner/serverapi.go
@@ -217,6 +217,8 @@ func ParseInstalledPkgs(distro config.Distro, kernel models.Kernel, pkgList stri
 		osType = &rhel{redhatBase: redhatBase{base: base}}
 	case constant.CentOS:
 		osType = &centos{redhatBase: redhatBase{base: base}}
+	case constant.Rocky:
+		osType = &rocky{redhatBase: redhatBase{base: base}}
 	case constant.Oracle:
 		osType = &oracle{redhatBase: redhatBase{base: base}}
 	case constant.Amazon:

--- a/scanner/utils.go
+++ b/scanner/utils.go
@@ -26,7 +26,7 @@ func isRunningKernel(pack models.Package, family string, kernel models.Kernel) (
 		}
 		return false, false
 
-	case constant.RedHat, constant.Oracle, constant.CentOS, constant.Amazon:
+	case constant.RedHat, constant.Oracle, constant.CentOS, constant.Rocky, constant.Amazon:
 		switch pack.Name {
 		case "kernel", "kernel-devel", "kernel-core", "kernel-modules", "kernel-uek":
 			ver := fmt.Sprintf("%s-%s.%s", pack.Version, pack.Release, pack.Arch)


### PR DESCRIPTION
# What did you implement:
With #1260, an attempt to support Rocky Linux has been incorporated into master. However, this implementation is inadequate and will be fixed in this PR to work properly.

Please note that Trivy does not yet support Rocky Linux.(2021/07/02)
https://github.com/aquasecurity/trivy/issues/1053
https://github.com/future-architect/vuls/blob/master/contrib/trivy/parser/parser.go#L145-L169

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

```console
$ vuls scan
[Jul  2 16:02:03]  INFO [localhost] vuls-v0.15.11-build-20210702_160035_1179f50
[Jul  2 16:02:03]  INFO [localhost] Start scanning
[Jul  2 16:02:03]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Jul  2 16:02:03]  INFO [localhost] Validating config...
[Jul  2 16:02:03]  INFO [localhost] Detecting Server/Container OS... 
[Jul  2 16:02:03]  INFO [localhost] Detecting OS of servers... 
[Jul  2 16:02:03]  INFO [localhost] (1/1) Detected: vuls-target: rocky 8.4
[Jul  2 16:02:03]  INFO [localhost] Detecting OS of containers... 
[Jul  2 16:02:03]  INFO [localhost] Checking Scan Modes... 
[Jul  2 16:02:03]  INFO [localhost] Detecting Platforms... 
[Jul  2 16:02:04]  INFO [localhost] (1/1) vuls-target is running on other
[Jul  2 16:02:04]  INFO [vuls-target] Scanning OS pkg in fast mode


Scan Summary
================
vuls-target	rocky8.4	189 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ vuls report
[Jul  2 16:02:10]  INFO [localhost] vuls-v0.15.11-build-20210702_160035_1179f50
[Jul  2 16:02:10]  INFO [localhost] Validating config...
[Jul  2 16:02:10]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Jul  2 16:02:10]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/usr/share/vuls-data/oval.sqlite3
[Jul  2 16:02:10]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/usr/share/vuls-data/gost.sqlite3
[Jul  2 16:02:10]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Jul  2 16:02:10]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Jul  2 16:02:10]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2021-07-02T16:02:04+09:00
[Jul  2 16:02:10]  INFO [localhost] OVAL rocky 8.4 found. defs: 611
[Jul  2 16:02:10]  INFO [localhost] OVAL rocky 8.4 is fresh. lastModified: 2021-07-02T15:44:50+09:00
[Jul  2 16:02:10]  INFO [localhost] vuls-target: 7 CVEs are detected with OVAL
[Jul  2 16:02:10]  INFO [localhost] vuls-target: 26 unfixed CVEs are detected with gost
[Jul  2 16:02:10]  INFO [localhost] vuls-target: 0 CVEs are detected with CPE
[Jul  2 16:02:11]  INFO [localhost] vuls-target: 0 PoC are detected
[Jul  2 16:02:11]  INFO [localhost] vuls-target: 0 exploits are detected
vuls-target (rocky8.4)
======================
Total: 32 (Critical:2 High:9 Medium:16 Low:5 ?:0)
7/32 Fixed, 2 poc, 0 exploits, en: 0, ja: 0 alerts
189 installed

+----------------+------+--------+-----+------+---------+-------------------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC | CERT |  FIXED  |                       NVD                       |
+----------------+------+--------+-----+------+---------+-------------------------------------------------+
| CVE-2021-20231 |  9.8 |  AV:N  | POC |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-20231 |
| CVE-2021-20232 |  9.8 |  AV:N  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-20232 |
| CVE-2021-3517  |  8.6 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3517  |
| CVE-2021-3518  |  8.6 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3518  |
| CVE-2021-3520  |  8.6 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3520  |
| CVE-2020-35448 |  7.8 |  AV:L  | POC |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2020-35448 |
| CVE-2021-3516  |  7.8 |  AV:L  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3516  |
| CVE-2019-20838 |  7.5 |  AV:N  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2019-20838 |
| CVE-2021-27218 |  7.5 |  AV:N  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-27218 |
| CVE-2021-33560 |  7.5 |  AV:N  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-33560 |
| CVE-2021-3537  |  7.5 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3537  |
| CVE-2021-20271 |  6.9 |  AV:L  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-20271 |
| CVE-2021-3541  |  6.9 |  AV:N  |     |      |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3541  |
| CVE-2021-3487  |  6.5 |  AV:N  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3487  |
| CVE-2021-35938 |  6.5 |  AV:L  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-35938 |
| CVE-2021-35939 |  6.5 |  AV:L  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-35939 |
| CVE-2021-3445  |  6.4 |  AV:N  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3445  |
| CVE-2021-35937 |  6.3 |  AV:L  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-35937 |
| CVE-2020-13529 |  6.1 |  AV:A  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2020-13529 |
| CVE-2021-33574 |  5.9 |  AV:N  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-33574 |
| CVE-2021-3580  |  5.9 |  AV:N  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3580  |
| CVE-2020-14155 |  5.3 |  AV:N  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2020-14155 |
| CVE-2021-28153 |  5.3 |  AV:N  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-28153 |
| CVE-2021-20269 |  4.7 |  AV:L  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-20269 |
| CVE-2021-20284 |  4.7 |  AV:L  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-20284 |
| CVE-2021-3421  |  4.7 |  AV:L  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3421  |
| CVE-2021-20197 |  4.2 |  AV:L  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-20197 |
| CVE-2021-22876 |  3.7 |  AV:N  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-22876 |
| CVE-2021-3200  |  3.3 |  AV:L  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3200  |
| CVE-2021-20266 |  3.1 |  AV:N  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-20266 |
| CVE-2021-22898 |  3.1 |  AV:N  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-22898 |
| CVE-2021-27645 |  2.5 |  AV:L  |     |      | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-27645 |
+----------------+------+--------+-----+------+---------+-------------------------------------------------+
```
# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference
- #1260 
- https://github.com/vulsdoc/vuls/pull/158
