### PR TITLE
fix(gost): add nil check

### DIFF
--- a/gost/gost.go
+++ b/gost/gost.go
@@ -47,8 +47,10 @@ func FillCVEsWithRedHat(r *models.ScanResult, cnf config.GostConf) error {
 		return err
 	}
 	defer func() {
-		if err := db.CloseDB(); err != nil {
-			logging.Log.Errorf("Failed to close DB. err: %+v", err)
+		if db != nil {
+			if err := db.CloseDB(); err != nil {
+				logging.Log.Errorf("Failed to close DB. err: %+v", err)
+			}
 		}
 	}()
 	return RedHat{Base{DBDriver{DB: db, Cnf: &cnf}}}.fillCvesWithRedHatAPI(r)


### PR DESCRIPTION
# What did you implement:
`newGostDB` returns db as nil in HTTP mode. 
https://github.com/future-architect/vuls/blob/ffdb78962f9bc96df527bb468ed3d5856337a395/gost/gost.go#L83-L86

It seems to dereference the nil pointer at the time of `db.Close()`.
https://github.com/future-architect/vuls/blob/ffdb78962f9bc96df527bb468ed3d5856337a395/gost/gost.go#L50

Fixes https://github.com/future-architect/vuls/issues/1281

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
$ vuls.master report --refresh-cve
[Feb  2 20:04:19]  INFO [localhost] vuls-v0.19.2-build-20220128_200342_b4c23c1
[Feb  2 20:04:19]  INFO [localhost] Validating config...
[Feb  2 20:04:19]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Feb  2 20:04:19]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/usr/share/vuls-data/oval.sqlite3
[Feb  2 20:04:19]  INFO [localhost] gost.type=http, gost.url=http://127.0.0.1:1325, gost.SQLite3Path=
[Feb  2 20:04:19]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Feb  2 20:04:19]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Feb  2 20:04:19]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/usr/share/vuls-data/go-kev.sqlite3
[Feb  2 20:04:19]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2022-02-02T20:04:19+09:00
[Feb  2 20:04:19]  INFO [localhost] OVAL ubuntu 20.04 found. defs: 9552
[Feb  2 20:04:19]  INFO [localhost] OVAL ubuntu 20.04 is fresh. lastModified: 2022-02-02T20:03:18+09:00
[Feb  2 20:04:19]  WARN [localhost] The OVAL name of the running kernel image {Release:5.13.0-27-generic Version: RebootRequired:false} is not found. So vulns of `linux` wll be detected. server: localhost
[Feb  2 20:04:22]  INFO [localhost] localhost: 396 CVEs are detected with OVAL
[Feb  2 20:04:29]  INFO [localhost] localhost: 16 unfixed CVEs are detected with gost
[Feb  2 20:04:29]  INFO [localhost] localhost: 0 CVEs are detected with CPE
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x10fb5bc]

goroutine 1 [running]:
github.com/future-architect/vuls/gost.FillCVEsWithRedHat.func1()
	/home/mainek00n/go/src/github.com/future-architect/vuls/gost/gost.go:50 +0x1c
github.com/future-architect/vuls/gost.FillCVEsWithRedHat(0x0, {{{0x15f6648, 0x4}, {0xc0004cf328, 0x4}, {0xc000144270, 0x15}, {0x0, 0x0}, 0x0}})
	/home/mainek00n/go/src/github.com/future-architect/vuls/gost/gost.go:54 +0x190
github.com/future-architect/vuls/detector.Detect({0xc000649300, 0x1, 0x1}, {0xc00075fce0, 0x52})
	/home/mainek00n/go/src/github.com/future-architect/vuls/detector/detector.go:94 +0x163c
github.com/future-architect/vuls/subcmds.(*ReportCmd).Execute(0xc00064e840, {0xc000132010, 0xc00073fea0}, 0xc000467440, {0x1, 0x138eee0, 0x1})
	/home/mainek00n/go/src/github.com/future-architect/vuls/subcmds/report.go:246 +0x7dd
github.com/google/subcommands.(*Commander).Execute(0xc00016f800, {0x198cb30, 0xc000134000}, {0x0, 0x0, 0x0})
	/home/mainek00n/go/pkg/mod/github.com/google/subcommands@v1.2.0/subcommands.go:209 +0x3bc
github.com/google/subcommands.Execute(...)
	/home/mainek00n/go/pkg/mod/github.com/google/subcommands@v1.2.0/subcommands.go:492
main.main()
	/home/mainek00n/go/src/github.com/future-architect/vuls/cmd/vuls/main.go:37 +0x2f7

$ vuls.pr report --refresh-cve
[Feb  2 20:04:34]  INFO [localhost] vuls-v0.19.2-build-20220202_200052_84fa4ce
[Feb  2 20:04:34]  INFO [localhost] Validating config...
[Feb  2 20:04:34]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Feb  2 20:04:34]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/usr/share/vuls-data/oval.sqlite3
[Feb  2 20:04:34]  INFO [localhost] gost.type=http, gost.url=http://127.0.0.1:1325, gost.SQLite3Path=
[Feb  2 20:04:34]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Feb  2 20:04:34]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Feb  2 20:04:34]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/usr/share/vuls-data/go-kev.sqlite3
[Feb  2 20:04:34]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2022-02-02T20:04:19+09:00
[Feb  2 20:04:34]  INFO [localhost] OVAL ubuntu 20.04 found. defs: 9552
[Feb  2 20:04:34]  INFO [localhost] OVAL ubuntu 20.04 is fresh. lastModified: 2022-02-02T20:03:18+09:00
[Feb  2 20:04:34]  WARN [localhost] The OVAL name of the running kernel image {Release:5.13.0-27-generic Version: RebootRequired:false} is not found. So vulns of `linux` wll be detected. server: localhost
[Feb  2 20:04:37]  INFO [localhost] localhost: 396 CVEs are detected with OVAL
[Feb  2 20:04:42]  INFO [localhost] localhost: 16 unfixed CVEs are detected with gost
[Feb  2 20:04:42]  INFO [localhost] localhost: 0 CVEs are detected with CPE
[Feb  2 20:04:44]  INFO [localhost] localhost: 4 PoC are detected
[Feb  2 20:04:44]  INFO [localhost] localhost: 1 exploits are detected
[Feb  2 20:04:44]  INFO [localhost] localhost: total 412 CVEs detected
[Feb  2 20:04:44]  INFO [localhost] localhost: 0 CVEs filtered by --confidence-over=80
localhost (ubuntu20.04)
=======================
Total: 412 (Critical:24 High:115 Medium:222 Low:42 ?:9)
2/412 Fixed, 47 poc, 1 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
2763 installed
...
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference
