### PR TITLE
fix(configtest,scan): support SSH config file

### DIFF
--- a/config/loader.go
+++ b/config/loader.go
@@ -1,9 +1,9 @@
 package config
 
 // Load loads configuration
-func Load(path, keyPass string) error {
+func Load(path string) error {
 	loader := TOMLLoader{}
-	return loader.Load(path, keyPass)
+	return loader.Load(path)
 }
 
 // Loader is interface of concrete loader

--- a/config/loader.go
+++ b/config/loader.go
@@ -2,8 +2,7 @@ package config
 
 // Load loads configuration
 func Load(path, keyPass string) error {
-	var loader Loader
-	loader = TOMLLoader{}
+	loader := TOMLLoader{}
 	return loader.Load(path, keyPass)
 }
 

--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -149,18 +149,11 @@ func setDefaultIfEmpty(server *ServerInfo) error {
 		}
 
 		if server.Port == "" {
-			if Conf.Default.Port != "" {
-				server.Port = Conf.Default.Port
-			} else {
-				server.Port = "22"
-			}
+			server.Port = Conf.Default.Port
 		}
 
 		if server.User == "" {
 			server.User = Conf.Default.User
-			if server.User == "" && server.Port != "local" {
-				return xerrors.Errorf("server.user is empty")
-			}
 		}
 
 		if server.SSHConfigPath == "" {

--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -15,7 +15,7 @@ type TOMLLoader struct {
 }
 
 // Load load the configuration TOML file specified by path arg.
-func (c TOMLLoader) Load(pathToToml, _ string) error {
+func (c TOMLLoader) Load(pathToToml string) error {
 	// util.Log.Infof("Loading config: %s", pathToToml)
 	if _, err := toml.DecodeFile(pathToToml, &Conf); err != nil {
 		return err

--- a/subcmds/configtest.go
+++ b/subcmds/configtest.go
@@ -17,9 +17,8 @@ import (
 
 // ConfigtestCmd is Subcommand
 type ConfigtestCmd struct {
-	configPath     string
-	askKeyPassword bool
-	timeoutSec     int
+	configPath string
+	timeoutSec int
 }
 
 // Name return subcommand name
@@ -35,7 +34,6 @@ func (*ConfigtestCmd) Usage() string {
 			[-config=/path/to/config.toml]
 			[-log-to-file]
 			[-log-dir=/path/to/log]
-			[-ask-key-password]
 			[-timeout=300]
 			[-containers-only]
 			[-http-proxy=http://192.168.0.1:8080]
@@ -59,10 +57,6 @@ func (p *ConfigtestCmd) SetFlags(f *flag.FlagSet) {
 
 	f.IntVar(&p.timeoutSec, "timeout", 5*60, "Timeout(Sec)")
 
-	f.BoolVar(&p.askKeyPassword, "ask-key-password", false,
-		"Ask ssh privatekey password before scanning",
-	)
-
 	f.StringVar(&config.Conf.HTTPProxy, "http-proxy", "",
 		"http://proxy-url:port (default: empty)")
 
@@ -79,18 +73,7 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 		return subcommands.ExitUsageError
 	}
 
-	var keyPass string
-	var err error
-	if p.askKeyPassword {
-		prompt := "SSH key password: "
-		if keyPass, err = getPasswd(prompt); err != nil {
-			logging.Log.Error(err)
-			return subcommands.ExitFailure
-		}
-	}
-
-	err = config.Load(p.configPath, keyPass)
-	if err != nil {
+	if err := config.Load(p.configPath); err != nil {
 		msg := []string{
 			fmt.Sprintf("Error loading %s", p.configPath),
 			"If you update Vuls and get this error, there may be incompatible changes in config.toml",

--- a/subcmds/report.go
+++ b/subcmds/report.go
@@ -175,7 +175,7 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	logging.Log = logging.NewCustomLogger(config.Conf.Debug, config.Conf.Quiet, config.Conf.LogToFile, config.Conf.LogDir, "", "")
 	logging.Log.Infof("vuls-%s-%s", config.Version, config.Revision)
 
-	if err := config.Load(p.configPath, ""); err != nil {
+	if err := config.Load(p.configPath); err != nil {
 		logging.Log.Errorf("Error loading %s, %+v", p.configPath, err)
 		return subcommands.ExitUsageError
 	}

--- a/subcmds/saas.go
+++ b/subcmds/saas.go
@@ -65,7 +65,7 @@ func (p *SaaSCmd) SetFlags(f *flag.FlagSet) {
 func (p *SaaSCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	logging.Log = logging.NewCustomLogger(config.Conf.Debug, config.Conf.Quiet, config.Conf.LogToFile, config.Conf.LogDir, "", "")
 	logging.Log.Infof("vuls-%s-%s", config.Version, config.Revision)
-	if err := config.Load(p.configPath, ""); err != nil {
+	if err := config.Load(p.configPath); err != nil {
 		logging.Log.Errorf("Error loading %s, %+v", p.configPath, err)
 		return subcommands.ExitUsageError
 	}

--- a/subcmds/server.go
+++ b/subcmds/server.go
@@ -93,7 +93,7 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 func (p *ServerCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	logging.Log = logging.NewCustomLogger(config.Conf.Debug, config.Conf.Quiet, config.Conf.LogToFile, config.Conf.LogDir, "", "")
 	logging.Log.Infof("vuls-%s-%s", config.Version, config.Revision)
-	if err := config.Load(p.configPath, ""); err != nil {
+	if err := config.Load(p.configPath); err != nil {
 		logging.Log.Errorf("Error loading %s. err: %+v", p.configPath, err)
 		return subcommands.ExitUsageError
 	}

--- a/subcmds/tui.go
+++ b/subcmds/tui.go
@@ -110,7 +110,7 @@ func (p *TuiCmd) SetFlags(f *flag.FlagSet) {
 func (p *TuiCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	logging.Log = logging.NewCustomLogger(config.Conf.Debug, config.Conf.Quiet, config.Conf.LogToFile, config.Conf.LogDir, "", "")
 	logging.Log.Infof("vuls-%s-%s", config.Version, config.Revision)
-	if err := config.Load(p.configPath, ""); err != nil {
+	if err := config.Load(p.configPath); err != nil {
 		logging.Log.Errorf("Error loading %s, err: %+v", p.configPath, err)
 		return subcommands.ExitUsageError
 	}

--- a/subcmds/util.go
+++ b/subcmds/util.go
@@ -1,28 +1,11 @@
 package subcmds
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/howeyc/gopass"
 	homedir "github.com/mitchellh/go-homedir"
-	"golang.org/x/xerrors"
 )
-
-func getPasswd(prompt string) (string, error) {
-	for {
-		fmt.Print(prompt)
-		pass, err := gopass.GetPasswdMasked()
-		if err != nil {
-			return "", xerrors.New("Failed to read a password")
-		}
-		if 0 < len(pass) {
-			return string(pass), nil
-		}
-	}
-
-}
 
 func mkdirDotVuls() error {
 	home, err := homedir.Dir()


### PR DESCRIPTION
# What did you implement:
I would like to support the case where a user tries to scan vuls with the host written in SSH Config.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- /home/mainek00n/.ssh/config
```console
Host vuls-target
    HostName 127.0.0.1
    Port 2222
    Identityfile ~/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa
    Identitiesonly yes
    User root
    KexAlgorithms +diffie-hellman-group1-sha1
```

> ssh(1) obtains configuration data from the following sources in the following order:
           1.   command-line options
           2.   user's configuration file (~/.ssh/config)
           3.   system-wide configuration file (/etc/ssh/ssh_config)

ref: https://man7.org/linux/man-pages/man5/ssh_config.5.html

## When user, port, and keyPath are not specified
- config.toml
```toml
[default]

[servers.vuls-target]
host                = "vuls-target"
scanMode           = ["fast"]
scanModules        = ["ospkg"]
```

### master
It seems that user is always required.
```console
$ vuls configtest -debug
[Feb 11 22:26:21]  INFO [localhost] vuls-v0.19.3-build-20220211_201157_671be3f
[Feb 11 22:26:21] ERROR [localhost] Error loading /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
If you update Vuls and get this error, there may be incompatible changes in config.toml
Please check config.toml template : https://vuls.io/docs/en/usage-settings.html
Failed to set default value to config. server: vuls-target, err:
    github.com/future-architect/vuls/config.TOMLLoader.Load
        /home/mainek00n/go/src/github.com/future-architect/vuls/config/tomlloader.go:39
  - server.user is empty:
    github.com/future-architect/vuls/config.setDefaultIfEmpty
        /home/mainek00n/go/src/github.com/future-architect/vuls/config/tomlloader.go:162
```

### MaineK00n/support-ssh-config
The user, port, and keypath information are all from ssh config, so they are not necessary.
Also, even if user and port are empty, they are set from the ssh settings. In this case, user = root and port = 2222.
```console
$ vuls configtest -debug
[Feb 11 22:29:53]  INFO [localhost] vuls-v0.19.3-build-20220211_222448_c0c4e66
[Feb 11 22:29:53]  INFO [localhost] Validating config...
[Feb 11 22:29:53]  INFO [localhost] Detecting Server/Container OS... 
[Feb 11 22:29:53]  INFO [localhost] Detecting OS of servers... 
[Feb 11 22:29:53] DEBUG [localhost] Validating SSH Settings for Server:vuls-target ...
[Feb 11 22:29:53] DEBUG [localhost] Executing... /usr/bin/ssh -G vuls-target
[Feb 11 22:29:53] DEBUG [localhost] Setting SSH User:root for Server:vuls-target ...
[Feb 11 22:29:53] DEBUG [localhost] Validating SSH HostName:127.0.0.1 for Server:vuls-target ...
[Feb 11 22:29:53] DEBUG [localhost] Setting SSH Port:2222 for Server:vuls-target ...
[Feb 11 22:29:53] DEBUG [localhost] Checking if the host's public key is in known_hosts...
[Feb 11 22:29:53] DEBUG [localhost] Executing... /usr/bin/ssh-keygen -F "[127.0.0.1]:2222" -f ~/.ssh/known_hosts
[Feb 11 22:29:53] DEBUG [localhost] Executing... ls /etc/debian_version
[Feb 11 22:29:53] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 vuls-target stty cols 1000; ls /etc/debian_version
  exitstatus: 2
  stdout: ls: cannot access '/etc/debian_version': No such file or directory

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:29:53] DEBUG [localhost] Not Debian like Linux. execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 vuls-target stty cols 1000; ls /etc/debian_version
  exitstatus: 2
  stdout: ls: cannot access '/etc/debian_version': No such file or directory

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:29:53] DEBUG [localhost] Executing... ls /etc/fedora-release
[Feb 11 22:29:53] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 vuls-target stty cols 1000; ls /etc/fedora-release
  exitstatus: 0
  stdout: /etc/fedora-release

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:29:53] DEBUG [localhost] Executing... cat /etc/fedora-release
[Feb 11 22:29:53] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 vuls-target stty cols 1000; cat /etc/fedora-release
  exitstatus: 0
  stdout: Fedora release 35 (Thirty Five)

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:29:53] DEBUG [localhost] Redhat like Linux. Host: vuls-target:2222
[Feb 11 22:29:53]  INFO [localhost] (1/1) Detected: vuls-target: fedora 35
[Feb 11 22:29:53]  INFO [localhost] Detecting OS of containers... 
[Feb 11 22:29:53]  INFO [localhost] Checking Scan Modes...
[Feb 11 22:29:53]  INFO [localhost] Checking dependencies...
[Feb 11 22:29:53]  INFO [vuls-target] Dependencies ... Pass
[Feb 11 22:29:53]  INFO [localhost] Checking sudo settings...
[Feb 11 22:29:53]  INFO [vuls-target] Sudo... Pass
[Feb 11 22:29:53]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Feb 11 22:29:53]  INFO [localhost] Scannable servers are below...
vuls-target
```
## When port, and keyPath are not specified
- config.toml
```toml
[default]

[servers.vuls-target]
host                = "vuls-target"
user                = "root"
scanMode           = ["fast"]
scanModules        = ["ospkg"]
```

### master
```console
$ vuls configtest -debug
[Feb 11 22:31:17]  INFO [localhost] vuls-v0.19.3-build-20220211_201157_671be3f
[Feb 11 22:31:17]  INFO [localhost] Validating config...
[Feb 11 22:31:17]  INFO [localhost] Detecting Server/Container OS... 
[Feb 11 22:31:17]  INFO [localhost] Detecting OS of servers... 
[Feb 11 22:31:17] ERROR [localhost] (1/1) Failed: vuls-target, err: [Failed to find the host in known_hosts. Plaese exec `$ ssh -i  root@vuls-target` or `$ ssh-keyscan -H 127.0.0.1 >> ~/.ssh/known_hosts`:
    github.com/future-architect/vuls/scanner.checkHostinKnownHosts
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:395]
[Feb 11 22:31:17] ERROR [localhost] Failed to configtest: Failed to init servers. err:
    github.com/future-architect/vuls/scanner.Scanner.Configtest
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:114
  - No scannable host OS:
    github.com/future-architect/vuls/scanner.Scanner.initServers
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:250
```

### MaineK00n/support-ssh-config
```console
$ vuls configtest -debug
[Feb 11 22:31:50]  INFO [localhost] vuls-v0.19.3-build-20220211_222448_c0c4e66
[Feb 11 22:31:50]  INFO [localhost] Validating config...
[Feb 11 22:31:50]  INFO [localhost] Detecting Server/Container OS... 
[Feb 11 22:31:50]  INFO [localhost] Detecting OS of servers... 
[Feb 11 22:31:50] DEBUG [localhost] Validating SSH Settings for Server:vuls-target ...
[Feb 11 22:31:50] DEBUG [localhost] Executing... /usr/bin/ssh -G -l root vuls-target
[Feb 11 22:31:50] DEBUG [localhost] Setting SSH User:root for Server:vuls-target ...
[Feb 11 22:31:50] DEBUG [localhost] Validating SSH HostName:127.0.0.1 for Server:vuls-target ...
[Feb 11 22:31:50] DEBUG [localhost] Setting SSH Port:2222 for Server:vuls-target ...
[Feb 11 22:31:50] DEBUG [localhost] Checking if the host's public key is in known_hosts...
[Feb 11 22:31:50] DEBUG [localhost] Executing... /usr/bin/ssh-keygen -F "[127.0.0.1]:2222" -f ~/.ssh/known_hosts
[Feb 11 22:31:50] DEBUG [localhost] Executing... ls /etc/debian_version
[Feb 11 22:31:50] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 vuls-target stty cols 1000; ls /etc/debian_version
  exitstatus: 2
  stdout: ls: cannot access '/etc/debian_version': No such file or directory

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:31:50] DEBUG [localhost] Not Debian like Linux. execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 vuls-target stty cols 1000; ls /etc/debian_version
  exitstatus: 2
  stdout: ls: cannot access '/etc/debian_version': No such file or directory

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:31:50] DEBUG [localhost] Executing... ls /etc/fedora-release
[Feb 11 22:31:50] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 vuls-target stty cols 1000; ls /etc/fedora-release
  exitstatus: 0
  stdout: /etc/fedora-release

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:31:50] DEBUG [localhost] Executing... cat /etc/fedora-release
[Feb 11 22:31:50] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 vuls-target stty cols 1000; cat /etc/fedora-release
  exitstatus: 0
  stdout: Fedora release 35 (Thirty Five)

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:31:50] DEBUG [localhost] Redhat like Linux. Host: vuls-target:2222
[Feb 11 22:31:50]  INFO [localhost] (1/1) Detected: vuls-target: fedora 35
[Feb 11 22:31:50]  INFO [localhost] Detecting OS of containers... 
[Feb 11 22:31:50]  INFO [localhost] Checking Scan Modes...
[Feb 11 22:31:50]  INFO [localhost] Checking dependencies...
[Feb 11 22:31:50]  INFO [vuls-target] Dependencies ... Pass
[Feb 11 22:31:50]  INFO [localhost] Checking sudo settings...
[Feb 11 22:31:50]  INFO [vuls-target] Sudo... Pass
[Feb 11 22:31:50]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Feb 11 22:31:50]  INFO [localhost] Scannable servers are below...
vuls-target
```

## When port is not specified
- config.toml
```toml
[default]

[servers.vuls-target]
host                = "vuls-target"
user                = "root"
keyPath            = "/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa"
scanMode           = ["fast"]
scanModules        = ["ospkg"]
```

### master
The port will always be set to the default value or 22, and it will look for known_hosts on that port.
The actual port to be used this time is 2222.
https://github.com/future-architect/vuls/blob/671be3f2f76bd2e8653f5f4194badca69c226620/config/tomlloader.go#L152-L156
```console
$ vuls configtest -debug
[Feb 11 22:32:58]  INFO [localhost] vuls-v0.19.3-build-20220211_201157_671be3f
[Feb 11 22:32:58]  INFO [localhost] Validating config...
[Feb 11 22:32:58]  INFO [localhost] Detecting Server/Container OS... 
[Feb 11 22:32:58]  INFO [localhost] Detecting OS of servers... 
[Feb 11 22:32:58] ERROR [localhost] (1/1) Failed: vuls-target, err: [Failed to find the host in known_hosts. Plaese exec `$ ssh -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa root@vuls-target` or `$ ssh-keyscan -H 127.0.0.1 >> ~/.ssh/known_hosts`:
    github.com/future-architect/vuls/scanner.checkHostinKnownHosts
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:395]
[Feb 11 22:32:58] ERROR [localhost] Failed to configtest: Failed to init servers. err:
    github.com/future-architect/vuls/scanner.Scanner.Configtest
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:114
  - No scannable host OS:
    github.com/future-architect/vuls/scanner.Scanner.initServers
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:250
```

### MaineK00n/support-ssh-config
```console
$ vuls configtest -debug
[Feb 11 22:33:33]  INFO [localhost] vuls-v0.19.3-build-20220211_222448_c0c4e66
[Feb 11 22:33:33]  INFO [localhost] Validating config...
[Feb 11 22:33:33]  INFO [localhost] Detecting Server/Container OS... 
[Feb 11 22:33:33]  INFO [localhost] Detecting OS of servers... 
[Feb 11 22:33:33] DEBUG [localhost] Validating SSH Settings for Server:vuls-target ...
[Feb 11 22:33:33] DEBUG [localhost] Executing... /usr/bin/ssh -G -l root vuls-target
[Feb 11 22:33:33] DEBUG [localhost] Setting SSH User:root for Server:vuls-target ...
[Feb 11 22:33:33] DEBUG [localhost] Validating SSH HostName:127.0.0.1 for Server:vuls-target ...
[Feb 11 22:33:33] DEBUG [localhost] Setting SSH Port:2222 for Server:vuls-target ...
[Feb 11 22:33:33] DEBUG [localhost] Checking if the host's public key is in known_hosts...
[Feb 11 22:33:33] DEBUG [localhost] Executing... /usr/bin/ssh-keygen -F "[127.0.0.1]:2222" -f ~/.ssh/known_hosts
[Feb 11 22:33:33] DEBUG [localhost] Executing... ls /etc/debian_version
[Feb 11 22:33:33] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -o PasswordAuthentication=no vuls-target stty cols 1000; ls /etc/debian_version
  exitstatus: 2
  stdout: ls: cannot access '/etc/debian_version': No such file or directory

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:33:33] DEBUG [localhost] Not Debian like Linux. execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -o PasswordAuthentication=no vuls-target stty cols 1000; ls /etc/debian_version
  exitstatus: 2
  stdout: ls: cannot access '/etc/debian_version': No such file or directory

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:33:33] DEBUG [localhost] Executing... ls /etc/fedora-release
[Feb 11 22:33:33] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -o PasswordAuthentication=no vuls-target stty cols 1000; ls /etc/fedora-release
  exitstatus: 0
  stdout: /etc/fedora-release

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:33:33] DEBUG [localhost] Executing... cat /etc/fedora-release
[Feb 11 22:33:33] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -o PasswordAuthentication=no vuls-target stty cols 1000; cat /etc/fedora-release
  exitstatus: 0
  stdout: Fedora release 35 (Thirty Five)

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:33:33] DEBUG [localhost] Redhat like Linux. Host: vuls-target:2222
[Feb 11 22:33:33]  INFO [localhost] (1/1) Detected: vuls-target: fedora 35
[Feb 11 22:33:33]  INFO [localhost] Detecting OS of containers... 
[Feb 11 22:33:33]  INFO [localhost] Checking Scan Modes...
[Feb 11 22:33:33]  INFO [localhost] Checking dependencies...
[Feb 11 22:33:33]  INFO [vuls-target] Dependencies ... Pass
[Feb 11 22:33:33]  INFO [localhost] Checking sudo settings...
[Feb 11 22:33:33]  INFO [vuls-target] Sudo... Pass
[Feb 11 22:33:33]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Feb 11 22:33:33]  INFO [localhost] Scannable servers are below...
vuls-target
```

## When keyPath is not specified
- config.toml
```toml
[default]

[servers.vuls-target]
host                = "vuls-target"
user                = "root"
port                 = "2222"
scanMode           = ["fast"]
scanModules        = ["ospkg"]
```

### master
`c.Host` does not resolve names, so it is necessary to use `hostname`.
https://github.com/future-architect/vuls/blob/master/scanner/serverapi.go#L378
https://github.com/future-architect/vuls/blob/master/scanner/serverapi.go#L383
```console
$ vuls configtest -debug
[Feb 11 22:36:47]  INFO [localhost] vuls-v0.19.3-build-20220211_201157_671be3f
[Feb 11 22:36:47]  INFO [localhost] Validating config...
[Feb 11 22:36:47]  INFO [localhost] Detecting Server/Container OS... 
[Feb 11 22:36:47]  INFO [localhost] Detecting OS of servers... 
[Feb 11 22:36:47] ERROR [localhost] (1/1) Failed: vuls-target, err: [Failed to find the host in known_hosts. Plaese exec `$ ssh -i  -p 2222 root@vuls-target` or `$ ssh-keyscan -H -p 2222 127.0.0.1 >> ~/.ssh/known_hosts`:
    github.com/future-architect/vuls/scanner.checkHostinKnownHosts
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:395]
[Feb 11 22:36:47] ERROR [localhost] Failed to configtest: Failed to init servers. err:
    github.com/future-architect/vuls/scanner.Scanner.Configtest
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:114
  - No scannable host OS:
    github.com/future-architect/vuls/scanner.Scanner.initServers
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:250
```

### MaineK00n/support-ssh-config
```console
$ vuls configtest -debug
[Feb 11 22:38:49]  INFO [localhost] vuls-v0.19.3-build-20220211_222448_c0c4e66
[Feb 11 22:38:49]  INFO [localhost] Validating config...
[Feb 11 22:38:49]  INFO [localhost] Detecting Server/Container OS... 
[Feb 11 22:38:49]  INFO [localhost] Detecting OS of servers... 
[Feb 11 22:38:49] DEBUG [localhost] Validating SSH Settings for Server:vuls-target ...
[Feb 11 22:38:49] DEBUG [localhost] Executing... /usr/bin/ssh -G -p 2222 -l root vuls-target
[Feb 11 22:38:49] DEBUG [localhost] Setting SSH User:root for Server:vuls-target ...
[Feb 11 22:38:49] DEBUG [localhost] Validating SSH HostName:127.0.0.1 for Server:vuls-target ...
[Feb 11 22:38:49] DEBUG [localhost] Setting SSH Port:2222 for Server:vuls-target ...
[Feb 11 22:38:49] DEBUG [localhost] Checking if the host's public key is in known_hosts...
[Feb 11 22:38:49] DEBUG [localhost] Executing... /usr/bin/ssh-keygen -F "[127.0.0.1]:2222" -f ~/.ssh/known_hosts
[Feb 11 22:38:49] DEBUG [localhost] Executing... ls /etc/debian_version
[Feb 11 22:38:49] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 vuls-target stty cols 1000; ls /etc/debian_version
  exitstatus: 2
  stdout: ls: cannot access '/etc/debian_version': No such file or directory

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:38:49] DEBUG [localhost] Not Debian like Linux. execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 vuls-target stty cols 1000; ls /etc/debian_version
  exitstatus: 2
  stdout: ls: cannot access '/etc/debian_version': No such file or directory

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:38:49] DEBUG [localhost] Executing... ls /etc/fedora-release
[Feb 11 22:38:49] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 vuls-target stty cols 1000; ls /etc/fedora-release
  exitstatus: 0
  stdout: /etc/fedora-release

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:38:49] DEBUG [localhost] Executing... cat /etc/fedora-release
[Feb 11 22:38:49] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vuls-target.%p -o Controlpersist=10m -l root -p 2222 vuls-target stty cols 1000; cat /etc/fedora-release
  exitstatus: 0
  stdout: Fedora release 35 (Thirty Five)

  stderr: 
  err: %!s(<nil>)
[Feb 11 22:38:49] DEBUG [localhost] Redhat like Linux. Host: vuls-target:2222
[Feb 11 22:38:49]  INFO [localhost] (1/1) Detected: vuls-target: fedora 35
[Feb 11 22:38:49]  INFO [localhost] Detecting OS of containers... 
[Feb 11 22:38:49]  INFO [localhost] Checking Scan Modes...
[Feb 11 22:38:49]  INFO [localhost] Checking dependencies...
[Feb 11 22:38:49]  INFO [vuls-target] Dependencies ... Pass
[Feb 11 22:38:49]  INFO [localhost] Checking sudo settings...
[Feb 11 22:38:49]  INFO [vuls-target] Sudo... Pass
[Feb 11 22:38:49]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Feb 11 22:38:49]  INFO [localhost] Scannable servers are below...
vuls-target
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://github.com/vulsdoc/vuls/pull/190

