### PR TITLE
fix(centos): identify CentOS and CentOS Stream

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -300,11 +300,17 @@ func (l Distro) String() string {
 
 // MajorVersion returns Major version
 func (l Distro) MajorVersion() (int, error) {
-	if l.Family == constant.Amazon {
+	switch l.Family {
+	case constant.Amazon:
 		return strconv.Atoi(getAmazonLinuxVersion(l.Release))
-	}
-	if 0 < len(l.Release) {
-		return strconv.Atoi(strings.Split(l.Release, ".")[0])
+	case constant.CentOS:
+		if 0 < len(l.Release) {
+			return strconv.Atoi(strings.Split(strings.TrimPrefix(l.Release, "stream"), ".")[0])
+		}
+	default:
+		if 0 < len(l.Release) {
+			return strconv.Atoi(strings.Split(l.Release, ".")[0])
+		}
 	}
 	return 0, xerrors.New("Release is empty")
 }

--- a/config/os.go
+++ b/config/os.go
@@ -63,14 +63,14 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 		}[major(release)]
 	case constant.CentOS:
 		// https://en.wikipedia.org/wiki/CentOS#End-of-support_schedule
-		// TODO Stream
 		eol, found = map[string]EOL{
-			"3": {Ended: true},
-			"4": {Ended: true},
-			"5": {Ended: true},
-			"6": {Ended: true},
-			"7": {StandardSupportUntil: time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC)},
-			"8": {StandardSupportUntil: time.Date(2021, 12, 31, 23, 59, 59, 0, time.UTC)},
+			"3":       {Ended: true},
+			"4":       {Ended: true},
+			"5":       {Ended: true},
+			"6":       {Ended: true},
+			"7":       {StandardSupportUntil: time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC)},
+			"8":       {StandardSupportUntil: time.Date(2021, 12, 31, 23, 59, 59, 0, time.UTC)},
+			"stream8": {StandardSupportUntil: time.Date(2024, 5, 31, 23, 59, 59, 0, time.UTC)},
 		}[major(release)]
 	case constant.Alma:
 		eol, found = map[string]EOL{

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -1833,8 +1833,8 @@ func Test_rhelDownStreamOSVersionToRHEL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := rhelDownStreamOSVersionToRHEL(tt.args.ver); got != tt.want {
-				t.Errorf("rhelDownStreamOSVersionToRHEL() = %v, want %v", got, tt.want)
+			if got := rhelRebuildOSVersionToRHEL(tt.args.ver); got != tt.want {
+				t.Errorf("rhelRebuildOSVersionToRHEL() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -54,14 +54,14 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 
 			release := result[2]
 			switch strings.ToLower(result[1]) {
-			case "centos", "centos linux", "centos stream":
+			case "centos", "centos linux":
 				cent := newCentOS(c)
 				cent.setDistro(constant.CentOS, release)
 				return true, cent
-			case "alma", "almalinux":
-				alma := newAlma(c)
-				alma.setDistro(constant.Alma, release)
-				return true, alma
+			case "centos stream":
+				cent := newCentOS(c)
+				cent.setDistro(constant.CentOS, fmt.Sprintf("stream%s", release))
+				return true, cent
 			default:
 				logging.Log.Warnf("Failed to parse CentOS: %s", r)
 			}
@@ -125,9 +125,13 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 
 			release := result[2]
 			switch strings.ToLower(result[1]) {
-			case "centos", "centos linux", "centos stream":
+			case "centos", "centos linux":
 				cent := newCentOS(c)
 				cent.setDistro(constant.CentOS, release)
+				return true, cent
+			case "centos stream":
+				cent := newCentOS(c)
+				cent.setDistro(constant.CentOS, fmt.Sprintf("stream%s", release))
 				return true, cent
 			case "alma", "almalinux":
 				alma := newAlma(c)
@@ -515,7 +519,7 @@ func (o *redhatBase) isExecNeedsRestarting() bool {
 		// TODO zypper ps
 		// https://github.com/future-architect/vuls/issues/696
 		return false
-	case constant.RedHat, constant.CentOS, constant.Rocky, constant.Oracle:
+	case constant.RedHat, constant.CentOS, constant.Alma, constant.Rocky, constant.Oracle:
 		majorVersion, err := o.Distro.MajorVersion()
 		if err != nil || majorVersion < 6 {
 			o.log.Errorf("Not implemented yet: %s, err: %+v", o.Distro, err)


### PR DESCRIPTION
# What did you implement:
CentOS8 and CentOS Stream8 use the same OVAL and Gost (RedHat Security API), but the EOL is different.
Currently, EOL of CentOS8 is also set for CentOS Stream8, and WARN is output. Fix this.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## master
```console
$ vuls scan
[Jan 14 13:46:55]  INFO [localhost] vuls-v0.19.1-build-20220114_134430_a3f7d1d
[Jan 14 13:46:55]  INFO [localhost] Start scanning
[Jan 14 13:46:55]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Jan 14 13:46:55]  INFO [localhost] Validating config...
[Jan 14 13:46:55]  INFO [localhost] Detecting Server/Container OS... 
[Jan 14 13:46:55]  INFO [localhost] Detecting OS of servers... 
[Jan 14 13:46:56]  INFO [localhost] (1/1) Detected: vuls-target: centos 8
[Jan 14 13:46:56]  INFO [localhost] Detecting OS of containers... 
[Jan 14 13:46:56]  INFO [localhost] Checking Scan Modes... 
[Jan 14 13:46:56]  INFO [localhost] Detecting Platforms... 
[Jan 14 13:46:57]  INFO [localhost] (1/1) vuls-target is running on other
[Jan 14 13:46:57]  INFO [vuls-target] Scanning OS pkg in fast mode
[Jan 14 13:47:02]  WARN [localhost] Some warnings occurred during scanning on vuls-target. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Standard OS support is EOL(End-of-Life). Purchase extended support if available or Upgrading your OS is strongly recommended.]


Scan Summary
================
vuls-target	centos8	207 installed, 52 updatable

Warning: [Standard OS support is EOL(End-of-Life). Purchase extended support if available or Upgrading your OS is strongly recommended.]



To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
$ vuls report
[Jan 14 13:48:18]  INFO [localhost] vuls-v0.19.1-build-20220114_134430_a3f7d1d
[Jan 14 13:48:18]  INFO [localhost] Validating config...
[Jan 14 13:48:18]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Jan 14 13:48:18]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/usr/share/vuls-data/oval.sqlite3
[Jan 14 13:48:18]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/usr/share/vuls-data/gost.sqlite3
[Jan 14 13:48:18]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Jan 14 13:48:18]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Jan 14 13:48:18]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/usr/share/vuls-data/go-kev.sqlite3
[Jan 14 13:48:18]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2022-01-14T13:48:07+09:00
[Jan 14 13:48:18]  INFO [localhost] OVAL centos 8 found. defs: 791
[Jan 14 13:48:18]  INFO [localhost] OVAL centos 8 is fresh. lastModified: 2022-01-13T11:14:28+09:00
[Jan 14 13:48:18]  INFO [localhost] vuls-target: 2 CVEs are detected with OVAL
[Jan 14 13:48:18]  INFO [localhost] vuls-target: 14 unfixed CVEs are detected with gost
[Jan 14 13:48:18]  INFO [localhost] vuls-target: 0 CVEs are detected with CPE
[Jan 14 13:48:18]  INFO [localhost] vuls-target: 0 PoC are detected
[Jan 14 13:48:18]  INFO [localhost] vuls-target: 0 exploits are detected
[Jan 14 13:48:18]  INFO [localhost] vuls-target: total 16 CVEs detected
[Jan 14 13:48:18]  INFO [localhost] vuls-target: 0 CVEs filtered by --confidence-over=80
vuls-target (centos8)
=====================
Total: 16 (Critical:1 High:4 Medium:11 Low:0 ?:0)
2/16 Fixed, 3 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 1 alerts
207 installed

Warning: Some warnings occurred.
[Standard OS support is EOL(End-of-Life). Purchase extended support if available or Upgrading your OS is strongly recommended.]


+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |                       NVD                       |
+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
| CVE-2021-42574 |  9.8 |  AV:N  | POC |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-42574 |
| CVE-2021-3999  |  8.1 |  AV:N  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3999  |
| CVE-2021-43618 |  7.5 |  AV:L  | POC |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-43618 |
| CVE-2021-3712  |  7.4 |  AV:N  |     |      CERT |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3712  |
| CVE-2021-41617 |  7.0 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-41617 |
| CVE-2021-23177 |  6.6 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-23177 |
| CVE-2017-14166 |  6.5 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2017-14166 |
| CVE-2017-14501 |  6.5 |  AV:N  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2017-14501 |
| CVE-2021-35938 |  6.5 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-35938 |
| CVE-2021-35939 |  6.5 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-35939 |
| CVE-2021-3634  |  6.5 |  AV:N  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3634  |
| CVE-2021-35937 |  6.3 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-35937 |
| CVE-2021-40528 |  5.9 |  AV:N  | POC |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-40528 |
| CVE-2021-3997  |  5.5 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3997  |
| CVE-2021-31566 |  4.4 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-31566 |
| CVE-2021-3521  |  4.4 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3521  |
+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
```

## PR
```console
$ vuls scan
[Jan 14 13:47:24]  INFO [localhost] vuls-v0.19.1-build-20220114_134453_66c0acb
[Jan 14 13:47:24]  INFO [localhost] Start scanning
[Jan 14 13:47:24]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Jan 14 13:47:24]  INFO [localhost] Validating config...
[Jan 14 13:47:24]  INFO [localhost] Detecting Server/Container OS... 
[Jan 14 13:47:24]  INFO [localhost] Detecting OS of servers... 
[Jan 14 13:47:24]  INFO [localhost] (1/1) Detected: vuls-target: centos stream8
[Jan 14 13:47:24]  INFO [localhost] Detecting OS of containers... 
[Jan 14 13:47:24]  INFO [localhost] Checking Scan Modes... 
[Jan 14 13:47:24]  INFO [localhost] Detecting Platforms... 
[Jan 14 13:47:25]  INFO [localhost] (1/1) vuls-target is running on other
[Jan 14 13:47:25]  INFO [vuls-target] Scanning OS pkg in fast mode


Scan Summary
================
vuls-target	centosstream8	207 installed, 52 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ vuls report
[Jan 14 13:49:34]  INFO [localhost] vuls-v0.19.1-build-20220114_134453_66c0acb
[Jan 14 13:49:34]  INFO [localhost] Validating config...
[Jan 14 13:49:34]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Jan 14 13:49:34]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/usr/share/vuls-data/oval.sqlite3
[Jan 14 13:49:34]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/usr/share/vuls-data/gost.sqlite3
[Jan 14 13:49:34]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Jan 14 13:49:34]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Jan 14 13:49:34]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/usr/share/vuls-data/go-kev.sqlite3
[Jan 14 13:49:34]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2022-01-14T13:49:24+09:00
[Jan 14 13:49:34]  INFO [localhost] OVAL redhat 8 found. defs: 791
[Jan 14 13:49:34]  INFO [localhost] OVAL redhat 8 is fresh. lastModified: 2022-01-13T11:14:28+09:00
[Jan 14 13:49:35]  INFO [localhost] vuls-target: 2 CVEs are detected with OVAL
[Jan 14 13:49:35]  INFO [localhost] vuls-target: 14 unfixed CVEs are detected with gost
[Jan 14 13:49:35]  INFO [localhost] vuls-target: 0 CVEs are detected with CPE
[Jan 14 13:49:35]  INFO [localhost] vuls-target: 0 PoC are detected
[Jan 14 13:49:35]  INFO [localhost] vuls-target: 0 exploits are detected
[Jan 14 13:49:35]  INFO [localhost] vuls-target: total 16 CVEs detected
[Jan 14 13:49:35]  INFO [localhost] vuls-target: 0 CVEs filtered by --confidence-over=80
vuls-target (centosstream8)
===========================
Total: 16 (Critical:1 High:4 Medium:11 Low:0 ?:0)
2/16 Fixed, 3 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 1 alerts
207 installed

+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |                       NVD                       |
+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
| CVE-2021-42574 |  9.8 |  AV:N  | POC |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-42574 |
| CVE-2021-3999  |  8.1 |  AV:N  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3999  |
| CVE-2021-43618 |  7.5 |  AV:L  | POC |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-43618 |
| CVE-2021-3712  |  7.4 |  AV:N  |     |      CERT |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3712  |
| CVE-2021-41617 |  7.0 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-41617 |
| CVE-2021-23177 |  6.6 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-23177 |
| CVE-2017-14166 |  6.5 |  AV:N  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2017-14166 |
| CVE-2017-14501 |  6.5 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2017-14501 |
| CVE-2021-35938 |  6.5 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-35938 |
| CVE-2021-35939 |  6.5 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-35939 |
| CVE-2021-3634  |  6.5 |  AV:N  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3634  |
| CVE-2021-35937 |  6.3 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-35937 |
| CVE-2021-40528 |  5.9 |  AV:N  | POC |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-40528 |
| CVE-2021-3997  |  5.5 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3997  |
| CVE-2021-31566 |  4.4 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-31566 |
| CVE-2021-3521  |  4.4 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3521  |
+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

