### PR TITLE
fix(oval/suse): use def.Advisory.Cves[0].CveID instead of def.Title

### DIFF
--- a/oval/suse.go
+++ b/oval/suse.go
@@ -65,27 +65,30 @@ func (o SUSE) FillWithOval(r *models.ScanResult) (nCVEs int, err error) {
 }
 
 func (o SUSE) update(r *models.ScanResult, defpacks defPacks) {
-	ovalContent := *o.convertToModel(&defpacks.def)
+	ovalContent := o.convertToModel(&defpacks.def)
+	if ovalContent == nil {
+		return
+	}
 	ovalContent.Type = models.NewCveContentType(o.family)
-	vinfo, ok := r.ScannedCves[defpacks.def.Title]
+	vinfo, ok := r.ScannedCves[ovalContent.CveID]
 	if !ok {
-		logging.Log.Debugf("%s is newly detected by OVAL", defpacks.def.Title)
+		logging.Log.Debugf("%s is newly detected by OVAL", ovalContent.CveID)
 		vinfo = models.VulnInfo{
-			CveID:       defpacks.def.Title,
+			CveID:       ovalContent.CveID,
 			Confidences: models.Confidences{models.OvalMatch},
-			CveContents: models.NewCveContents(ovalContent),
+			CveContents: models.NewCveContents(*ovalContent),
 		}
 	} else {
 		cveContents := vinfo.CveContents
 		ctype := models.NewCveContentType(o.family)
 		if _, ok := vinfo.CveContents[ctype]; ok {
-			logging.Log.Debugf("%s OVAL will be overwritten", defpacks.def.Title)
+			logging.Log.Debugf("%s OVAL will be overwritten", ovalContent.CveID)
 		} else {
-			logging.Log.Debugf("%s is also detected by OVAL", defpacks.def.Title)
+			logging.Log.Debugf("%s is also detected by OVAL", ovalContent.CveID)
 			cveContents = models.CveContents{}
 		}
 		vinfo.Confidences.AppendIfMissing(models.OvalMatch)
-		cveContents[ctype] = []models.CveContent{ovalContent}
+		cveContents[ctype] = []models.CveContent{*ovalContent}
 		vinfo.CveContents = cveContents
 	}
 
@@ -105,10 +108,15 @@ func (o SUSE) update(r *models.ScanResult, defpacks defPacks) {
 	}
 	vinfo.AffectedPackages = collectBinpkgFixstat.toPackStatuses()
 	vinfo.AffectedPackages.Sort()
-	r.ScannedCves[defpacks.def.Title] = vinfo
+	r.ScannedCves[ovalContent.CveID] = vinfo
 }
 
 func (o SUSE) convertToModel(def *ovalmodels.Definition) *models.CveContent {
+	if len(def.Advisory.Cves) != 1 {
+		logging.Log.Warnf("Unknown Oval format. Please register the issue as it needs to be investigated. https://github.com/vulsio/goval-dictionary/issues family: %s, defID: %s", o.family, def.DefinitionID)
+		return nil
+	}
+
 	refs := []models.Reference{}
 	for _, r := range def.References {
 		refs = append(refs, models.Reference{
@@ -117,23 +125,15 @@ func (o SUSE) convertToModel(def *ovalmodels.Definition) *models.CveContent {
 			RefID:  r.RefID,
 		})
 	}
-	cveCont := models.CveContent{
-		CveID:      def.Title,
-		Title:      def.Title,
-		Summary:    def.Description,
-		References: refs,
+	cve := def.Advisory.Cves[0]
+	score3, vec3 := parseCvss3(cve.Cvss3)
+	return &models.CveContent{
+		Title:         def.Title,
+		Summary:       def.Description,
+		CveID:         cve.CveID,
+		Cvss3Score:    score3,
+		Cvss3Vector:   vec3,
+		Cvss3Severity: cve.Impact,
+		References:    refs,
 	}
-
-	if 0 < len(def.Advisory.Cves) {
-		if len(def.Advisory.Cves) == 1 {
-			cve := def.Advisory.Cves[0]
-			score3, vec3 := parseCvss3(cve.Cvss3)
-			cveCont.Cvss3Score = score3
-			cveCont.Cvss3Vector = vec3
-			cveCont.Cvss3Severity = cve.Impact
-		} else {
-			logging.Log.Warnf("Unknown Oval format. Please register the issue as it needs to be investigated. https://github.com/future-architect/vuls/issues family: %s, defID: %s", o.family, def.DefinitionID)
-		}
-	}
-	return &cveCont
 }


### PR DESCRIPTION
# What did you implement:
In goval-dictionary, when fetching with `--no-details`, the title will be `""`.
In vuls, there was a bug in the title-dependent part.
Fix this.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```console
$ goval-dictionary fetch suse --suse-type opensuse-leap 15.3 --no-details
$ vuls report
[Feb 17 10:50:39]  INFO [localhost] vuls-v0.19.4-build-20220217_104818_716bf30
[Feb 17 10:50:39]  INFO [localhost] Validating config...
[Feb 17 10:50:39]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Feb 17 10:50:39]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/usr/share/vuls-data/oval.sqlite3
[Feb 17 10:50:39]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/usr/share/vuls-data/gost.sqlite3
[Feb 17 10:50:39]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Feb 17 10:50:39]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Feb 17 10:50:39]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/usr/share/vuls-data/go-kev.sqlite3
[Feb 17 10:50:39]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2022-02-17T10:50:28+09:00
[Feb 17 10:50:39]  INFO [localhost] OVAL opensuse.leap 15.3 found. defs: 1333
[Feb 17 10:50:39]  INFO [localhost] OVAL opensuse.leap 15.3 is fresh. lastModified: 2022-02-17T10:20:02+09:00
[Feb 17 10:50:39]  INFO [localhost] vuls-target: 11 CVEs are detected with OVAL
[Feb 17 10:50:39]  INFO [localhost] vuls-target: 0 unfixed CVEs are detected with gost
[Feb 17 10:50:39]  INFO [localhost] vuls-target: 0 CVEs are detected with CPE
[Feb 17 10:50:39]  INFO [localhost] vuls-target: 0 PoC are detected
[Feb 17 10:50:39]  INFO [localhost] vuls-target: 0 exploits are detected
[Feb 17 10:50:39]  INFO [localhost] vuls-target: total 11 CVEs detected
[Feb 17 10:50:39]  INFO [localhost] vuls-target: 0 CVEs filtered by --confidence-over=80
vuls-target (opensuse.leap15.3)
===============================
Total: 11 (Critical:3 High:5 Medium:3 Low:0 ?:0)
11/11 Fixed, 3 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
137 installed

+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |                       NVD                       |
+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
| CVE-2021-44142 |  9.9 |  AV:N  |     |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-44142 |
| CVE-2022-23218 |  9.8 |  AV:L  | POC |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2022-23218 |
| CVE-2022-23219 |  9.8 |  AV:L  | POC |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2022-23219 |
| CVE-2022-0336  |  8.8 |  AV:N  |     |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2022-0336  |
| CVE-2021-3999  |  8.1 |  AV:L  |     |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3999  |
| CVE-2020-27840 |  7.5 |  AV:N  |     |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2020-27840 |
| CVE-2021-20277 |  7.5 |  AV:N  |     |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-20277 |
| CVE-2021-36222 |  7.5 |  AV:N  |     |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-36222 |
| CVE-2021-20316 |  5.9 |  AV:N  |     |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-20316 |
| CVE-2021-44141 |  5.0 |  AV:N  |     |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-44141 |
| CVE-2021-43566 |  4.2 |  AV:N  | POC |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-43566 |
+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference
