### PR TITLE
feat(configtest,scan): detect known_hosts error

### DIFF
--- a/scanner/debian.go
+++ b/scanner/debian.go
@@ -48,8 +48,7 @@ func detectDebian(c config.ServerInfo) (bool, osTypeInterface, error) {
 			return false, nil, nil
 		}
 		if r.ExitStatus == 255 {
-			deb := newDebian(c) // Panic occur when return value 2 is nil and 3 is non-nil
-			return false, deb, xerrors.Errorf("Unable to connect via SSH. Scan with -vvv option to print SSH debugging messages and check SSH settings. If you have never SSH to the host to be scanned, SSH to the host before scanning in order to add the HostKey. %s@%s port: %s\n%s", c.User, c.Host, c.Port, r)
+			return false, &unknown{base{ServerInfo: c}}, xerrors.Errorf("Unable to connect via SSH. Scan with -vvv option to print SSH debugging messages and check SSH settings.\n%s", r)
 		}
 		logging.Log.Debugf("Not Debian like Linux. %s", r)
 		return false, nil, nil

--- a/scanner/serverapi.go
+++ b/scanner/serverapi.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/future-architect/vuls/cache"
@@ -278,6 +279,12 @@ func (s Scanner) detectServerOSes() (servers, errServers []osTypeInterface) {
 					logging.Log.Debugf("Panic: %s on %s", p, srv.ServerName)
 				}
 			}()
+			if err := checkHostinKnownHosts(srv); err != nil {
+				checkOS := unknown{base{ServerInfo: srv}}
+				checkOS.setErrs([]error{err})
+				osTypeChan <- &checkOS
+				return
+			}
 			osTypeChan <- s.detectOS(srv)
 		}(target)
 	}
@@ -288,12 +295,10 @@ func (s Scanner) detectServerOSes() (servers, errServers []osTypeInterface) {
 		case res := <-osTypeChan:
 			if 0 < len(res.getErrs()) {
 				errServers = append(errServers, res)
-				logging.Log.Errorf("(%d/%d) Failed: %s, err: %+v",
-					i+1, len(s.Targets), res.getServerInfo().ServerName, res.getErrs())
+				logging.Log.Errorf("(%d/%d) Failed: %s, err: %+v", i+1, len(s.Targets), res.getServerInfo().ServerName, res.getErrs())
 			} else {
 				servers = append(servers, res)
-				logging.Log.Infof("(%d/%d) Detected: %s: %s",
-					i+1, len(s.Targets), res.getServerInfo().ServerName, res.getDistro())
+				logging.Log.Infof("(%d/%d) Detected: %s: %s", i+1, len(s.Targets), res.getServerInfo().ServerName, res.getDistro())
 			}
 		case <-timeout:
 			msg := "Timed out while detecting servers"
@@ -317,6 +322,69 @@ func (s Scanner) detectServerOSes() (servers, errServers []osTypeInterface) {
 		}
 	}
 	return
+}
+
+func checkHostinKnownHosts(c config.ServerInfo) error {
+	if isLocalExec(c.Port, c.Host) {
+		return nil
+	}
+
+	args := []string{"-G"}
+	if len(c.SSHConfigPath) > 0 {
+		args = []string{"-G", "-F", c.SSHConfigPath}
+	}
+	r := localExec(c, fmt.Sprintf("ssh %s %s", strings.Join(args, " "), c.Host), noSudo)
+	if !r.isSuccess() {
+		return xerrors.Errorf("Failed to print SSH configuration. err: %w", r.Error)
+	}
+
+	var (
+		hostname         string
+		globalKnownHosts string
+		userKnownHosts   string
+	)
+	for _, line := range strings.Split(r.Stdout, "\n") {
+		if strings.HasPrefix(line, "hostname ") {
+			hostname = strings.TrimPrefix(line, "hostname ")
+		} else if strings.HasPrefix(line, "globalknownhostsfile ") {
+			globalKnownHosts = strings.TrimPrefix(line, "globalknownhostsfile ")
+		} else if strings.HasPrefix(line, "userknownhostsfile ") {
+			userKnownHosts = strings.TrimPrefix(line, "userknownhostsfile ")
+		}
+	}
+
+	knownHostsPaths := []string{}
+	for _, knownHosts := range []string{userKnownHosts, globalKnownHosts} {
+		for _, knownHost := range strings.Split(knownHosts, " ") {
+			if knownHost != "" {
+				knownHostsPaths = append(knownHostsPaths, knownHost)
+			}
+		}
+	}
+	if len(knownHostsPaths) == 0 {
+		return xerrors.New("Failed to find any known_hosts to use. Please check the UserKnownHostsFile and GlobalKnownHostsFile settings for SSH.")
+	}
+
+	for _, knownHosts := range knownHostsPaths {
+		if c.Port != "" && c.Port != "22" {
+			cmd := fmt.Sprintf("ssh-keygen -F %s -f %s", fmt.Sprintf("\"[%s]:%s\"", c.Host, c.Port), knownHosts)
+			if r := localExec(c, cmd, noSudo); r.isSuccess() {
+				return nil
+			}
+		}
+		cmd := fmt.Sprintf("ssh-keygen -F %s -f %s", c.Host, knownHosts)
+		if r := localExec(c, cmd, noSudo); r.isSuccess() {
+			return nil
+		}
+	}
+
+	sshCmd := fmt.Sprintf("ssh -i %s %s@%s", c.KeyPath, c.User, c.Host)
+	sshKeyScancmd := fmt.Sprintf("ssh-keyscan -H %s >> %s", hostname, knownHostsPaths[0])
+	if c.Port != "" && c.Port != "22" {
+		sshCmd = fmt.Sprintf("ssh -i %s -p %s %s@%s", c.KeyPath, c.Port, c.User, c.Host)
+		sshKeyScancmd = fmt.Sprintf("ssh-keyscan -H -p %s %s >> %s", c.Port, hostname, knownHostsPaths[0])
+	}
+	return xerrors.Errorf("Failed to find the host in known_hosts. Plaese exec `$ %s` or `$ %s`", sshCmd, sshKeyScancmd)
 }
 
 func (s Scanner) detectContainerOSes(hosts []osTypeInterface) (actives, inactives []osTypeInterface) {


### PR DESCRIPTION
# What did you implement:

vuls uses SSH connection when scanning.
The SSH connection of vuls scan is basically set to `StrictHostKeyChecking=yes`, so the host's public key must be registered in known_hosts.
However, the error message does not classify whether the error is caused by the host's public key not being registered in known_hosts or not.
This PR classifies the errors that occur when the host's public key is not registered in known_hosts for the user.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## master
```console
$ vuls scan
[Feb 10 23:13:10]  INFO [localhost] vuls-v0.19.2-build-20220128_200342_b4c23c1
[Feb 10 23:13:10]  INFO [localhost] Start scanning
[Feb 10 23:13:10]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Feb 10 23:13:10]  INFO [localhost] Validating config...
[Feb 10 23:13:10]  INFO [localhost] Detecting Server/Container OS... 
[Feb 10 23:13:10]  INFO [localhost] Detecting OS of servers... 
[Feb 10 23:13:11] ERROR [localhost] (1/1) Failed: vuls-target, err: [Failed to detect OS:
    github.com/future-architect/vuls/scanner.Scanner.detectOS
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:452
  - Unable to connect via SSH. Scan with -vvv option to print SSH debugging messages and check SSH settings. If you have never SSH to the host to be scanned, SSH to the host before scanning in order to add the HostKey. root@127.0.0.1 port: 2222
    execResult: servername: vuls-target
      cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m root@127.0.0.1 -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -o PasswordAuthentication=no stty cols 1000; ls /etc/debian_version
      exitstatus: 255
      stdout: 
      stderr: 
      err: %!s(<nil>):
    github.com/future-architect/vuls/scanner.detectDebian
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/debian.go:52]
[Feb 10 23:13:11] ERROR [localhost] Failed to scan: Failed to init servers. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:86
  - No scannable host OS:
    github.com/future-architect/vuls/scanner.Scanner.initServers
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:239
```

## MaineK00n/detect-known_hosts-err
```console
$ vuls scan
[Feb 10 23:15:10]  INFO [localhost] vuls-v0.19.3-build-20220210_231344_fef4291
[Feb 10 23:15:10]  INFO [localhost] Start scanning
[Feb 10 23:15:10]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Feb 10 23:15:10]  INFO [localhost] Validating config...
[Feb 10 23:15:10]  INFO [localhost] Detecting Server/Container OS... 
[Feb 10 23:15:10]  INFO [localhost] Detecting OS of servers... 
[Feb 10 23:15:10] ERROR [localhost] (1/1) Failed: vuls-target, err: [Failed to find the host in known_hosts. Plaese exec `$ ssh -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -p 2222 root@127.0.0.1` or `$ ssh-keyscan -H -p 2222 127.0.0.1 >> ~/.ssh/known_hosts`:
    github.com/future-architect/vuls/scanner.checkHostinKnownHosts
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/serverapi.go:381]
[Feb 10 23:15:10] ERROR [localhost] Failed to scan: Failed to init servers. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/serverapi.go:87
  - No scannable host OS:
    github.com/future-architect/vuls/scanner.Scanner.initServers
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/serverapi.go:242
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference
