### PR TITLE
feat(library): add auto detect library

### DIFF
--- a/models/library.go
+++ b/models/library.go
@@ -137,17 +137,24 @@ var LibraryMap = map[string]string{
 	"Gemfile.lock":       "ruby",
 	"Cargo.lock":         "rust",
 	"composer.lock":      "php",
+	"requirements.txt":   "python",
 	"Pipfile.lock":       "python",
 	"poetry.lock":        "python",
 	"packages.lock.json": ".net",
+	"packages.config":    ".net",
 	"go.sum":             "gomod",
+	"pom.xml":            "java",
+	"*.jar":              "java",
+	"*.war":              "java",
+	"*.ear":              "java",
+	"*.par":              "java",
 }
 
 // GetLibraryKey returns target library key
 func (s LibraryScanner) GetLibraryKey() string {
 	fileName := filepath.Base(s.LockfilePath)
 	switch s.Type {
-	case "jar", "war", "ear":
+	case "jar", "war", "ear", "par":
 		return "java"
 	}
 	return LibraryMap[fileName]

--- a/scanner/base.go
+++ b/scanner/base.go
@@ -592,12 +592,12 @@ func (l *base) scanLibraries() (err error) {
 	if l.ServerInfo.FindLock {
 		findopt := ""
 		for filename := range models.LibraryMap {
-			findopt += fmt.Sprintf("-name %q -o ", "*"+filename)
+			findopt += fmt.Sprintf("-name %q -o ", filename)
 		}
 
 		// delete last "-o "
-		// find / -name "*package-lock.json" -o -name "*yarn.lock" ... 2>&1 | grep -v "find: "
-		cmd := fmt.Sprintf(`find / ` + findopt[:len(findopt)-3] + ` 2>&1 | grep -v "find: "`)
+		// find / -type f -and \( -name "package-lock.json" -o -name "yarn.lock" ... \) 2>&1 | grep -v "find: "
+		cmd := fmt.Sprintf(`find / -type f -and \( ` + findopt[:len(findopt)-3] + ` \) 2>&1 | grep -v "find: "`)
 		r := exec(l.ServerInfo, cmd, noSudo)
 		if r.ExitStatus != 0 && r.ExitStatus != 1 {
 			return xerrors.Errorf("Failed to find lock files")

--- a/subcmds/discover.go
+++ b/subcmds/discover.go
@@ -185,12 +185,12 @@ func printConfigToml(ips []string) (err error) {
 #keyPath            = "/home/username/.ssh/id_rsa"
 #scanMode           = ["fast", "fast-root", "deep", "offline"]
 #scanModules        = ["ospkg", "wordpress", "lockfile", "port"]
+#lockfiles = ["/path/to/package-lock.json"]
 #cpeNames = [
 #  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
 #]
 #owaspDCXMLPath     = "/tmp/dependency-check-report.xml"
 #ignoreCves         = ["CVE-2014-6271"]
-#containersOnly     = false
 #containerType      = "docker" #or "lxd" or "lxc" default: docker
 #containersIncluded = ["${running}"]
 #containersExcluded = ["container_name_a"]
@@ -209,6 +209,8 @@ host                = "{{$ip}}"
 #scanModules        = ["ospkg", "wordpress", "lockfile", "port"]
 #type               = "pseudo"
 #memo               = "DB Server"
+#findLock = true
+#lockfiles = ["/path/to/package-lock.json"]
 #cpeNames           = [ "cpe:/a:rubyonrails:ruby_on_rails:4.2.1" ]
 #owaspDCXMLPath     = "/path/to/dependency-check-report.xml"
 #ignoreCves         = ["CVE-2014-0160"]


### PR DESCRIPTION
# What did you implement:

Fixes #1416

Increase the scope of automatic library detection by findLock=true.

## Type of change

- [x] New feature non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
```console
$ go run cmd/vuls/main.go scan -config=./config.toml library
[Mar 14 21:01:10]  INFO [localhost] vuls-`make build` or `make install` will show the version-
[Mar 14 21:01:10]  INFO [localhost] Start scanning
[Mar 14 21:01:10]  INFO [localhost] config: ./config.toml
[Mar 14 21:01:10]  INFO [localhost] Validating config...
[Mar 14 21:01:10]  INFO [localhost] Detecting Server/Container OS... 
[Mar 14 21:01:10]  INFO [localhost] Detecting OS of servers... 
[Mar 14 21:01:10]  INFO [localhost] (1/1) Detected: library: ubuntu 20.04
[Mar 14 21:01:10]  INFO [localhost] Detecting OS of containers... 
[Mar 14 21:01:10]  INFO [localhost] Checking Scan Modes... 
[Mar 14 21:01:10]  INFO [localhost] Detecting Platforms... 
[Mar 14 21:01:11]  INFO [localhost] (1/1) library is running on other
[Mar 14 21:01:11]  INFO [library] Scanning Lockfile...
[Mar 14 21:01:11] DEBUG [localhost] execResult: servername: library
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-library.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; find / -type f -and \( -name "*.par" -o -name "yarn.lock" -o -name "composer.lock" -o -name "package-lock.json" -o -name "Cargo.lock" -o -name "go.sum" -o -name "pom.xml" -o -name "*.war" -o -name "requirements.txt" -o -name "packages.lock.json" -o -name "poetry.lock" -o -name "packages.config" -o -name "*.jar" -o -name "*.ear" -o -name "Gemfile.lock" -o -name "Pipfile.lock"  \) 2>&1 | grep -v "find: "
...

Scan Summary
================
library	ubuntu20.04	0 installed	2107 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

- config.toml
```toml
[servers]
[servers.library]
host                = "127.0.0.1"
port               = "2222"
user               = "root"
keyPath            = "/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
findLock = true
```

- Dockerfile
```dockerfile
FROM ubuntu:20.04

# SSH Setting
RUN apt update && apt install -y openssh-server
RUN mkdir /var/run/sshd

RUN sed -i 's/#\?PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
RUN sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd

ENV NOTVISIBLE "in users profile"
RUN echo "export VISIBLE=now" >> /etc/profile

COPY .ssh/id_rsa.pub /root/authorized_keys
RUN mkdir ~/.ssh && \
    mv ~/authorized_keys ~/.ssh/authorized_keys && \
    chmod 0600 ~/.ssh/authorized_keys

EXPOSE 22

# Vuls Setting
RUN apt install -y lsof iproute2
RUN DEBIAN_FRONTEND=noninteractive apt install -y debian-goodies

# add lockfiles
RUN apt install -y git
RUN git clone https://github.com/vulsio/integration.git

CMD ["/usr/sbin/sshd", "-D"]

```

## diff master vs MaineK00n/add-more-autodetect
### master
```console
$ grep '"path":' results/2022-03-14T21:01:23+09:00/library.json | sort | uniq
            "path": "/integration/data/lockfile/Cargo.lock"
            "path": "/integration/data/lockfile/composer.lock"
            "path": "/integration/data/lockfile/Gemfile.lock"
            "path": "/integration/data/lockfile/go.sum"
            "path": "/integration/data/lockfile/package-lock.json"
            "path": "/integration/data/lockfile/packages.lock.json"
            "path": "/integration/data/lockfile/Pipfile.lock"
            "path": "/integration/data/lockfile/poetry.lock"
            "path": "/integration/data/lockfile/yarn.lock"
```

### MaineK00n/add-more-autodetect
```console
$ grep '"path":' results/2022-03-14T21:01:11+09:00/library.json | sort | uniq
            "path": "/integration/data/lockfile/Cargo.lock"
            "path": "/integration/data/lockfile/composer.lock"
            "path": "/integration/data/lockfile/Gemfile.lock"
            "path": "/integration/data/lockfile/go.sum"
            "path": "/integration/data/lockfile/package-lock.json"
            "path": "/integration/data/lockfile/packages.config"
            "path": "/integration/data/lockfile/packages.lock.json"
            "path": "/integration/data/lockfile/Pipfile.lock"
            "path": "/integration/data/lockfile/poetry.lock"
            "path": "/integration/data/lockfile/pom.xml"
            "path": "/integration/data/lockfile/requirements.txt"
            "path": "/integration/data/lockfile/test.jar"
            "path": "/integration/data/lockfile/yarn.lock"
```


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://github.com/vulsdoc/vuls/pull/198

