### PR TITLE
fix(configtest,scan): fix validateSSHConfig

### DIFF
--- a/scanner/serverapi.go
+++ b/scanner/serverapi.go
@@ -335,7 +335,7 @@ func (s Scanner) detectServerOSes() (servers, errServers []osTypeInterface) {
 }
 
 func validateSSHConfig(c *config.ServerInfo) error {
-	if isLocalExec(c.Port, c.Host) {
+	if isLocalExec(c.Port, c.Host) || c.Type == constant.ServerTypePseudo {
 		return nil
 	}
 


### PR DESCRIPTION
# What did you implement:

Fixes https://github.com/future-architect/vuls/issues/1389

If ServerType is pseudo, SSH config check does not run.
Also, if StrictHostKeyChecking is no, it will not check if the host's public key is registered in known_hosts.
In addition, if there is a description of proxyjump or proxycommand, it is difficult to follow the destination of the proxy, so once the check of known_hosts is abandoned.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## env
- config.toml
```toml
[servers]

[servers.forti]
type = "pseudo"
cpeNames = [
    "cpe:/o:fortinet:fortios:4.3.0",
]

[servers.vuls-target]
host                = "vuls-target"
sshConfigPath		= "/home/mainek00n/.ssh/config"
scanMode           = ["fast"]
scanModules        = ["ospkg"]
```

- /home/mainek00n/.ssh/config
```
Host vuls-target
    HostName 127.0.0.1
    Port 2222
    Identityfile ~/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa
    StrictHostKeyChecking no
    UserKnownHostsFile /dev/null
    Identitiesonly yes
    User root
    KexAlgorithms +diffie-hellman-group1-sha1
```

The hostname: 127.0.0.1 and port: 2222 are not registered in known_hosts.
```console
$ ssh-keygen -F '[127.0.0.1]:2222'
$ echo $?
1
```

## master(787604d)
```console
$ vuls configtest -debug
[Feb 16 06:21:21]  INFO [localhost] vuls-v0.19.3-build-20220216_055807_787604d
[Feb 16 06:21:21]  INFO [localhost] Validating config...
[Feb 16 06:21:21]  INFO [localhost] Detecting Server/Container OS... 
[Feb 16 06:21:21]  INFO [localhost] Detecting OS of servers... 
[Feb 16 06:21:21] DEBUG [localhost] Validating SSH Settings for Server:vuls-target ...
[Feb 16 06:21:21] DEBUG [localhost] Executing... /usr/bin/ssh -G -F /home/mainek00n/.ssh/config vuls-target
[Feb 16 06:21:21] DEBUG [localhost] Validating SSH Settings for Server:forti ...
[Feb 16 06:21:21] DEBUG [localhost] Executing... /usr/bin/ssh -G 
[Feb 16 06:21:21] DEBUG [localhost] Setting SSH User:root for Server:vuls-target ...
[Feb 16 06:21:21] DEBUG [localhost] Validating SSH HostName:127.0.0.1 for Server:vuls-target ...
[Feb 16 06:21:21] DEBUG [localhost] Setting SSH Port:2222 for Server:vuls-target ...
[Feb 16 06:21:21] DEBUG [localhost] Checking if the host's public key is in known_hosts...
[Feb 16 06:21:21] DEBUG [localhost] Executing... /usr/bin/ssh-keygen -F "[127.0.0.1]:2222" -f /dev/null
[Feb 16 06:21:21] ERROR [localhost] (1/2) Failed: forti, err: [Failed to print SSH configuration. err:
    github.com/future-architect/vuls/scanner.validateSSHConfig
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:368
  - exit status 255]
[Feb 16 06:21:21] DEBUG [localhost] Executing... /usr/bin/ssh-keygen -F 127.0.0.1 -f /dev/null
[Feb 16 06:21:21] DEBUG [localhost] Executing... /usr/bin/ssh-keygen -F "[127.0.0.1]:2222" -f /etc/ssh/ssh_known_hosts
[Feb 16 06:21:21] DEBUG [localhost] Executing... /usr/bin/ssh-keygen -F 127.0.0.1 -f /etc/ssh/ssh_known_hosts
[Feb 16 06:21:21] DEBUG [localhost] Executing... /usr/bin/ssh-keygen -F "[127.0.0.1]:2222" -f /etc/ssh/ssh_known_hosts2
[Feb 16 06:21:21] DEBUG [localhost] Executing... /usr/bin/ssh-keygen -F 127.0.0.1 -f /etc/ssh/ssh_known_hosts2
[Feb 16 06:21:21] ERROR [localhost] (2/2) Failed: vuls-target, err: [Failed to find the host in known_hosts. Plaese exec `$ ssh -F /home/mainek00n/.ssh/config -p 2222 -l root vuls-target` or `$ ssh-keyscan -H -p 2222 127.0.0.1 >> /dev/null`:
    github.com/future-architect/vuls/scanner.validateSSHConfig
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:449]
[Feb 16 06:21:21] ERROR [localhost] Failed to configtest: Failed to init servers. err:
    github.com/future-architect/vuls/scanner.Scanner.Configtest
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:116
  - No scannable host OS:
    github.com/future-architect/vuls/scanner.Scanner.initServers
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/serverapi.go:252
```

## MaineK00n/fix-validate-ssh-config
```console
$ vuls configtest -debug
[Feb 16 06:25:51]  INFO [localhost] vuls-v0.19.3-build-20220216_062146_3000b2d
[Feb 16 06:25:51]  INFO [localhost] Validating config...
[Feb 16 06:25:51]  INFO [localhost] Detecting Server/Container OS... 
[Feb 16 06:25:51]  INFO [localhost] Detecting OS of servers... 
[Feb 16 06:25:51] DEBUG [localhost] Validating SSH Settings for Server:vuls-target ...
[Feb 16 06:25:51] DEBUG [localhost] Executing... /usr/bin/ssh -G -F /home/mainek00n/.ssh/config vuls-target
[Feb 16 06:25:51]  INFO [localhost] (1/2) Detected: forti: pseudo 
[Feb 16 06:25:51] DEBUG [localhost] Setting SSH User:root for Server:vuls-target ...
[Feb 16 06:25:51] DEBUG [localhost] Validating SSH HostName:127.0.0.1 for Server:vuls-target ...
[Feb 16 06:25:51] DEBUG [localhost] Setting SSH Port:2222 for Server:vuls-target ...
[Feb 16 06:25:51] DEBUG [localhost] Executing... ls /etc/debian_version
[Feb 16 06:25:51] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -F /home/mainek00n/.ssh/config -l root -p 2222 vuls-target stty cols 1000; ls /etc/debian_version
  exitstatus: 2
  stdout: ls: cannot access '/etc/debian_version': No such file or directory

  stderr: Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
Connection to 127.0.0.1 closed.

  err: %!s(<nil>)
[Feb 16 06:25:51] DEBUG [localhost] Not Debian like Linux. execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -F /home/mainek00n/.ssh/config -l root -p 2222 vuls-target stty cols 1000; ls /etc/debian_version
  exitstatus: 2
  stdout: ls: cannot access '/etc/debian_version': No such file or directory

  stderr: Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
Connection to 127.0.0.1 closed.

  err: %!s(<nil>)
[Feb 16 06:25:51] DEBUG [localhost] Executing... ls /etc/fedora-release
[Feb 16 06:25:52] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -F /home/mainek00n/.ssh/config -l root -p 2222 vuls-target stty cols 1000; ls /etc/fedora-release
  exitstatus: 2
  stdout: ls: cannot access '/etc/fedora-release': No such file or directory

  stderr: Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
Connection to 127.0.0.1 closed.

  err: %!s(<nil>)
[Feb 16 06:25:52] DEBUG [localhost] Executing... ls /etc/oracle-release
[Feb 16 06:25:52] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -F /home/mainek00n/.ssh/config -l root -p 2222 vuls-target stty cols 1000; ls /etc/oracle-release
  exitstatus: 2
  stdout: ls: cannot access '/etc/oracle-release': No such file or directory

  stderr: Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
Connection to 127.0.0.1 closed.

  err: %!s(<nil>)
[Feb 16 06:25:52] DEBUG [localhost] Executing... ls /etc/almalinux-release
[Feb 16 06:25:52] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -F /home/mainek00n/.ssh/config -l root -p 2222 vuls-target stty cols 1000; ls /etc/almalinux-release
  exitstatus: 2
  stdout: ls: cannot access '/etc/almalinux-release': No such file or directory

  stderr: Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
Connection to 127.0.0.1 closed.

  err: %!s(<nil>)
[Feb 16 06:25:52] DEBUG [localhost] Executing... ls /etc/rocky-release
[Feb 16 06:25:52] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -F /home/mainek00n/.ssh/config -l root -p 2222 vuls-target stty cols 1000; ls /etc/rocky-release
  exitstatus: 2
  stdout: ls: cannot access '/etc/rocky-release': No such file or directory

  stderr: Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
Connection to 127.0.0.1 closed.

  err: %!s(<nil>)
[Feb 16 06:25:52] DEBUG [localhost] Executing... ls /etc/centos-release
[Feb 16 06:25:52] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -F /home/mainek00n/.ssh/config -l root -p 2222 vuls-target stty cols 1000; ls /etc/centos-release
  exitstatus: 0
  stdout: /etc/centos-release

  stderr: Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
Connection to 127.0.0.1 closed.

  err: %!s(<nil>)
[Feb 16 06:25:52] DEBUG [localhost] Executing... cat /etc/centos-release
[Feb 16 06:25:52] DEBUG [localhost] execResult: servername: vuls-target
  cmd: /usr/bin/ssh -tt -F /home/mainek00n/.ssh/config -l root -p 2222 vuls-target stty cols 1000; cat /etc/centos-release
  exitstatus: 0
  stdout: CentOS Stream release 8

  stderr: Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
Connection to 127.0.0.1 closed.

  err: %!s(<nil>)
[Feb 16 06:25:52] DEBUG [localhost] Redhat like Linux. Host: vuls-target:2222
[Feb 16 06:25:52]  INFO [localhost] (2/2) Detected: vuls-target: centos stream8
[Feb 16 06:25:52]  INFO [localhost] Detecting OS of containers... 
[Feb 16 06:25:52]  INFO [localhost] Checking Scan Modes...
[Feb 16 06:25:52]  INFO [localhost] Checking dependencies...
[Feb 16 06:25:52]  INFO [vuls-target] Dependencies ... Pass
[Feb 16 06:25:52]  INFO [localhost] Checking sudo settings...
[Feb 16 06:25:52]  INFO [vuls-target] Sudo... Pass
[Feb 16 06:25:52]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Feb 16 06:25:52]  INFO [localhost] Scannable servers are below...
vuls-target forti
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

