### PR TITLE
feat(debian): validate running kernel version

### DIFF
--- a/gost/debian.go
+++ b/gost/debian.go
@@ -61,13 +61,18 @@ func (deb Debian) DetectCVEs(r *models.ScanResult, _ bool) (nCVEs int, err error
 		}
 	}
 
-	stashLinuxPackage := r.Packages["linux"]
+	var stashLinuxPackage models.Package
+	if linux, ok := r.Packages["linux"]; ok {
+		stashLinuxPackage = linux
+	}
 	nFixedCVEs, err := deb.detectCVEsWithFixState(r, "resolved")
 	if err != nil {
 		return 0, err
 	}
 
-	r.Packages["linux"] = stashLinuxPackage
+	if stashLinuxPackage.Name != "" {
+		r.Packages["linux"] = stashLinuxPackage
+	}
 	nUnfixedCVEs, err := deb.detectCVEsWithFixState(r, "open")
 	if err != nil {
 		return 0, err

--- a/gost/debian.go
+++ b/gost/debian.go
@@ -46,14 +46,18 @@ func (deb Debian) DetectCVEs(r *models.ScanResult, _ bool) (nCVEs int, err error
 
 	// Add linux and set the version of running kernel to search Gost.
 	if r.Container.ContainerID == "" {
-		newVer := ""
-		if p, ok := r.Packages["linux-image-"+r.RunningKernel.Release]; ok {
-			newVer = p.NewVersion
-		}
-		r.Packages["linux"] = models.Package{
-			Name:       "linux",
-			Version:    r.RunningKernel.Version,
-			NewVersion: newVer,
+		if r.RunningKernel.Version != "" {
+			newVer := ""
+			if p, ok := r.Packages["linux-image-"+r.RunningKernel.Release]; ok {
+				newVer = p.NewVersion
+			}
+			r.Packages["linux"] = models.Package{
+				Name:       "linux",
+				Version:    r.RunningKernel.Version,
+				NewVersion: newVer,
+			}
+		} else {
+			logging.Log.Warnf("Since the exact kernel version is not available, the vulnerability in the linux package is not detected.")
 		}
 	}
 

--- a/oval/debian.go
+++ b/oval/debian.go
@@ -141,14 +141,18 @@ func (o Debian) FillWithOval(r *models.ScanResult) (nCVEs int, err error) {
 
 	// Add linux and set the version of running kernel to search OVAL.
 	if r.Container.ContainerID == "" {
-		newVer := ""
-		if p, ok := r.Packages[linuxImage]; ok {
-			newVer = p.NewVersion
-		}
-		r.Packages["linux"] = models.Package{
-			Name:       "linux",
-			Version:    r.RunningKernel.Version,
-			NewVersion: newVer,
+		if r.RunningKernel.Version != "" {
+			newVer := ""
+			if p, ok := r.Packages[linuxImage]; ok {
+				newVer = p.NewVersion
+			}
+			r.Packages["linux"] = models.Package{
+				Name:       "linux",
+				Version:    r.RunningKernel.Version,
+				NewVersion: newVer,
+			}
+		} else {
+			logging.Log.Warnf("Since the exact kernel version is not available, the vulnerability in the linux package is not detected.")
 		}
 	}
 

--- a/scanner/base.go
+++ b/scanner/base.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/aquasecurity/fanal/analyzer"
 	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
+	debver "github.com/knqyf263/go-deb-version"
 
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/constant"
@@ -132,6 +133,10 @@ func (l *base) runningKernel() (release, version string, err error) {
 		ss := strings.Fields(r.Stdout)
 		if 6 < len(ss) {
 			version = ss[6]
+		}
+		if _, err := debver.NewVersion(version); err != nil {
+			l.log.Warnf("kernel running version is invalid. skip kernel vulnerability detection. actual kernel version: %s, err: %s", version, err)
+			version = ""
 		}
 	}
 	return

--- a/scanner/serverapi_test.go
+++ b/scanner/serverapi_test.go
@@ -36,14 +36,6 @@ func TestViaHTTP(t *testing.T) {
 		},
 		{
 			header: map[string]string{
-				"X-Vuls-OS-Family":      "debian",
-				"X-Vuls-OS-Release":     "8",
-				"X-Vuls-Kernel-Release": "2.6.32-695.20.3.el6.x86_64",
-			},
-			wantErr: errKernelVersionHeader,
-		},
-		{
-			header: map[string]string{
 				"X-Vuls-OS-Family":      "centos",
 				"X-Vuls-OS-Release":     "6.9",
 				"X-Vuls-Kernel-Release": "2.6.32-695.20.3.el6.x86_64",
@@ -92,6 +84,22 @@ func TestViaHTTP(t *testing.T) {
 				RunningKernel: models.Kernel{
 					Release: "3.16.0-4-amd64",
 					Version: "3.16.51-2",
+				},
+			},
+		},
+		{
+			header: map[string]string{
+				"X-Vuls-OS-Family":      "debian",
+				"X-Vuls-OS-Release":     "8.10",
+				"X-Vuls-Kernel-Release": "3.16.0-4-amd64",
+			},
+			body: "",
+			expectedResult: models.ScanResult{
+				Family:  "debian",
+				Release: "8.10",
+				RunningKernel: models.Kernel{
+					Release: "3.16.0-4-amd64",
+					Version: "",
 				},
 			},
 		},


### PR DESCRIPTION
# What did you implement:
Fixes https://github.com/future-architect/vuls/issues/846

If Debian is the scanning target, and docker is used, or if the correct kernel version cannot be obtained for some reason, it will output a warn log and will not detect OVAL or gost in the linux package.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Using the Docker environment, I reproduced the case of an invalid kernel version.
```console
// In the container to be scanned
$ root@a7226e85a420:~# uname -a
Linux a7226e85a420 5.13.0-28-generic #31~20.04.1-Ubuntu SMP Wed Jan 19 14:08:10 UTC 2022 x86_64 GNU/Linux

$ go run cmd/vuls/main.go scan
[Feb  7 06:05:09]  INFO [localhost] vuls-`make build` or `make install` will show the version-
[Feb  7 06:05:09]  INFO [localhost] Start scanning
[Feb  7 06:05:09]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Feb  7 06:05:09]  INFO [localhost] Validating config...
[Feb  7 06:05:09]  INFO [localhost] Detecting Server/Container OS... 
[Feb  7 06:05:09]  INFO [localhost] Detecting OS of servers... 
[Feb  7 06:05:09]  INFO [localhost] (1/1) Detected: vuls-target: debian 11.2
[Feb  7 06:05:09]  INFO [localhost] Detecting OS of containers... 
[Feb  7 06:05:09]  INFO [localhost] Checking Scan Modes... 
[Feb  7 06:05:09]  INFO [localhost] Detecting Platforms... 
[Feb  7 06:05:10]  INFO [localhost] (1/1) vuls-target is running on other
[Feb  7 06:05:10]  INFO [vuls-target] Scanning OS pkg in fast mode
[Feb  7 06:05:10]  WARN [vuls-target] kernel running version is invalid. skip kernel vulnerability detection. actual kernel version: Jan, err: upstream_version must start with digit


Scan Summary
================
vuls-target	debian11.2	319 installed





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ go run cmd/vuls/main.go report
[Feb  7 06:22:57]  INFO [localhost] vuls-`make build` or `make install` will show the version-
[Feb  7 06:22:57]  INFO [localhost] Validating config...
[Feb  7 06:22:57]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Feb  7 06:22:57]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/goval-dictionary/oval.sqlite3
[Feb  7 06:22:57]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/usr/share/vuls-data/gost.sqlite3
[Feb  7 06:22:57]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Feb  7 06:22:57]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Feb  7 06:22:57]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/usr/share/vuls-data/go-kev.sqlite3
[Feb  7 06:22:57]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2022-02-07T06:05:10+09:00
[Feb  7 06:22:57]  INFO [localhost] OVAL debian 11.2 found. defs: 0
[Feb  7 06:22:57]  INFO [localhost] Skip OVAL and Scan with gost alone.
[Feb  7 06:22:57]  INFO [localhost] vuls-target: 0 CVEs are detected with OVAL
[Feb  7 06:22:57]  WARN [localhost] Since the exact kernel version is not available, the vulnerability in the linux package is not detected.
[Feb  7 06:22:58]  INFO [localhost] vuls-target: 128 CVEs are detected with gost
[Feb  7 06:22:58]  INFO [localhost] vuls-target: 0 CVEs are detected with CPE
[Feb  7 06:22:58]  INFO [localhost] vuls-target: 2 PoC are detected
[Feb  7 06:22:58]  INFO [localhost] vuls-target: 0 exploits are detected
[Feb  7 06:22:58]  INFO [localhost] vuls-target: total 128 CVEs detected
[Feb  7 06:22:58]  INFO [localhost] vuls-target: 0 CVEs filtered by --confidence-over=80
vuls-target (debian11.2)
========================
Total: 128 (Critical:14 High:42 Medium:50 Low:12 ?:10)
0/128 Fixed, 31 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
319 installed
```

master report shows that there are 203 cases, and about 75 cases may be false positives for vulnerabilities related to the linux package.
```console
$ vuls report --refresh-cve
[Feb  7 06:23:40]  INFO [localhost] vuls-v0.19.2-build-20220128_200342_b4c23c1
[Feb  7 06:23:40]  INFO [localhost] Validating config...
[Feb  7 06:23:40]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Feb  7 06:23:40]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/goval-dictionary/oval.sqlite3
[Feb  7 06:23:40]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/usr/share/vuls-data/gost.sqlite3
[Feb  7 06:23:40]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Feb  7 06:23:40]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Feb  7 06:23:40]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/usr/share/vuls-data/go-kev.sqlite3
[Feb  7 06:23:40]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2022-02-07T06:05:10+09:00
[Feb  7 06:23:40]  INFO [localhost] OVAL debian 11.2 found. defs: 0
[Feb  7 06:23:40]  INFO [localhost] Skip OVAL and Scan with gost alone.
[Feb  7 06:23:40]  INFO [localhost] vuls-target: 0 CVEs are detected with OVAL
[Feb  7 06:23:42]  INFO [localhost] vuls-target: 203 CVEs are detected with gost
[Feb  7 06:23:42]  INFO [localhost] vuls-target: 0 CVEs are detected with CPE
[Feb  7 06:23:42]  INFO [localhost] vuls-target: 3 PoC are detected
[Feb  7 06:23:42]  INFO [localhost] vuls-target: 0 exploits are detected
[Feb  7 06:23:42]  INFO [localhost] vuls-target: total 203 CVEs detected
[Feb  7 06:23:42]  INFO [localhost] vuls-target: 0 CVEs filtered by --confidence-over=80
vuls-target (debian11.2)
========================
Total: 203 (Critical:15 High:64 Medium:89 Low:16 ?:19)
0/203 Fixed, 34 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 3 alerts
319 installed
```
# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

