### PR TITLE
feat(server): Apply filters for IgnoreCves and PkgsRegexps on server mode

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -143,7 +143,6 @@ func (h VulsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		})
 	}
 
-
 	for _, w := range reports {
 		if err := w.Write(r); err != nil {
 			logging.Log.Errorf("Failed to report. err: %+v", err)

--- a/server/server.go
+++ b/server/server.go
@@ -23,6 +23,8 @@ import (
 // VulsHandler is used for vuls server mode
 type VulsHandler struct {
 	ToLocalFile bool
+	IgnoreUnfixed bool
+	IgnoreUnscoredCves bool
 }
 
 // ServeHTTP is http handler
@@ -112,6 +114,14 @@ func (h VulsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		ignorePkgsRegexps = s.IgnorePkgsRegexp
 	}
 	r.ScannedCves = r.ScannedCves.FilterIgnorePkgs(ignorePkgsRegexps)
+
+	// IgnoreUnfixed
+	r.ScannedCves = r.ScannedCves.FilterUnfixed(h.IgnoreUnfixed)
+
+	// IgnoreUnscoredCves
+	if h.IgnoreUnscoredCves {
+		r.ScannedCves = r.ScannedCves.FindScoredVulns()
+	}
 
 	// set ReportedAt to current time when it's set to the epoch, ensures that ReportedAt will be set
 	// properly for scans sent to vuls when running in server mode

--- a/subcmds/server.go
+++ b/subcmds/server.go
@@ -18,9 +18,11 @@ import (
 
 // ServerCmd is subcommand for server
 type ServerCmd struct {
-	configPath  string
-	listen      string
-	toLocalFile bool
+	configPath         string
+	listen             string
+	toLocalFile        bool
+	ignoreUnfixed      bool
+	ignoreUnscoredCves bool
 }
 
 // Name return subcommand name
@@ -70,11 +72,11 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 	f.Float64Var(&config.Conf.CvssScoreOver, "cvss-over", 0,
 		"-cvss-over=6.5 means Servering CVSS Score 6.5 and over (default: 0 (means Server all))")
 
-	f.BoolVar(&config.Conf.IgnoreUnscoredCves, "ignore-unscored-cves", false,
-		"Don't Server the unscored CVEs")
-
-	f.BoolVar(&config.Conf.IgnoreUnfixed, "ignore-unfixed", false,
+	f.BoolVar(&p.ignoreUnfixed, "ignore-unfixed", false,
 		"Don't show the unfixed CVEs")
+
+	f.BoolVar(&p.ignoreUnscoredCves, "ignore-unscored-cves", false,
+		"Don't show the unscored CVEs")
 
 	f.StringVar(&config.Conf.HTTPProxy, "http-proxy", "",
 		"http://proxy-url:port (default: empty)")
@@ -99,7 +101,9 @@ func (p *ServerCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	}
 
 	http.Handle("/vuls", server.VulsHandler{
-		ToLocalFile: p.toLocalFile,
+		ToLocalFile:        p.toLocalFile,
+		IgnoreUnfixed:      p.ignoreUnfixed,
+		IgnoreUnscoredCves: p.ignoreUnscoredCves,
 	})
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "ok")


### PR DESCRIPTION
# What did you implement:
Closes #1267 

> The default settings should be applied to vuls server scans as well.

I applied the filters for ignoreCves and PkgsRegexps to the result from server mode.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
### How to reproduce this?
To get the same kind of results, simply run the `vuls server` command  with the same config on listed below on run the same POST command.

- Tested with the listed config below
```toml
[default]
ignorePkgsRegexp = [
  "^openssh"
]

ignoreCves = [
  "CVE-2004-0230"
]

[servers.via-server]
host = "localhost"
port = "local"
```

- Commands that were used to test
```bash
dpkg-query -W -f='${binary:Package},${db:Status-Abbrev},${Version},${Source},${source:Version}\n' |
curl -sS -o - -X POST \
  -H "content-type: text/plain" -H 'X-Vuls-OS-Family: debian' \
  -H "X-Vuls-Server-Name: via-server" \
  -H "X-Vuls-OS-Release: $(cat /etc/debian_version)" \
  -H "X-Vuls-Kernel-Release: $(uname -r)" \
  -H "X-Vuls-Kernel-Version: $(uname -a | awk '{print $7}')" \
  http://127.0.0.1:5515/vuls \
  --data-binary @- | jq . > via-server-without-openssh.json
```

Then, Checked the result by myself.

### Results for `ignoreCves`
- before
```bash
❯ grep CVE-2004-0230 via-server.json
      "CVE-2004-0230": {
        "cveID": "CVE-2004-0230",
            "cveID": "CVE-2004-0230",
            "sourceLink": "https://security-tracker.debian.org/tracker/CVE-2004-0230",
            "cveID": "CVE-2004-0230",
                "link": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2004-0230",
                "link": "http://nvd.nist.gov/nvd.cfm?cvename=CVE-2004-0230",
            "cveID": "CVE-2004-0230",
            "sourceLink": "https://nvd.nist.gov/vuln/detail/CVE-2004-0230",
```

- after
```bash
❯ grep CVE-2004-0230 via-server.json
empty
```

### Results for `PkgsRegexps`
`CVE-2019-16905` is one of the cves that includes openssh 

- before 
```
❯ grep CVE-2019-16905 via-server-without-opnessh.json
      "CVE-2019-16905": {
        "cveID": "CVE-2019-16905",
            "cveID": "CVE-2019-16905",
            "sourceLink": "https://security-tracker.debian.org/tracker/CVE-2019-16905",
            "cveID": "CVE-2019-16905",
                "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16905",
                "link": "https://nvd.nist.gov/vuln/detail/CVE-2019-16905",
            "cveID": "CVE-2019-16905",
            "sourceLink": "https://nvd.nist.gov/vuln/detail/CVE-2019-16905",
```

- after
```
❯ grep CVE-2019-16905 via-server-without-opnessh.json
empty
```

# Checklist:
- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# References
- https://github.com/vulsdoc/vuls/pull/161

