### PR TITLE
feat(scanner/redhat): each package has modularitylabel

### DIFF
--- a/models/packages.go
+++ b/models/packages.go
@@ -82,6 +82,7 @@ type Package struct {
 	NewRelease       string               `json:"newRelease"`
 	Arch             string               `json:"arch"`
 	Repository       string               `json:"repository"`
+	ModularityLabel  string               `json:"modularitylabel"`
 	Changelog        *Changelog           `json:"changelog,omitempty"`
 	AffectedProcs    []AffectedProcess    `json:",omitempty"`
 	NeedRestartProcs []NeedRestartProcess `json:",omitempty"`

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -1573,6 +1573,29 @@ func TestIsOvalDefAffected(t *testing.T) {
 			notFixedYet: false,
 			fixedIn:     "1.16.1-1.module+el8.3.0+8844+e5e7039f.1",
 		},
+		{
+			in: in{
+				family: constant.RedHat,
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:            "nginx",
+							Version:         "1.16.1-1.module+el8.3.0+8844+e5e7039f.1",
+							NotFixedYet:     false,
+							ModularityLabel: "nginx:1.16",
+						},
+					},
+				},
+				req: request{
+					packName:        "nginx",
+					versionRelease:  "1.16.0-1.module+el8.3.0+8844+e5e7039f.1",
+					modularityLabel: "nginx:1.16:version:context",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+			fixedIn:     "1.16.1-1.module+el8.3.0+8844+e5e7039f.1",
+		},
 		// dnf module 2
 		{
 			in: in{
@@ -1598,6 +1621,28 @@ func TestIsOvalDefAffected(t *testing.T) {
 			affected:    false,
 			notFixedYet: false,
 		},
+		{
+			in: in{
+				family: constant.RedHat,
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:            "nginx",
+							Version:         "1.16.1-1.module+el8.3.0+8844+e5e7039f.1",
+							NotFixedYet:     false,
+							ModularityLabel: "nginx:1.16",
+						},
+					},
+				},
+				req: request{
+					packName:        "nginx",
+					versionRelease:  "1.16.2-1.module+el8.3.0+8844+e5e7039f.1",
+					modularityLabel: "nginx:1.16:version:context",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
 		// dnf module 3
 		{
 			in: in{
@@ -1618,6 +1663,28 @@ func TestIsOvalDefAffected(t *testing.T) {
 				},
 				mods: []string{
 					"nginx:1.14",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: constant.RedHat,
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:            "nginx",
+							Version:         "1.16.1-1.module+el8.3.0+8844+e5e7039f.1",
+							NotFixedYet:     false,
+							ModularityLabel: "nginx:1.16",
+						},
+					},
+				},
+				req: request{
+					packName:        "nginx",
+					versionRelease:  "1.16.0-1.module+el8.3.0+8844+e5e7039f.1",
+					modularityLabel: "nginx:1.14:version:context",
 				},
 			},
 			affected:    false,
@@ -1651,6 +1718,31 @@ func TestIsOvalDefAffected(t *testing.T) {
 			notFixedYet: false,
 			fixedIn:     "0:8.0.27-1.module_f35+13269+c9322734",
 		},
+		{
+			in: in{
+				family: constant.Fedora,
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:            "community-mysql",
+							Version:         "0:8.0.27-1.module_f35+13269+c9322734",
+							Arch:            "x86_64",
+							NotFixedYet:     false,
+							ModularityLabel: "mysql:8.0:3520211031142409:f27b74a8",
+						},
+					},
+				},
+				req: request{
+					packName:        "community-mysql",
+					arch:            "x86_64",
+					versionRelease:  "8.0.26-1.module_f35+12627+b26747dd",
+					modularityLabel: "mysql:8.0:version:context",
+				},
+			},
+			affected:    true,
+			notFixedYet: false,
+			fixedIn:     "0:8.0.27-1.module_f35+13269+c9322734",
+		},
 		// dnf module 5 (req is non-modular package, oval is modular package)
 		{
 			in: in{
@@ -1678,6 +1770,29 @@ func TestIsOvalDefAffected(t *testing.T) {
 			affected:    false,
 			notFixedYet: false,
 		},
+		{
+			in: in{
+				family: constant.Fedora,
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:            "community-mysql",
+							Version:         "0:8.0.27-1.module_f35+13269+c9322734",
+							Arch:            "x86_64",
+							NotFixedYet:     false,
+							ModularityLabel: "mysql:8.0:3520211031142409:f27b74a8",
+						},
+					},
+				},
+				req: request{
+					packName:       "community-mysql",
+					arch:           "x86_64",
+					versionRelease: "8.0.26-1.fc35",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
 		// dnf module 6 (req is modular package, oval is non-modular package)
 		{
 			in: in{
@@ -1700,6 +1815,30 @@ func TestIsOvalDefAffected(t *testing.T) {
 				},
 				mods: []string{
 					"mysql:8.0",
+				},
+			},
+			affected:    false,
+			notFixedYet: false,
+		},
+		{
+			in: in{
+				family: constant.Fedora,
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:            "community-mysql",
+							Version:         "0:8.0.27-1.fc35",
+							Arch:            "x86_64",
+							NotFixedYet:     false,
+							ModularityLabel: "",
+						},
+					},
+				},
+				req: request{
+					packName:        "community-mysql",
+					arch:            "x86_64",
+					versionRelease:  "8.0.26-1.module_f35+12627+b26747dd",
+					modularityLabel: "mysql:8.0:3520211031142409:f27b74a8",
 				},
 			},
 			affected:    false,
@@ -2140,6 +2279,43 @@ func TestIsOvalDefAffected(t *testing.T) {
 					arch:           "x86_64",
 				},
 				mods: []string{"nodejs:20"},
+			},
+			affected:    true,
+			notFixedYet: true,
+			fixState:    "Affected",
+			fixedIn:     "",
+		},
+		{
+			in: in{
+				family:  constant.RedHat,
+				release: "8",
+				def: ovalmodels.Definition{
+					Advisory: ovalmodels.Advisory{
+						AffectedResolution: []ovalmodels.Resolution{
+							{
+								State: "Affected",
+								Components: []ovalmodels.Component{
+									{
+										Component: "nodejs:20/nodejs",
+									},
+								},
+							},
+						},
+					},
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:            "nodejs",
+							NotFixedYet:     true,
+							ModularityLabel: "nodejs:20",
+						},
+					},
+				},
+				req: request{
+					packName:        "nodejs",
+					versionRelease:  "1:20.11.1-1.module+el8.9.0+21380+12032667",
+					modularityLabel: "nodejs:20:version:context",
+					arch:            "x86_64",
+				},
 			},
 			affected:    true,
 			notFixedYet: true,

--- a/scanner/base.go
+++ b/scanner/base.go
@@ -92,9 +92,6 @@ type osPackages struct {
 	// installed source packages (Debian based only)
 	SrcPackages models.SrcPackages
 
-	// enabled dnf modules or packages
-	EnabledDnfModules []string
-
 	// Detected Vulnerabilities Key: CVE-ID
 	VulnInfos models.VulnInfos
 
@@ -545,7 +542,6 @@ func (l *base) convertToModel() models.ScanResult {
 		RunningKernel:     l.Kernel,
 		Packages:          l.Packages,
 		SrcPackages:       l.SrcPackages,
-		EnabledDnfModules: l.EnabledDnfModules,
 		WordPressPackages: l.WordPress,
 		LibraryScanners:   l.LibraryScanners,
 		WindowsKB:         l.windowsKB,

--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -422,19 +422,6 @@ func (o *redhatBase) scanPackages() (err error) {
 		return xerrors.Errorf("Failed to scan installed packages: %w", err)
 	}
 
-	if !(o.getServerInfo().Mode.IsOffline() || (o.Distro.Family == constant.RedHat && o.getServerInfo().Mode.IsFast())) {
-		if err := o.yumMakeCache(); err != nil {
-			err = xerrors.Errorf("Failed to make repository cache: %w", err)
-			o.log.Warnf("err: %+v", err)
-			o.warns = append(o.warns, err)
-			// Only warning this error
-		}
-	}
-
-	if o.EnabledDnfModules, err = o.detectEnabledDnfModules(); err != nil {
-		return xerrors.Errorf("Failed to detect installed dnf modules: %w", err)
-	}
-
 	fn := func(pkgName string) execResult { return o.exec(fmt.Sprintf("rpm -q --last %s", pkgName), noSudo) }
 	o.Kernel.RebootRequired, err = o.rebootRequired(fn)
 	if err != nil {
@@ -520,6 +507,7 @@ func (o *redhatBase) parseInstalledPackages(stdout string) (models.Packages, mod
 	latestKernelRelease := ver.NewVersion("")
 
 	// openssl 0 1.0.1e	30.el6.11 x86_64
+	// community-mysql-common 0 8.0.26 1.module_f35+12627+b26747dd x86_64 mysql:8.0:3520210817160118:f27b74a8
 	lines := strings.Split(stdout, "\n")
 	for _, line := range lines {
 		if trimmed := strings.TrimSpace(line); trimmed == "" {
@@ -579,9 +567,8 @@ func (o *redhatBase) parseInstalledPackages(stdout string) (models.Packages, mod
 
 func (o *redhatBase) parseInstalledPackagesLine(line string) (*models.Package, error) {
 	fields := strings.Fields(line)
-	if len(fields) != 5 {
-		return nil,
-			xerrors.Errorf("Failed to parse package line: %s", line)
+	if len(fields) < 5 {
+		return nil, xerrors.Errorf("Failed to parse package line: %s", line)
 	}
 
 	ver := ""
@@ -592,11 +579,17 @@ func (o *redhatBase) parseInstalledPackagesLine(line string) (*models.Package, e
 		ver = fmt.Sprintf("%s:%s", epoch, fields[2])
 	}
 
+	modularitylabel := ""
+	if len(fields) == 6 && fields[5] != "(none)" {
+		modularitylabel = fields[5]
+	}
+
 	return &models.Package{
-		Name:    fields[0],
-		Version: ver,
-		Release: fields[3],
-		Arch:    fields[4],
+		Name:            fields[0],
+		Version:         ver,
+		Release:         fields[3],
+		Arch:            fields[4],
+		ModularityLabel: modularitylabel,
 	}, nil
 }
 
@@ -887,6 +880,7 @@ func (o *redhatBase) getOwnerPkgs(paths []string) (names []string, _ error) {
 func (o *redhatBase) rpmQa() string {
 	const old = `rpm -qa --queryformat "%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{ARCH}\n"`
 	const newer = `rpm -qa --queryformat "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH}\n"`
+	const modularity = `rpm -qa --queryformat "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH} %{MODULARITYLABEL}\n"`
 	switch o.Distro.Family {
 	case constant.OpenSUSE:
 		if o.Distro.Release == "tumbleweed" {
@@ -900,9 +894,25 @@ func (o *redhatBase) rpmQa() string {
 			return old
 		}
 		return newer
+	case constant.Fedora:
+		if v, _ := o.Distro.MajorVersion(); v < 30 {
+			return newer
+		}
+		return modularity
+	case constant.Amazon:
+		switch v, _ := o.Distro.MajorVersion(); v {
+		case 1, 2:
+			return newer
+		default:
+			return modularity
+		}
 	default:
-		if v, _ := o.Distro.MajorVersion(); v < 6 {
+		v, _ := o.Distro.MajorVersion()
+		if v < 6 {
 			return old
+		}
+		if v >= 8 {
+			return modularity
 		}
 		return newer
 	}
@@ -910,7 +920,8 @@ func (o *redhatBase) rpmQa() string {
 
 func (o *redhatBase) rpmQf() string {
 	const old = `rpm -qf --queryformat "%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{ARCH}\n" `
-	const newer = `rpm -qf --queryformat "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH}\n" `
+	const newer = `rpm -qf --queryformat "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH}\n"`
+	const modularity = `rpm -qf --queryformat "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH} %{MODULARITYLABEL}\n"`
 	switch o.Distro.Family {
 	case constant.OpenSUSE:
 		if o.Distro.Release == "tumbleweed" {
@@ -924,48 +935,26 @@ func (o *redhatBase) rpmQf() string {
 			return old
 		}
 		return newer
+	case constant.Fedora:
+		if v, _ := o.Distro.MajorVersion(); v < 30 {
+			return newer
+		}
+		return modularity
+	case constant.Amazon:
+		switch v, _ := o.Distro.MajorVersion(); v {
+		case 1, 2:
+			return newer
+		default:
+			return modularity
+		}
 	default:
-		if v, _ := o.Distro.MajorVersion(); v < 6 {
+		v, _ := o.Distro.MajorVersion()
+		if v < 6 {
 			return old
+		}
+		if v >= 8 {
+			return modularity
 		}
 		return newer
 	}
-}
-
-func (o *redhatBase) detectEnabledDnfModules() ([]string, error) {
-	switch o.Distro.Family {
-	case constant.RedHat, constant.CentOS, constant.Alma, constant.Rocky, constant.Fedora:
-		//TODO OracleLinux
-	default:
-		return nil, nil
-	}
-	if v, _ := o.Distro.MajorVersion(); v < 8 {
-		return nil, nil
-	}
-
-	cmd := `dnf --nogpgcheck --cacheonly --color=never --quiet module list --enabled`
-	r := o.exec(util.PrependProxyEnv(cmd), noSudo)
-	if !r.isSuccess() {
-		if strings.Contains(r.Stdout, "Cache-only enabled but no cache") {
-			return nil, xerrors.Errorf("sudo yum check-update to make local cache before scanning: %s", r)
-		}
-		return nil, xerrors.Errorf("Failed to dnf module list: %s", r)
-	}
-	return o.parseDnfModuleList(r.Stdout)
-}
-
-func (o *redhatBase) parseDnfModuleList(stdout string) (labels []string, err error) {
-	scanner := bufio.NewScanner(strings.NewReader(stdout))
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "Hint:") || !strings.Contains(line, "[i]") {
-			continue
-		}
-		ss := strings.Fields(line)
-		if len(ss) < 2 {
-			continue
-		}
-		labels = append(labels, fmt.Sprintf("%s:%s", ss[0], ss[1]))
-	}
-	return
 }

--- a/scanner/redhatbase_test.go
+++ b/scanner/redhatbase_test.go
@@ -223,6 +223,26 @@ func TestParseInstalledPackagesLine(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"community-mysql 0 8.0.26 1.module_f35+12627+b26747dd x86_64 mysql:8.0:3520210817160118:f27b74a8",
+			models.Package{
+				Name:            "community-mysql",
+				Version:         "8.0.26",
+				Release:         "1.module_f35+12627+b26747dd",
+				ModularityLabel: "mysql:8.0:3520210817160118:f27b74a8",
+			},
+			false,
+		},
+		{
+			"dnf-utils 0 4.0.24 1.fc35 noarch (none)",
+			models.Package{
+				Name:            "dnf-utils",
+				Version:         "4.0.24",
+				Release:         "1.fc35",
+				ModularityLabel: "",
+			},
+			false,
+		},
 	}
 
 	for i, tt := range packagetests {
@@ -241,6 +261,9 @@ func TestParseInstalledPackagesLine(t *testing.T) {
 		}
 		if p.Release != tt.pack.Release {
 			t.Errorf("release: expected %s, actual %s", tt.pack.Release, p.Release)
+		}
+		if p.ModularityLabel != tt.pack.ModularityLabel {
+			t.Errorf("modularitylabel: expected %s, actual %s", tt.pack.ModularityLabel, p.ModularityLabel)
 		}
 	}
 }
@@ -522,47 +545,6 @@ func TestParseNeedsRestarting(t *testing.T) {
 		if !reflect.DeepEqual(tt.out, procs) {
 			t.Errorf("expected %#v, actual %#v", tt.out, procs)
 		}
-	}
-}
-
-func Test_redhatBase_parseDnfModuleList(t *testing.T) {
-	type args struct {
-		stdout string
-	}
-	tests := []struct {
-		name       string
-		args       args
-		wantLabels []string
-		wantErr    bool
-	}{
-		{
-			name: "Success",
-			args: args{
-				stdout: `Red Hat Enterprise Linux 8 for x86_64 - AppStream from RHUI (RPMs)
-Name                                     Stream                                         Profiles                                          Summary
-virt                 rhel [d][e] common [d]                               Virtualization module
-nginx                                    1.14 [d][e]                                    common [d] [i]                                    nginx webserver
-
-Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled`,
-			},
-			wantLabels: []string{
-				"nginx:1.14",
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			o := &redhatBase{}
-			gotLabels, err := o.parseDnfModuleList(tt.args.stdout)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("redhatBase.parseDnfModuleList() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(gotLabels, tt.wantLabels) {
-				t.Errorf("redhatBase.parseDnfModuleList() = %v, want %v", gotLabels, tt.wantLabels)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
# What did you implement:
I think that instead of having a group of enable modules, each package should have a modularitylabel of the module it belongs to.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
[vagrant@rhel8 ~]$ cat /etc/os-release 
NAME="Red Hat Enterprise Linux"
VERSION="8.9 (Ootpa)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="8.9"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Red Hat Enterprise Linux 8.9 (Ootpa)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:8::baseos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
REDHAT_BUGZILLA_PRODUCT_VERSION=8.9
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="8.9"

[vagrant@rhel8 ~]$ dnf --nogpgcheck --cacheonly --color=never --quiet module list --enabled
Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
Name                                             Stream                                     Profiles                                          Summary                                                              
perl                                             5.26 [d][e]                                common [d], minimal                               Practical Extraction and Report Language                             
perl-IO-Socket-SSL                               2.066 [d][e]                               common [d]                                        Perl library for transparent TLS                                     
perl-libwww-perl                                 6.34 [d][e]                                common [d]                                        A Perl interface to the World-Wide Web                               
python36                                         3.6 [d][e]                                 build, common [d]                                 Python programming language, version 3.6                             

Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled

[vagrant@rhel8 ~]$ rpm -qa --queryformat "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH} %{MODULARITYLABEL}\n" | grep python36
python36 0 3.6.8 38.module+el8.5.0+12207+5c5719bc x86_64 python36:3.6:8050020210811103506:982725ab
```


## before
```console
$ vuls scan
[May 10 17:59:17]  INFO [localhost] vuls-v0.25.2-build-20240510_175728_ef2be3d
...

Scan Summary
================
vagrant	redhat8.9	509 installed





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ cat results/2024-05-10T17-59-19+0900/vagrant.json | jq .enabledDnfModules
$ cat results/2024-05-10T17-59-19+0900/vagrant.json | jq .packages.python36
{
  "name": "python36",
  "version": "3.6.8",
  "release": "38.module+el8.5.0+12207+5c5719bc",
  "newVersion": "",
  "newRelease": "",
  "arch": "x86_64",
  "repository": ""
}


$ vuls report
[May 10 18:00:58]  INFO [localhost] vuls-v0.25.2-build-20240510_175728_ef2be3d
...
vagrant (redhat8.9)
===================
Total: 410 (Critical:6 High:115 Medium:272 Low:15 ?:2)
71/410 Fixed, 65 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
509 installed
...

$ cat results/2024-05-10T17-59-19+0900/vagrant.json | jq '.scannedCves."CVE-2015-20107"'
```

## after
```console
$ vuls scan
[May 10 17:52:47]  INFO [localhost] vuls-v0.25.2-build-20240510_173812_4ec0344
...

Scan Summary
================
vagrant	redhat8.9	509 installed





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ cat results/2024-05-10T15-38-01+0900/vagrant.json | jq .enabledDnfModules
$ cat results/2024-05-10T17-52-49+0900/vagrant.json | jq .packages.python36
{
  "name": "python36",
  "version": "3.6.8",
  "release": "38.module+el8.5.0+12207+5c5719bc",
  "newVersion": "",
  "newRelease": "",
  "arch": "x86_64",
  "repository": "",
  "modularitylabel": "python36:3.6:8050020210811103506:982725ab"
}

$ vuls report
[May 10 17:54:43]  INFO [localhost] vuls-v0.25.2-build-20240510_173812_4ec0344
...
vagrant (redhat8.9)
===================
Total: 414 (Critical:6 High:118 Medium:273 Low:15 ?:2)
71/414 Fixed, 69 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
509 installed
...

$ cat results/2024-05-10T17-52-49+0900/vagrant.json | jq '.scannedCves."CVE-2015-20107"'
{
  "cveID": "CVE-2015-20107",
  "confidences": [
    {
      "score": 100,
      "detectionMethod": "OvalMatch"
    }
  ],
  "affectedPackages": [
    {
      "name": "python36",
      "notFixedYet": true,
      "fixState": "Affected"
    }
  ],
...
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

