### PR TITLE
feat: replace NVD-column with packages-column at output of report

### DIFF
--- a/reporter/util.go
+++ b/reporter/util.go
@@ -255,6 +255,7 @@ No CVE-IDs are found in updatable packages.
 		// v2max := vinfo.MaxCvss2Score().Value.Score
 		// v3max := vinfo.MaxCvss3Score().Value.Score
 
+		packnames := strings.Join(vinfo.AffectedPackages.Names(), ", ")
 		// packname := vinfo.AffectedPackages.FormatTuiSummary()
 		// packname += strings.Join(vinfo.CpeURIs, ", ")
 
@@ -263,12 +264,12 @@ No CVE-IDs are found in updatable packages.
 			exploits = "POC"
 		}
 
-		link := ""
-		if strings.HasPrefix(vinfo.CveID, "CVE-") {
-			link = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vinfo.CveID)
-		} else if strings.HasPrefix(vinfo.CveID, "WPVDBID-") {
-			link = fmt.Sprintf("https://wpscan.com/vulnerabilities/%s", strings.TrimPrefix(vinfo.CveID, "WPVDBID-"))
-		}
+		// link := ""
+		// if strings.HasPrefix(vinfo.CveID, "CVE-") {
+		// 	link = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vinfo.CveID)
+		// } else if strings.HasPrefix(vinfo.CveID, "WPVDBID-") {
+		// 	link = fmt.Sprintf("https://wpscan.com/vulnerabilities/%s", strings.TrimPrefix(vinfo.CveID, "WPVDBID-"))
+		// }
 
 		data = append(data, []string{
 			vinfo.CveIDDiffFormat(),
@@ -279,7 +280,7 @@ No CVE-IDs are found in updatable packages.
 			exploits,
 			fmt.Sprintf("%9s", vinfo.AlertDict.FormatSource()),
 			fmt.Sprintf("%7s", vinfo.PatchStatus(r.Packages)),
-			link,
+			packnames,
 		})
 	}
 
@@ -294,7 +295,8 @@ No CVE-IDs are found in updatable packages.
 		"PoC",
 		"Alert",
 		"Fixed",
-		"NVD",
+		// "NVD",
+		"Packages",
 	})
 	table.SetBorder(true)
 	table.AppendBulk(data)

--- a/reporter/util.go
+++ b/reporter/util.go
@@ -299,6 +299,7 @@ No CVE-IDs are found in updatable packages.
 		"Packages",
 	})
 	table.SetBorder(true)
+	table.SetRowLine(true)
 	table.AppendBulk(data)
 	table.Render()
 	return fmt.Sprintf("%s\n%s", header, b.String())

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -456,7 +456,7 @@ func validateSSHConfig(c *config.ServerInfo) error {
 	sshKeyScanArgs = append(sshKeyScanArgs, fmt.Sprintf("%s >> %s", hostname, knownHostsPaths[0]))
 	sshConnCmd := fmt.Sprintf("ssh %s", strings.Join(sshConnArgs, " "))
 	sshKeyScancmd := fmt.Sprintf("ssh-keyscan %s", strings.Join(sshKeyScanArgs, " "))
-	return xerrors.Errorf("Failed to find the host in known_hosts. Plaese exec `$ %s` or `$ %s`", sshConnCmd, sshKeyScancmd)
+	return xerrors.Errorf("Failed to find the host in known_hosts. Please exec `$ %s` or `$ %s`", sshConnCmd, sshKeyScancmd)
 }
 
 func (s Scanner) detectContainerOSes(hosts []osTypeInterface) (actives, inactives []osTypeInterface) {


### PR DESCRIPTION
# What did you implement:

Replace NVD column with PACKAGES column at the output of `vuls report` and add table row lines.
+fix spelling mistake

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

```
❯ vuls report
[Mar  7 20:49:10]  INFO [localhost] vuls-v0.19.4-build-20220307_202611_dc9ae7a
[Mar  7 20:49:10]  INFO [localhost] Validating config...
[Mar  7 20:49:10]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/home/masato/go/src/github.com/future-architect/vuls/cve.sqlite3
[Mar  7 20:49:10]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/masato/go/src/github.com/future-architect/vuls/oval.sqlite3
[Mar  7 20:49:10]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/home/masato/go/src/github.com/future-architect/vuls/gost.sqlite3
[Mar  7 20:49:10]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/home/masato/go/src/github.com/future-architect/vuls/go-exploitdb.sqlite3
[Mar  7 20:49:10]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/home/masato/go/src/github.com/future-architect/vuls/go-msfdb.sqlite3
[Mar  7 20:49:10]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/home/masato/go/src/github.com/future-architect/vuls/go-kev.sqlite3
[Mar  7 20:49:10]  INFO [localhost] Loaded: /home/masato/go/src/github.com/future-architect/vuls/results/2022-03-07T20:47:20+09:00
[Mar  7 20:49:10]  INFO [localhost] No need to refresh
[Mar  7 20:49:10]  INFO [localhost] localhost: total 257 CVEs detected
[Mar  7 20:49:10]  INFO [localhost] localhost: 0 CVEs filtered by --confidence-over=80
localhost (ubuntu20.04)
=======================
Total: 257 (Critical:0 High:1 Medium:92 Low:117 ?:47)
0/257 Fixed, 0 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
1932 installed

+------------------+------+--------+-----+-----------+---------+----------------------------------------+
|      CVE-ID      | CVSS | ATTACK | POC |   ALERT   |  FIXED  |                PACKAGES                |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2019-11707   |  8.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2013-7445    |  6.9 |        |     |           | unfixed | linux-image-5.4.0-100-generic          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2015-8553    |  6.9 |        |     |           | unfixed | linux-image-5.4.0-100-generic          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2016-1585    |  6.9 |        |     |           | unfixed | apparmor                               |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2016-8660    |  6.9 |        |     |           | unfixed | linux-image-5.4.0-100-generic          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2017-7810    |  6.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2017-7826    |  6.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2017-7827    |  6.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2017-7831    |  6.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2018-17977   |  6.9 |        |     |           | unfixed | linux-image-5.4.0-100-generic          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2018-5089    |  6.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2018-5090    |  6.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2018-5093    |  6.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2018-5094    |  6.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2018-5125    |  6.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2018-5126    |  6.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2018-5145    |  6.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2018-5150    |  6.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2018-5151    |  6.9 |        |     |           | unfixed | libmozjs-52-0                          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2020-10134   |  6.9 |        |     |           | unfixed | bluez                                  |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2020-10756   |  6.9 |        |     |           | unfixed | slirp4netns                            |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2020-13844   |  6.9 |        |     |           | unfixed | cpp, cpp-7, g++, gcc,                  |
|                  |      |        |     |           |         | gcc-7-base, gcc-8-base, gcc-9          |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
| CVE-2020-13962   |  6.9 |        |     |           | unfixed | libqt5core5a, libqt5dbus5,             |
|                  |      |        |     |           |         | libqt5gui5, libqt5network5,            |
|                  |      |        |     |           |         | libqt5opengl5,                         |
|                  |      |        |     |           |         | libqt5printsupport5,                   |
|                  |      |        |     |           |         | libqt5sql5, libqt5sql5-sqlite,         |
|                  |      |        |     |           |         | libqt5test5,                           |
|                  |      |        |     |           |         | libqt5widgets5, libqt5xml5,            |
|                  |      |        |     |           |         | qt5-gtk-platformtheme                  |
+------------------+------+--------+-----+-----------+---------+----------------------------------------+
... snip ....
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES