### PR TITLE
fix(detector/ospkg): Skip OVAL/gost search when the number of packages is 0

### DIFF
--- a/detector/util.go
+++ b/detector/util.go
@@ -26,10 +26,7 @@ func reuseScannedCves(r *models.ScanResult) bool {
 	case constant.FreeBSD, constant.Raspbian:
 		return true
 	}
-	if isTrivyResult(r) {
-		return true
-	}
-	return false
+	return isTrivyResult(r)
 }
 
 func isTrivyResult(r *models.ScanResult) bool {

--- a/models/scanresults.go
+++ b/models/scanresults.go
@@ -309,7 +309,6 @@ func (r ScanResult) RemoveRaspbianPackFromResult() *ScanResult {
 	for _, pack := range r.SrcPackages {
 		if !IsRaspbianPackage(pack.Name, pack.Version) {
 			srcPacks[pack.Name] = pack
-
 		}
 	}
 


### PR DESCRIPTION
# What did you implement:
skip OVAL/gost search when the number of packages is 0.

Fixes #1342 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
$ cat config.toml
...
[servers]

[servers.localhost]
host                = "localhost"
port               = "local"
user               = "mainek00n"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["/home/mainek00n/Downloads/lockfiles/log4j-core-2.14.1.jar"]
...

$ vuls scan
[Dec 14 17:29:58]  INFO [localhost] vuls-v0.19.0-build-20211214_172301_a01f9c9
[Dec 14 17:29:58]  INFO [localhost] Start scanning
[Dec 14 17:29:58]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Dec 14 17:29:58]  INFO [localhost] Validating config...
[Dec 14 17:29:58]  INFO [localhost] Detecting Server/Container OS... 
[Dec 14 17:29:58]  INFO [localhost] Detecting OS of servers... 
[Dec 14 17:29:58]  INFO [localhost] (1/1) Detected: localhost: ubuntu 20.04
[Dec 14 17:29:58]  INFO [localhost] Detecting OS of containers... 
[Dec 14 17:29:58]  INFO [localhost] Checking Scan Modes... 
[Dec 14 17:29:58]  INFO [localhost] Detecting Platforms... 
[Dec 14 17:29:59]  INFO [localhost] (1/1) localhost is running on other
[Dec 14 17:29:59]  INFO [localhost] Scanning Lockfile...
2021-12-14T17:29:59.318+0900	DEBUG	jar/parse.go:90	Parsing Java artifacts...	{"file": "/home/mainek00n/Downloads/lockfiles/log4j-core-2.14.1.jar"}


Scan Summary
================
localhost	ubuntu20.04	0 installed	1 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ vuls report 
[Dec 14 17:30:15]  INFO [localhost] vuls-v0.19.0-build-20211214_172301_a01f9c9
[Dec 14 17:30:15]  INFO [localhost] Validating config...
[Dec 14 17:30:15]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Dec 14 17:30:15]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/usr/share/vuls-data/oval.sqlite3
[Dec 14 17:30:15]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/usr/share/vuls-data/gost.sqlite3
[Dec 14 17:30:15]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Dec 14 17:30:15]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Dec 14 17:30:15]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/usr/share/vuls-data/go-kev.sqlite3
[Dec 14 17:30:15]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2021-12-14T17:29:59+09:00
[Dec 14 17:30:15]  INFO [localhost] Updating library db...
[Dec 14 17:30:15]  INFO [localhost] localhost: 1 CVEs are detected with Library
[Dec 14 17:30:15]  INFO [localhost] Number of packages is 0. Skip OVAL and gost detection
[Dec 14 17:30:15]  INFO [localhost] localhost: 0 CVEs are detected with CPE
[Dec 14 17:30:15]  INFO [localhost] localhost: 0 PoC are detected
[Dec 14 17:30:15]  INFO [localhost] localhost: 0 exploits are detected
[Dec 14 17:30:15]  INFO [localhost] localhost: total 1 CVEs detected
[Dec 14 17:30:15]  INFO [localhost] localhost: 0 CVEs filtered by --confidence-over=80
localhost (ubuntu20.04)
=======================
Total: 1 (Critical:1 High:0 Medium:0 Low:0 ?:0)
1/1 Fixed, 0 poc, 0 exploits, cisa: 1, uscert: 0, jpcert: 0 alerts
0 installed, 1 libs

+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |                       NVD                       |
+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
| CVE-2021-44228 | 10.0 |        |     |      CISA |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-44228 |
+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

