### PR TITLE
fix getting wp core version string via ssh

### DIFF
--- a/scanner/base.go
+++ b/scanner/base.go
@@ -707,9 +707,10 @@ func (l *base) scanWordPress() error {
 		return nil
 	}
 	l.log.Info("Scanning WordPress...")
-	cmd := fmt.Sprintf("sudo -u %s -i -- %s cli version --allow-root",
+	cmd := fmt.Sprintf("sudo -u %s -i -- %s core version --path=%s --allow-root",
 		l.ServerInfo.WordPress.OSUser,
-		l.ServerInfo.WordPress.CmdPath)
+		l.ServerInfo.WordPress.CmdPath,
+		l.ServerInfo.WordPress.DocRoot)
 	if r := exec(l.ServerInfo, cmd, noSudo); !r.isSuccess() {
 		return xerrors.Errorf("Failed to exec `%s`. Check the OS user, command path of wp-cli, DocRoot and permission: %#v", cmd, l.ServerInfo.WordPress)
 	}

--- a/scanner/base.go
+++ b/scanner/base.go
@@ -751,7 +751,7 @@ func (l *base) detectWordPress() (*models.WordPressPackages, error) {
 }
 
 func (l *base) detectWpCore() (string, error) {
-	cmd := fmt.Sprintf("sudo -u %s -i -- %s core version --path=%s --allow-root",
+	cmd := fmt.Sprintf("sudo -u %s -i -- %s core version --path=%s --allow-root 2>/dev/null",
 		l.ServerInfo.WordPress.OSUser,
 		l.ServerInfo.WordPress.CmdPath,
 		l.ServerInfo.WordPress.DocRoot)


### PR DESCRIPTION
Fix getting wp core version string via ssh.

Fixes # (issue)

Expected: "5.7.4"
Actual:  "sudo: unable to resolve host ubuntu\n5.7.4"

```
config.toml

[servers.ubuntu]
host        = "192.0.2.1"
port        = "22"
user        = "vuls"
keyPath     = "/var/db/vuls/.ssh/id_rsa"
scanModules = ["wordpress"]

[servers.ubuntu.wordpress]
cmdPath     = "/usr/local/bin/wp"
osUser      = "vuls"
docRoot     = "/var/www/html"
```

```
$ vuls scan ubuntu

$ cat results/current/ubuntu.json
...
    "WordPressPackages": [
        {
            "name": "core",
            "version": "sudo: unable to resolve host ubuntu\n5.7.4",
            "type": "core"
        },
```

scan in debug mode

```
$ vuls scan -debug  ubuntu
...
[Dec 16 21:26:28] DEBUG [localhost] Executing... sudo -u vuls -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root
[Dec 16 21:26:28] DEBUG [localhost] execResult: servername: ubuntu
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/var/db/vuls/.vuls/controlmaster-%r-ubuntu.%p -o Controlpersist=10m vuls@192.0.2.1 -p 22 -i /var/db/vuls/.ssh/id_rsa -o PasswordAuthentication=no stty cols 1000; sudo -u vuls -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root
  exitstatus: 0
  stdout: sudo: unable to resolve host ubuntu
5.7.4

  stderr: 
  err: %!s(<nil>)
```

This is caused by ssh `-t` option.

see https://stackoverflow.com/a/41797019
>Using a pty has a notable side effect: stdout and stderr are combined and both reported via stdout

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

