### PR TITLE
fix(util): Major() behavior for major version

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -176,7 +176,7 @@ func Major(version string) string {
 	} else {
 		ver = ss[1]
 	}
-	return ver[0:strings.Index(ver, ".")]
+	return strings.Split(ver, ".")[0]
 }
 
 // GetHTTPClient return http.Client

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -165,6 +165,10 @@ func Test_major(t *testing.T) {
 			expected: "",
 		},
 		{
+			in:       "4",
+			expected: "4",
+		},
+		{
 			in:       "4.1",
 			expected: "4",
 		},


### PR DESCRIPTION
# What did you implement:

Fixes https://github.com/future-architect/vuls/issues/1390

When Major() is performed on a major version, the method of obtaining the index results in an index of -1, which causes out-of-range access. This has been fixed by implementing split with `.`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## master
```console
$ vuls configtest -debug
[Feb 15 05:14:48]  INFO [localhost] vuls-v0.19.3-build-20220215_051246_0733561
[Feb 15 05:14:48]  INFO [localhost] Validating config...
[Feb 15 05:14:48]  INFO [localhost] Detecting Server/Container OS... 
[Feb 15 05:14:48]  INFO [localhost] Detecting OS of servers... 
[Feb 15 05:14:48] DEBUG [localhost] Validating SSH Settings for Server:vuls-target ...
[Feb 15 05:14:48] DEBUG [localhost] Executing... /usr/bin/ssh -G -F /home/mainek00n/.ssh/config -p 2222 -l root 127.0.0.1
[Feb 15 05:14:48] DEBUG [localhost] Setting SSH User:root for Server:vuls-target ...
[Feb 15 05:14:48] DEBUG [localhost] Validating SSH HostName:127.0.0.1 for Server:vuls-target ...
[Feb 15 05:14:48] DEBUG [localhost] Setting SSH Port:2222 for Server:vuls-target ...
[Feb 15 05:14:48] DEBUG [localhost] Checking if the host's public key is in known_hosts...
[Feb 15 05:14:48] DEBUG [localhost] Executing... /usr/bin/ssh-keygen -F "[127.0.0.1]:2222" -f ~/.ssh/known_hosts
[Feb 15 05:14:48] DEBUG [localhost] Executing... ls /etc/debian_version
[Feb 15 05:14:48] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -F /home/mainek00n/.ssh/config -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; ls /etc/debian_version
  exitstatus: 2
  stdout: ls: cannot access '/etc/debian_version': No such file or directory

  stderr: Connection to 127.0.0.1 closed.

  err: %!s(<nil>)
...
[Feb 15 05:14:49] DEBUG [localhost] Executing... ls /etc/centos-release
[Feb 15 05:14:49] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -F /home/mainek00n/.ssh/config -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; ls /etc/centos-release
  exitstatus: 0
  stdout: /etc/centos-release

  stderr: Connection to 127.0.0.1 closed.

  err: %!s(<nil>)
[Feb 15 05:14:49] DEBUG [localhost] Executing... cat /etc/centos-release
[Feb 15 05:14:49] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -F /home/mainek00n/.ssh/config -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; cat /etc/centos-release
  exitstatus: 0
  stdout: CentOS Stream release 8

  stderr: Connection to 127.0.0.1 closed.

  err: %!s(<nil>)
[Feb 15 05:14:49] DEBUG [localhost] Panic: runtime error: slice bounds out of range [:-1] on vuls-target
```

## MaineK00n/fix-major
```console
$ vuls configtest
[Feb 15 05:14:35]  INFO [localhost] vuls-v0.19.3-build-20220215_051225_73e1cd0
[Feb 15 05:14:35]  INFO [localhost] Validating config...
[Feb 15 05:14:35]  INFO [localhost] Detecting Server/Container OS... 
[Feb 15 05:14:35]  INFO [localhost] Detecting OS of servers... 
[Feb 15 05:14:36]  INFO [localhost] (1/1) Detected: vuls-target: centos stream8
[Feb 15 05:14:36]  INFO [localhost] Detecting OS of containers... 
[Feb 15 05:14:36]  INFO [localhost] Checking Scan Modes...
[Feb 15 05:14:36]  INFO [localhost] Checking dependencies...
[Feb 15 05:14:36]  INFO [vuls-target] Dependencies ... Pass
[Feb 15 05:14:36]  INFO [localhost] Checking sudo settings...
[Feb 15 05:14:36]  INFO [vuls-target] Sudo... Pass
[Feb 15 05:14:36]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Feb 15 05:14:36]  INFO [localhost] Scannable servers are below...
vuls-target 
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

