### PR TITLE
fix: Ubuntu 21.10 and 20.xx

### DIFF
--- a/gost/ubuntu.go
+++ b/gost/ubuntu.go
@@ -26,6 +26,7 @@ func (ubu Ubuntu) supported(version string) bool {
 		"2004": "focal",
 		"2010": "groovy",
 		"2104": "hirsute",
+		"2110": "impish",
 	}[version]
 	return ok
 }

--- a/gost/ubuntu_test.go
+++ b/gost/ubuntu_test.go
@@ -61,6 +61,13 @@ func TestUbuntu_Supported(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "21.10 is supported",
+			args: args{
+				ubuReleaseVer: "2110",
+			},
+			want: true,
+		},
+		{
 			name: "empty string is not supported yet",
 			args: args{
 				ubuReleaseVer: "",

--- a/oval/debian.go
+++ b/oval/debian.go
@@ -331,9 +331,18 @@ func (o Ubuntu) FillWithOval(r *models.ScanResult) (nCVEs int, err error) {
 	case "20":
 		kernelNamesInOval := []string{
 			"linux-aws",
+			"linux-aws-edge",
 			"linux-azure",
+			"linux-base",
+			"linux-base-sgx",
 			"linux-gcp",
+			"linux-gcp-edge",
+			"linux-generic",
+			"linux-gke",
+			"linux-gkeop",
+			"linux-ibm",
 			"linux-kvm",
+			"linux-lowlatency",
 			"linux-meta",
 			"linux-meta-aws",
 			"linux-meta-azure",
@@ -343,8 +352,10 @@ func (o Ubuntu) FillWithOval(r *models.ScanResult) (nCVEs int, err error) {
 			"linux-meta-oracle",
 			"linux-meta-raspi",
 			"linux-meta-riscv",
+			"linux-oem",
 			"linux-oem-5.6",
 			"linux-oracle",
+			"linux-oracle-edge",
 			"linux-raspi",
 			"linux-raspi2",
 			"linux-riscv",
@@ -353,6 +364,7 @@ func (o Ubuntu) FillWithOval(r *models.ScanResult) (nCVEs int, err error) {
 			"linux-signed-gcp",
 			"linux-signed-oem-5.6",
 			"linux-signed-oracle",
+			"linux-virtual",
 			"linux",
 		}
 		return o.fillWithOval(r, kernelNamesInOval)


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

- fix *WARN*

```
% vuls report
[Oct 18 13:05:51]  INFO [localhost] vuls-v0.18.1-build-20211013_134621_8659668
[Oct 18 13:05:51]  WARN [localhost] Ubuntu 21.10 is not supported yet
```

- add linux-generic in ubuntu 20.xx kernel name list. this will be correcting reboot required message.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes #1214 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

