### PR TITLE
fix(gost): URI in ubuntu.go corrected, did not work

### DIFF
--- a/gost/ubuntu.go
+++ b/gost/ubuntu.go
@@ -53,7 +53,7 @@ func (ubu Ubuntu) DetectCVEs(r *models.ScanResult, _ bool) (nCVEs int, err error
 
 	packCvesList := []packCves{}
 	if ubu.DBDriver.Cnf.IsFetchViaHTTP() {
-		url, _ := util.URLPathJoin(ubu.DBDriver.Cnf.GetURL(), "ubuntu", ubuReleaseVer, "pkg")
+		url, _ := util.URLPathJoin(ubu.DBDriver.Cnf.GetURL(), "ubuntu", ubuReleaseVer, "pkgs")
 		responses, err := getAllUnfixedCvesViaHTTP(r, url)
 		if err != nil {
 			return 0, err


### PR DESCRIPTION
URI correction for ubuntu; see gost project: https://github.com/knqyf263/gost/blob/master/server/server.go#L48

# What did you implement:

corrected the URI according to gost source code. see https://github.com/knqyf263/gost/blob/master/server/server.go#L48

When creating reports using gost for ubuntu hosts:
```
time="Jul 29 09:21:18" level=warning msg="Failed to HTTP GET. retrying in 395.339215ms seconds. err: HTTP GET error, url: http://gost:1325/ubuntu/2004/pkg/dbus/unfixed-cves, resp: &{404 Not Found 404 HTTP/1.1 1 1 map[Content-Length:[24] Content-Type:[application/json; charset=UTF-8] Date:[Thu, 29 Jul 2021 09:21:18 GMT] Retry-Count:[0]] {{\"message\":\"Not Found\"}\n    } 24 [] true false map[] 0xc003a1e100 <nil>}, err: []:\n    github.com/future-architect/vuls/gost.httpGet.func1\n        /go/src/github.com/future-architect/vuls/gost/util.go:169" 
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I think there is no need to test. URI was wrong and is correct now.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [X] Check that there aren't other open pull requests for the same issue/feature
- [X] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [X] Enable "Allow edits from maintainers" for this PR
- [X] Update the messages below

***Is this ready for review?:*** YES 


