### PR TITLE
fix scanUnsecurePackages for FreeBSD pkg audit output change

### DIFF
--- a/scanner/freebsd.go
+++ b/scanner/freebsd.go
@@ -208,11 +208,11 @@ func (o *bsd) scanUnsecurePackages() (models.VulnInfos, error) {
 	blocks := o.splitIntoBlocks(r.Stdout)
 	for _, b := range blocks {
 		n, cveIDs, vulnID := o.parseBlock(b)
-		if len(cveIDs) == 0 {
-			continue
-		}
 		if len(n) != 0 {
 			name = n
+		}
+		if len(cveIDs) == 0 {
+			continue
 		}
 		pack, found := o.Packages[name]
 		if !found {

--- a/scanner/freebsd.go
+++ b/scanner/freebsd.go
@@ -203,12 +203,16 @@ func (o *bsd) scanUnsecurePackages() (models.VulnInfos, error) {
 		return nil, nil
 	}
 
+	name := ""
 	packAdtRslt := []pkgAuditResult{}
 	blocks := o.splitIntoBlocks(r.Stdout)
 	for _, b := range blocks {
-		name, cveIDs, vulnID := o.parseBlock(b)
+		n, cveIDs, vulnID := o.parseBlock(b)
 		if len(cveIDs) == 0 {
 			continue
+		}
+		if len(n) != 0 {
+			name = n
 		}
 		pack, found := o.Packages[name]
 		if !found {

--- a/scanner/freebsd.go
+++ b/scanner/freebsd.go
@@ -335,7 +335,7 @@ type pkgAuditResult struct {
 func (o *bsd) splitIntoBlocks(stdout string) (blocks []string) {
 	scanner := bufio.NewScanner(strings.NewReader(stdout))
 	for scanner.Scan() {
-		line := scanner.Text()
+		line := strings.TrimSpace(scanner.Text())
 		if strings.HasSuffix(line, " is vulnerable:") {
 			blocks = append(blocks, line)
 			continue

--- a/scanner/freebsd_test.go
+++ b/scanner/freebsd_test.go
@@ -206,7 +206,23 @@ WWW: https://vuxml.FreeBSD.org/freebsd/ab3e98d9-8175-11e4-907d-d050992ecde8.html
 	}{
 		{
 			in: `vulnxml file up-to-date
-go-1.17.1,1 is vulnerable:
+libxml2-2.9.10 is vulnerable:
+libxml -- multiple vulnerabilities
+WWW: https://vuxml.FreeBSD.org/freebsd/f5abafc0-fcf6-11ea-8758-e0d55e2a8bf9.html`,
+			name:   "libxml2",
+			cveIDs: []string{},
+			vulnID: "f5abafc0-fcf6-11ea-8758-e0d55e2a8bf9",
+		},
+		{
+			in: `libxml2 -- Possible denial of service
+CVE: CVE-2021-3541
+WWW: https://vuxml.FreeBSD.org/freebsd/524bd03a-bb75-11eb-bf35-080027f515ea.html`,
+			name:   "",
+			cveIDs: []string{"CVE-2021-3541"},
+			vulnID: "524bd03a-bb75-11eb-bf35-080027f515ea",
+		},
+		{
+			in: `go-1.17.1,1 is vulnerable:
 go -- multiple vulnerabilities
 CVE: CVE-2021-41772
 CVE: CVE-2021-41771
@@ -222,11 +238,6 @@ WWW: https://vuxml.FreeBSD.org/freebsd/4fce9635-28c0-11ec-9ba8-002324b2fba8.html
 			name:   "",
 			cveIDs: []string{"CVE-2021-38297"},
 			vulnID: "4fce9635-28c0-11ec-9ba8-002324b2fba8",
-		},
-		{
-			in:     `2 problem(s) in 1 installed package(s) found.`,
-			cveIDs: []string{},
-			vulnID: "",
 		},
 	}
 

--- a/scanner/freebsd_test.go
+++ b/scanner/freebsd_test.go
@@ -196,6 +196,54 @@ WWW: https://vuxml.FreeBSD.org/freebsd/ab3e98d9-8175-11e4-907d-d050992ecde8.html
 			t.Errorf("expected vulnID: %s, actual %s", tt.vulnID, aVulnID)
 		}
 	}
+
+	// alternative outputs
+	tests = []struct {
+		in     string
+		name   string
+		cveIDs []string
+		vulnID string
+	}{
+		{
+			in: `vulnxml file up-to-date
+go-1.17.1,1 is vulnerable:
+go -- multiple vulnerabilities
+CVE: CVE-2021-41772
+CVE: CVE-2021-41771
+WWW: https://vuxml.FreeBSD.org/freebsd/930def19-3e05-11ec-9ba8-002324b2fba8.html`,
+			name:   "go",
+			cveIDs: []string{"CVE-2021-41772", "CVE-2021-41771"},
+			vulnID: "930def19-3e05-11ec-9ba8-002324b2fba8",
+		},
+		{
+			in: `go -- misc/wasm, cmd/link: do not let command line arguments overwrite global data
+CVE: CVE-2021-38297
+WWW: https://vuxml.FreeBSD.org/freebsd/4fce9635-28c0-11ec-9ba8-002324b2fba8.html`,
+			name:   "",
+			cveIDs: []string{"CVE-2021-38297"},
+			vulnID: "4fce9635-28c0-11ec-9ba8-002324b2fba8",
+		},
+		{
+			in:     `2 problem(s) in 1 installed package(s) found.`,
+			cveIDs: []string{},
+			vulnID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		aName, aCveIDs, aVulnID := d.parseBlock(tt.in)
+		if tt.name != aName {
+			t.Errorf("expected vulnID: %s, actual %s", tt.vulnID, aVulnID)
+		}
+		for i := range tt.cveIDs {
+			if tt.cveIDs[i] != aCveIDs[i] {
+				t.Errorf("expected cveID: %s, actual %s", tt.cveIDs[i], aCveIDs[i])
+			}
+		}
+		if tt.vulnID != aVulnID {
+			t.Errorf("expected vulnID: %s, actual %s", tt.vulnID, aVulnID)
+		}
+	}
 }
 
 func TestParsePkgInfo(t *testing.T) {

--- a/scanner/freebsd_test.go
+++ b/scanner/freebsd_test.go
@@ -135,16 +135,16 @@ CVE: CVE-2014-8500
 WWW: https://vuxml.FreeBSD.org/freebsd/ab3e98d9-8175-11e4-907d-d050992ecde8.html
 `,
 				`go-1.17.1,1 is vulnerable:
-  go -- multiple vulnerabilities
-  CVE: CVE-2021-41772
-  CVE: CVE-2021-41771
-  WWW: https://vuxml.FreeBSD.org/freebsd/930def19-3e05-11ec-9ba8-002324b2fba8.html
+go -- multiple vulnerabilities
+CVE: CVE-2021-41772
+CVE: CVE-2021-41771
+WWW: https://vuxml.FreeBSD.org/freebsd/930def19-3e05-11ec-9ba8-002324b2fba8.html
 
-  go -- misc/wasm, cmd/link: do not let command line arguments overwrite global data
-  CVE: CVE-2021-38297
-  WWW: https://vuxml.FreeBSD.org/freebsd/4fce9635-28c0-11ec-9ba8-002324b2fba8.html
+go -- misc/wasm, cmd/link: do not let command line arguments overwrite global data
+CVE: CVE-2021-38297
+WWW: https://vuxml.FreeBSD.org/freebsd/4fce9635-28c0-11ec-9ba8-002324b2fba8.html
 
-  Packages that depend on go: 
+Packages that depend on go:
 
 2 problem(s) in 1 installed package(s) found.`},
 		},


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

fix scanUnsecurePackages for FreeBSD pkg audit output change

Fixes # (issue)

```
$ vuls scan
[Nov 16 13:47:51]  INFO [localhost] Start scanning
[Nov 16 13:47:51]  INFO [localhost] config: /usr/local/etc/vuls/config.toml
[Nov 16 13:47:51]  INFO [localhost] Validating config...
[Nov 16 13:47:51]  INFO [localhost] Detecting Server/Container OS... 
[Nov 16 13:47:51]  INFO [localhost] Detecting OS of servers... 
[Nov 16 13:47:51]  INFO [localhost] (1/1) Detected: localhost: freebsd 13.0-RELEASE-p5
[Nov 16 13:47:51]  INFO [localhost] Detecting OS of containers... 
[Nov 16 13:47:51]  INFO [localhost] Checking Scan Modes... 
[Nov 16 13:47:51]  INFO [localhost] Detecting Platforms... 
[Nov 16 13:47:52]  INFO [localhost] (1/1) localhost is running on other
[Nov 16 13:47:52]  INFO [localhost] Detecting IPS identifiers... 
[Nov 16 13:47:52]  INFO [localhost] (1/1) localhost has 0 IPS integration
[Nov 16 13:47:52]  INFO [localhost] Scanning vulnerabilities... 
[Nov 16 13:47:52]  INFO [localhost] Scanning vulnerable OS packages...
[Nov 16 13:47:52]  INFO [localhost] Scanning in fast mode
[Nov 16 13:47:56] ERROR [localhost] Failed to scan vulnerable packages: Vulnerable package:  is not found
[Nov 16 13:47:56] ERROR [localhost] Error on localhost, err: [Vulnerable package:  is not found:
    github.com/future-architect/vuls/scan.(*bsd).scanUnsecurePackages
        github.com/future-architect/vuls/scan/freebsd.go:213]
```

pkg audit output

```
$ pkg -v  
1.17.2

$ pkg audit -F -r -f /tmp/vuln.db
vulnxml file up-to-date
go-1.17.1,1 is vulnerable:
  go -- multiple vulnerabilities
  CVE: CVE-2021-41772
  CVE: CVE-2021-41771
  WWW: https://vuxml.FreeBSD.org/freebsd/930def19-3e05-11ec-9ba8-002324b2fba8.html

  go -- misc/wasm, cmd/link: do not let command line arguments overwrite global data
  CVE: CVE-2021-38297
  WWW: https://vuxml.FreeBSD.org/freebsd/4fce9635-28c0-11ec-9ba8-002324b2fba8.html

  Packages that depend on go: 

2 problem(s) in 1 installed package(s) found.
```

## Type of change

Please delete options that are not relevant.

- [*] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [*] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

