### PR TITLE
feat(debian): support Debian 11(bullseye)

### DIFF
--- a/config/os.go
+++ b/config/os.go
@@ -110,6 +110,7 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 			"8":  {Ended: true},
 			"9":  {StandardSupportUntil: time.Date(2022, 6, 30, 23, 59, 59, 0, time.UTC)},
 			"10": {StandardSupportUntil: time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC)},
+			"11": {StandardSupportUntil: time.Date(2026, 6, 30, 23, 59, 59, 0, time.UTC)},
 		}[major(release)]
 	case constant.Raspbian:
 		// Not found

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -290,6 +290,14 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			now:      time.Date(2021, 1, 6, 23, 59, 59, 0, time.UTC),
 			stdEnded: false,
 			extEnded: false,
+			found:    true,
+		},
+		{
+			name:     "Debian 12 is not supported yet",
+			fields:   fields{family: Debian, release: "12"},
+			now:      time.Date(2021, 1, 6, 23, 59, 59, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
 			found:    false,
 		},
 		//alpine

--- a/gost/debian.go
+++ b/gost/debian.go
@@ -31,6 +31,7 @@ func (deb Debian) supported(major string) bool {
 		"8":  "jessie",
 		"9":  "stretch",
 		"10": "buster",
+		"11": "bullseye",
 	}[major]
 	return ok
 }

--- a/gost/debian_test.go
+++ b/gost/debian_test.go
@@ -39,9 +39,16 @@ func TestDebian_Supported(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "11 is not supported yet",
+			name: "11 is supported",
 			args: args{
 				major: "11",
+			},
+			want: true,
+		},
+		{
+			name: "12 is not supported yet",
+			args: args{
+				major: "12",
 			},
 			want: false,
 		},


### PR DESCRIPTION
# What did you implement:
Debian 11 has been released, OVAL etc., so vuls fully scans Debian 11.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
```console
$ vuls scan && vuls report
[Sep  1 21:43:34]  INFO [localhost] vuls-v0.15.13-build-20210901_200909_b9416ae
[Sep  1 21:43:34]  INFO [localhost] Start scanning
[Sep  1 21:43:34]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Sep  1 21:43:34]  INFO [localhost] Validating config...
[Sep  1 21:43:34]  INFO [localhost] Detecting Server/Container OS... 
[Sep  1 21:43:34]  INFO [localhost] Detecting OS of servers... 
[Sep  1 21:43:35]  INFO [localhost] (1/1) Detected: vuls-target: debian 11.0
[Sep  1 21:43:35]  INFO [localhost] Detecting OS of containers... 
[Sep  1 21:43:35]  INFO [localhost] Checking Scan Modes... 
[Sep  1 21:43:35]  INFO [localhost] Detecting Platforms... 
[Sep  1 21:43:36]  INFO [localhost] (1/1) vuls-target is running on other
[Sep  1 21:43:36]  INFO [vuls-target] Scanning OS pkg in fast mode


Scan Summary
================
vuls-target	debian11.0	332 installed

To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
[Sep  1 21:43:36]  INFO [localhost] vuls-v0.15.13-build-20210901_200909_b9416ae
[Sep  1 21:43:36]  INFO [localhost] Validating config...
[Sep  1 21:43:36]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Sep  1 21:43:36]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/oval.debian11.sqlite3
[Sep  1 21:43:36]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/usr/share/vuls-data/gost.sqlite3
[Sep  1 21:43:36]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Sep  1 21:43:36]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Sep  1 21:43:36]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2021-09-01T21:43:36+09:00
[Sep  1 21:43:36]  INFO [localhost] OVAL debian 11.0 found. defs: 19051
[Sep  1 21:43:36]  INFO [localhost] OVAL debian 11.0 is fresh. lastModified: 2021-09-01T21:09:46+09:00
[Sep  1 21:43:36]  INFO [localhost] vuls-target: 1 CVEs are detected with OVAL
[Sep  1 21:43:37]  INFO [localhost] vuls-target: 183 CVEs are detected with gost
[Sep  1 21:43:37]  INFO [localhost] vuls-target: 0 CVEs are detected with CPE
[Sep  1 21:43:39]  INFO [localhost] vuls-target: 9 PoC are detected
[Sep  1 21:43:39]  INFO [localhost] vuls-target: 1 exploits are detected
vuls-target (debian11.0)
========================
Total: 184 (Critical:8 High:61 Medium:95 Low:12 ?:8)
1/184 Fixed, 78 poc, 1 exploits, en: 5, ja: 4 alerts
332 installed
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://github.com/kotakanbe/goval-dictionary/pull/149
- https://github.com/vulsdoc/vuls/pull/166