### PR TITLE
feat(oval): support EPEL

### DIFF
--- a/constant/constant.go
+++ b/constant/constant.go
@@ -32,6 +32,9 @@ const (
 	// Oracle is
 	Oracle = "oracle"
 
+	// EPEL is
+	EPEL = "epel"
+
 	// FreeBSD is
 	FreeBSD = "freebsd"
 

--- a/models/packages.go
+++ b/models/packages.go
@@ -80,6 +80,7 @@ type Package struct {
 	NewVersion       string               `json:"newVersion"`
 	NewRelease       string               `json:"newRelease"`
 	Arch             string               `json:"arch"`
+	Vendor           string               `json:"vendor"`
 	Repository       string               `json:"repository"`
 	Changelog        *Changelog           `json:"changelog,omitempty"`
 	AffectedProcs    []AffectedProcess    `json:",omitempty"`

--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -500,25 +500,25 @@ func (o *redhatBase) parseInstalledPackages(stdout string) (models.Packages, mod
 }
 
 func (o *redhatBase) parseInstalledPackagesLine(line string) (*models.Package, error) {
-	fields := strings.Fields(line)
-	if len(fields) != 5 {
-		return nil,
-			xerrors.Errorf("Failed to parse package line: %s", line)
+	ss := strings.SplitN(line, " ", 6)
+	if len(ss) != 6 {
+		return nil, xerrors.Errorf("Failed to parse package line: %s", line)
 	}
 
 	ver := ""
-	epoch := fields[1]
+	epoch := ss[1]
 	if epoch == "0" || epoch == "(none)" {
-		ver = fields[2]
+		ver = ss[2]
 	} else {
-		ver = fmt.Sprintf("%s:%s", epoch, fields[2])
+		ver = fmt.Sprintf("%s:%s", epoch, ss[2])
 	}
 
 	return &models.Package{
-		Name:    fields[0],
+		Name:    ss[0],
 		Version: ver,
-		Release: fields[3],
-		Arch:    fields[4],
+		Release: ss[3],
+		Arch:    ss[4],
+		Vendor:  strings.TrimSuffix(ss[5], "\r"),
 	}, nil
 }
 
@@ -783,8 +783,8 @@ func (o *redhatBase) getOwnerPkgs(paths []string) (names []string, _ error) {
 }
 
 func (o *redhatBase) rpmQa() string {
-	const old = `rpm -qa --queryformat "%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{ARCH}\n"`
-	const new = `rpm -qa --queryformat "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH}\n"`
+	const old = `rpm -qa --queryformat "%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{ARCH} %{VENDOR}\n"`
+	const new = `rpm -qa --queryformat "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH} %{VENDOR}\n"`
 	switch o.Distro.Family {
 	case constant.OpenSUSE:
 		if o.Distro.Release == "tumbleweed" {
@@ -807,8 +807,8 @@ func (o *redhatBase) rpmQa() string {
 }
 
 func (o *redhatBase) rpmQf() string {
-	const old = `rpm -qf --queryformat "%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{ARCH}\n" `
-	const new = `rpm -qf --queryformat "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH}\n" `
+	const old = `rpm -qf --queryformat "%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{ARCH} %{VENDOR}\n" `
+	const new = `rpm -qf --queryformat "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH} %{VENDOR}\n" `
 	switch o.Distro.Family {
 	case constant.OpenSUSE:
 		if o.Distro.Release == "tumbleweed" {


### PR DESCRIPTION
# What did you implement:
support EPEL repository

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ vuls scan
[Mar  7 11:03:56]  INFO [localhost] vuls-`make build` or `make install` will show the version-
[Mar  7 11:03:56]  INFO [localhost] Start scanning
[Mar  7 11:03:56]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Mar  7 11:03:56]  INFO [localhost] Validating config...
[Mar  7 11:03:56]  INFO [localhost] Detecting Server/Container OS... 
[Mar  7 11:03:56]  INFO [localhost] Detecting OS of servers... 
[Mar  7 11:03:57]  INFO [localhost] (1/1) Detected: vuls-target: rocky 8.5
[Mar  7 11:03:57]  INFO [localhost] Detecting OS of containers... 
[Mar  7 11:03:57]  INFO [localhost] Checking Scan Modes... 
[Mar  7 11:03:57]  INFO [localhost] Detecting Platforms... 
[Mar  7 11:03:59]  INFO [localhost] (1/1) vuls-target is running on other
[Mar  7 11:03:59]  INFO [vuls-target] Scanning OS pkg in fast mode


Scan Summary
================
vuls-target	rocky8.5	233 installed, 2 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ vuls report 
[Mar  7 11:04:14]  INFO [localhost] vuls-`make build` or `make install` will show the version-
[Mar  7 11:04:14]  INFO [localhost] Validating config...
[Mar  7 11:04:14]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Mar  7 11:04:14]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/goval-dictionary/oval.sqlite3
[Mar  7 11:04:14]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/usr/share/vuls-data/gost.sqlite3
[Mar  7 11:04:14]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Mar  7 11:04:14]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Mar  7 11:04:14]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/usr/share/vuls-data/go-kev.sqlite3
[Mar  7 11:04:14]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2022-03-07T11:03:59+09:00
[Mar  7 11:04:14]  INFO [localhost] OVAL redhat 8.5 found. defs: 822
[Mar  7 11:04:14]  INFO [localhost] OVAL redhat 8.5 is fresh. lastModified: 2022-03-07T08:50:13+09:00
[Mar  7 11:04:15]  INFO [localhost] vuls-target: 1 CVEs are detected with OVAL
[Mar  7 11:04:15]  INFO [localhost] vuls-target: 17 unfixed CVEs are detected with gost
[Mar  7 11:04:15]  INFO [localhost] vuls-target: 0 CVEs are detected with CPE
[Mar  7 11:04:15]  INFO [localhost] vuls-target: 0 PoC are detected
[Mar  7 11:04:15]  INFO [localhost] vuls-target: 0 exploits are detected
[Mar  7 11:04:15]  INFO [localhost] vuls-target: total 17 CVEs detected
[Mar  7 11:04:15]  INFO [localhost] vuls-target: 0 CVEs filtered by --confidence-over=80
vuls-target (rocky8.5)
======================
Total: 17 (Critical:0 High:6 Medium:11 Low:0 ?:0)
1/17 Fixed, 2 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
233 installed

+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |                       NVD                       |
+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
| CVE-2021-36367 |  8.9 |  AV:N  |     |           |   fixed | https://nvd.nist.gov/vuln/detail/CVE-2021-36367 |
| CVE-2021-3999  |  8.1 |  AV:N  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3999  |
| CVE-2020-35492 |  7.8 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2020-35492 |
| CVE-2020-19131 |  7.5 |  AV:N  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2020-19131 |
| CVE-2021-43618 |  7.5 |  AV:L  | POC |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-43618 |
| CVE-2021-41617 |  7.0 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-41617 |
| CVE-2021-23177 |  6.6 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-23177 |
| CVE-2017-14166 |  6.5 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2017-14166 |
| CVE-2017-14501 |  6.5 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2017-14501 |
| CVE-2021-35938 |  6.5 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-35938 |
| CVE-2021-35939 |  6.5 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-35939 |
| CVE-2021-35937 |  6.3 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-35937 |
| CVE-2021-40528 |  5.9 |  AV:N  | POC |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-40528 |
| CVE-2018-18700 |  5.5 |  AV:N  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2018-18700 |
| CVE-2021-3997  |  5.5 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3997  |
| CVE-2021-31566 |  4.4 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-31566 |
| CVE-2021-3521  |  4.4 |  AV:L  |     |           | unfixed | https://nvd.nist.gov/vuln/detail/CVE-2021-3521  |
+----------------+------+--------+-----+-----------+---------+-------------------------------------------------+
```

![image](https://user-images.githubusercontent.com/16035056/156960582-355762c6-b74e-4ac1-8867-4f8a16af1201.png)

- test Docker image
```Dockerfile
FROM rockylinux/rockylinux:8

RUN dnf -y upgrade && dnf -y install openssh-server glibc-langpack-en
RUN mkdir /var/run/sshd

RUN sed -i 's/#\?PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
RUN sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd

ENV NOTVISIBLE "in users profile"
RUN echo "export VISIBLE=now" >> /etc/profile

COPY .ssh/id_rsa.pub /root/authorized_keys
RUN mkdir ~/.ssh && \
    mv ~/authorized_keys ~/.ssh/authorized_keys && \
    chmod 0600 ~/.ssh/authorized_keys

RUN ssh-keygen -A
RUN rm -rf /run/nologin

EXPOSE 22

# Vuls Setting
RUN dnf -y install dnf-utils which lsof iproute

# EPEL
RUN dnf -y install 'dnf-command(config-manager)' && dnf config-manager --set-enabled powertools
RUN dnf -y install epel-release
# FEDORA-EPEL-2021-3c32bc85f8 CVE-2021-36367
RUN dnf -y install https://dl.fedoraproject.org/pub/archive/epel/8.3/Everything/x86_64/Packages/p/putty-0.74-4.el8.x86_64.rpm

CMD ["/usr/sbin/sshd", "-D"]
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference
- https://github.com/vulsio/goval-dictionary/pull/213
