### PR TITLE
fix: handling when image contains no trivy-target

### DIFF
--- a/contrib/trivy/parser/v2/parser.go
+++ b/contrib/trivy/parser/v2/parser.go
@@ -35,16 +35,14 @@ func (p ParserV2) Parse(vulnJSON []byte) (result *models.ScanResult, err error) 
 }
 
 func setScanResultMeta(scanResult *models.ScanResult, report *report.Report) error {
-	isTrivyTarget := false
+	const trivyTarget = "trivy-target"
 	for _, r := range report.Results {
-		const trivyTarget = "trivy-target"
 		if pkg.IsTrivySupportedOS(r.Type) {
 			scanResult.Family = r.Type
 			scanResult.ServerName = r.Target
 			scanResult.Optional = map[string]interface{}{
 				trivyTarget: r.Target,
 			}
-			isTrivyTarget = true
 		} else if pkg.IsTrivySupportedLib(r.Type) {
 			if scanResult.Family == "" {
 				scanResult.Family = constant.ServerTypePseudo
@@ -57,14 +55,13 @@ func setScanResultMeta(scanResult *models.ScanResult, report *report.Report) err
 					trivyTarget: r.Target,
 				}
 			}
-			isTrivyTarget = true
 		}
 		scanResult.ScannedAt = time.Now()
 		scanResult.ScannedBy = "trivy"
 		scanResult.ScannedVia = "trivy"
 	}
 
-	if !isTrivyTarget {
+	if _, ok := scanResult.Optional[trivyTarget]; !ok {
 		return xerrors.Errorf("this image contains no trivy target os or libraries.")
 	}
 	return nil

--- a/contrib/trivy/parser/v2/parser.go
+++ b/contrib/trivy/parser/v2/parser.go
@@ -62,7 +62,7 @@ func setScanResultMeta(scanResult *models.ScanResult, report *report.Report) err
 	}
 
 	if _, ok := scanResult.Optional[trivyTarget]; !ok {
-		return xerrors.Errorf("this image contains no trivy target os or libraries.")
+		return xerrors.Errorf("scanned images or libraries are not supported by Trivy. see https://aquasecurity.github.io/trivy/dev/vulnerability/detection/os/, https://aquasecurity.github.io/trivy/dev/vulnerability/detection/language/")
 	}
 	return nil
 }

--- a/contrib/trivy/parser/v2/parser_test.go
+++ b/contrib/trivy/parser/v2/parser_test.go
@@ -732,7 +732,7 @@ func TestParseError(t *testing.T) {
 	}{
 		"image hello-world": {
 			vulnJSON: helloWorldTrivy,
-			expected: xerrors.Errorf("this image contains no trivy target os or libraries."),
+			expected: xerrors.Errorf("scanned images or libraries are not supported by Trivy. see https://aquasecurity.github.io/trivy/dev/vulnerability/detection/os/, https://aquasecurity.github.io/trivy/dev/vulnerability/detection/language/"),
 		},
 	}
 

--- a/contrib/trivy/parser/v2/parser_test.go
+++ b/contrib/trivy/parser/v2/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/d4l3k/messagediff"
+	"golang.org/x/xerrors"
 
 	"github.com/future-architect/vuls/models"
 )
@@ -723,3 +724,80 @@ var osAndLibSR = &models.ScanResult{
 		"trivy-target": "quay.io/fluentd_elasticsearch/fluentd:v2.9.0 (debian 10.2)",
 	},
 }
+
+func TestParseError(t *testing.T) {
+	cases := map[string]struct {
+		vulnJSON []byte
+		expected error
+	}{
+		"image hello-world": {
+			vulnJSON: helloWorldTrivy,
+			expected: xerrors.Errorf("this image contains no trivy target os or libraries."),
+		},
+	}
+
+	for testcase, v := range cases {
+		_, err := ParserV2{}.Parse(v.vulnJSON)
+
+		diff, equal := messagediff.PrettyDiff(
+			v.expected,
+			err,
+			messagediff.IgnoreStructField("frame"),
+		)
+		if !equal {
+			t.Errorf("test: %s, diff %s", testcase, diff)
+		}
+	}
+}
+
+var helloWorldTrivy = []byte(`
+{
+  "SchemaVersion": 2,
+  "ArtifactName": "hello-world:latest",
+  "ArtifactType": "container_image",
+  "Metadata": {
+    "ImageID": "sha256:feb5d9fea6a5e9606aa995e879d862b825965ba48de054caab5ef356dc6b3412",
+    "DiffIDs": [
+      "sha256:e07ee1baac5fae6a26f30cabfe54a36d3402f96afda318fe0a96cec4ca393359"
+    ],
+    "RepoTags": [
+      "hello-world:latest"
+    ],
+    "RepoDigests": [
+      "hello-world@sha256:97a379f4f88575512824f3b352bc03cd75e239179eea0fecc38e597b2209f49a"
+    ],
+    "ImageConfig": {
+      "architecture": "amd64",
+      "container": "8746661ca3c2f215da94e6d3f7dfdcafaff5ec0b21c9aff6af3dc379a82fbc72",
+      "created": "2021-09-23T23:47:57.442225064Z",
+      "docker_version": "20.10.7",
+      "history": [
+        {
+          "created": "2021-09-23T23:47:57Z",
+          "created_by": "/bin/sh -c #(nop) COPY file:50563a97010fd7ce1ceebd1fa4f4891ac3decdf428333fb2683696f4358af6c2 in / "
+        },
+        {
+          "created": "2021-09-23T23:47:57Z",
+          "created_by": "/bin/sh -c #(nop)  CMD [\"/hello\"]",
+          "empty_layer": true
+        }
+      ],
+      "os": "linux",
+      "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+          "sha256:e07ee1baac5fae6a26f30cabfe54a36d3402f96afda318fe0a96cec4ca393359"
+        ]
+      },
+      "config": {
+        "Cmd": [
+          "/hello"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "Image": "sha256:b9935d4e8431fb1a7f0989304ec86b3329a99a25f5efdc7f09f3f8c41434ca6d"
+      }
+    }
+  }
+}`)


### PR DESCRIPTION
# What did you implement:

I added error handling to trivy-to-vuls.
If Trivy scan the image that is not Trivy supported OS or Libraries, Vuls behave the result is not parsable and is error.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. write a test code
2. I have tried to parse result of `./trivy -q image --list-all-pkgs -f json hello-world:latest` and confirmed outputting error as expected
3. I have tried to parse result of `./trivy -q image --list-all-packages -f json ubuntu:latest` and confirmed outputing no error as usual

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

