### PR TITLE
breaking-change(goval): change-redis-architecture

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/knqyf263/gost v0.2.0
 	github.com/kotakanbe/go-cve-dictionary v0.7.2-0.20210907024016-69922490c76a
 	github.com/kotakanbe/go-pingscanner v0.1.0
-	github.com/kotakanbe/goval-dictionary v0.3.6-0.20210912113205-047e4dbfd356
+	github.com/kotakanbe/goval-dictionary v0.5.0
 	github.com/kotakanbe/logrus-prefixed-formatter v0.0.0-20180123152602-928f7356cb96
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
@@ -88,7 +88,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
-	github.com/go-redis/redis v6.15.9+incompatible // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-github/v33 v33.0.0 // indirect
@@ -124,7 +123,7 @@ require (
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
 	github.com/mitchellh/copystructure v1.1.1 // indirect
-	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/mitchellh/mapstructure v1.4.2 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1050,8 +1050,8 @@ github.com/kotakanbe/go-cve-dictionary v0.7.2-0.20210907024016-69922490c76a h1:H
 github.com/kotakanbe/go-cve-dictionary v0.7.2-0.20210907024016-69922490c76a/go.mod h1:RRZTNWQL6KVchGwK/444079s/GipyVAzIyjuzgWw5IQ=
 github.com/kotakanbe/go-pingscanner v0.1.0 h1:VG4/9l0i8WeToXclj7bIGoAZAu7a07Z3qmQiIfU0gT0=
 github.com/kotakanbe/go-pingscanner v0.1.0/go.mod h1:/761QZzuZFcfN8h/1QuawUA+pKukp3qcNj5mxJCOiAk=
-github.com/kotakanbe/goval-dictionary v0.3.6-0.20210912113205-047e4dbfd356 h1:vF3bZmu2GC7xzYv6CwXhM0r82+AMNiMEuPDI/sKh9Tw=
-github.com/kotakanbe/goval-dictionary v0.3.6-0.20210912113205-047e4dbfd356/go.mod h1:0wsKDaOgxLC7yD9zyOkeZjHS5+7SjQSiSYefgkWee0g=
+github.com/kotakanbe/goval-dictionary v0.5.0 h1:tPoFakaDpBNGVTGxgN2p480AgatGX/zTpV2Hn89+7lQ=
+github.com/kotakanbe/goval-dictionary v0.5.0/go.mod h1:uAjJlvCvL5TCABKFhOT4BgwIar3LRVhS+Q3BGTsiv3o=
 github.com/kotakanbe/logrus-prefixed-formatter v0.0.0-20180123152602-928f7356cb96 h1:xNVK0mQJdQjw+QYeaMM4G6fvucWr8rTGGIhlPakx1wU=
 github.com/kotakanbe/logrus-prefixed-formatter v0.0.0-20180123152602-928f7356cb96/go.mod h1:ljq48H1V+0Vh0u7ucA3LjR4AfkAeCpxrf7LaaCk8Vmo=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -1172,8 +1172,9 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.4.2 h1:6h7AQ0yhTcIsmFmnAwQls75jp2Gzs4iB8W7pjMO+rqo=
+github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/integration/data/results/rhel_8.json
+++ b/integration/data/results/rhel_8.json
@@ -44,6 +44,7 @@
         "version": "",
         "rebootRequired": false
     },
+    "enabledDnfModules": ["nodejs:12"],
     "packages": {
         "NetworkManager": {
             "name": "NetworkManager",
@@ -5905,6 +5906,15 @@
                     "name": "rsyslogd"
                 }
             ]
+        },
+        "nodejs": {
+            "name": "nodejs",
+            "version": "1:12.14.1",
+            "release": "1.module+el8.1.0+5466+30f75628",
+            "newVersion": "1:12.14.1",
+            "newRelease": "1.module+el8.1.0+5466+30f75629",
+            "arch": "x86_64",
+            "repository": "rhel-8-appstream-rhui-rpms"
         },
         "sed": {
             "name": "sed",


### PR DESCRIPTION
Please use this revision with the latest version of goval-dictionary.
Old dictionaries can't detect it correctly.
Since the Redis schema has been changed, you have to delete Redis and fetch it again.

```console
// delete all old key
$ redis-cli keys "OVAL#*" | xargs redis-cli del
```

# What did you implement:

see https://github.com/kotakanbe/goval-dictionary/pull/145

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Integration test works fine.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
