### PR TITLE
feat: support server scan for suse with text/plain

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -237,6 +237,8 @@ func ParseInstalledPkgs(distro config.Distro, kernel models.Kernel, pkgList stri
 		osType = &amazon{redhatBase: redhatBase{base: base}}
 	case constant.Fedora:
 		osType = &fedora{redhatBase: redhatBase{base: base}}
+	case constant.OpenSUSE, constant.OpenSUSELeap, constant.SUSEEnterpriseServer, constant.SUSEEnterpriseDesktop:
+		osType = &suse{redhatBase: redhatBase{base: base}}
 	default:
 		return models.Packages{}, models.SrcPackages{}, xerrors.Errorf("Server mode for %s is not implemented yet", base.Distro.Family)
 	}


### PR DESCRIPTION
# What did you implement:

I implemented Server mode for SUSE with `text/plain`.
(`application/json` has already been implemented)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

I run vuls with Server mode and scan SLES in practice.
The actual requst and response are below.
I checked that packages are scanned and CVES are detected expectedly.

<details><summary>Request</summary><div>

```
curl -X POST -H "Content-Type: text/plain" -H "X-Vuls-OS-Family: suse.linux.enterprise.server" -H "X-Vuls-OS-Release: 12.5" -H "X-Vuls-Kernel-Release: 4.12.14-122.103-default" -H "X-Vuls-Server-Name: ip-192-168-0-181" --data-binary "
libsmbconf0 0 4.10.18+git.339.c912385a5e1 3.41.1 x86_64
mozilla-nspr 0 4.32 19.18.1 x86_64
libdcerpc0 0 4.10.18+git.339.c912385a5e1 3.41.1 x86_64
pciutils-ids 0 2019.08.30 12.6.1 noarch
libsmbldap2 0 4.10.18+git.339.c912385a5e1 3.41.1 x86_64
suse-build-key 0 12.0 7.12.1 noarch
ca-certificates-mozilla 0 2.44 12.34.1 noarch
timezone 0 2021e 74.55.1 x86_64
growpart 0 0.31 4.14.2 noarch
runc 0 1.0.2 16.14.1 x86_64
ruby2.1-rubygem-docker-api 0 1.31.0 11.2 x86_64
python-simplejson 0 3.8.2 12.1 x86_64
ruby2.1-rubygem-thor 0 0.19.1 1.1 x86_64
python-futures 0 3.0.2 15.3.1 noarch
ruby2.1-rubygem-ruby-dbus 0 0.9.3 3.6 x86_64
elfutils 0 0.158 7.13.3 x86_64
glib2-tools 0 2.48.2 12.22.1 x86_64
libnl3-200 0 3.2.23 4.4.6 x86_64
python3-setuptools 0 40.6.2 4.18.1 noarch
libicu52_1 0 52.1 8.10.1 x86_64
netcfg 0 11.5 29.1 noarch
binutils 0 2.37 9.44.1 x86_64
ruby2.1-rubygem-cheetah 0 0.5.0 4.1 x86_64
python3-jsonpointer 0 1.0 10.3.1 noarch
yast2-country-data 0 3.2.18 1.7 x86_64
python3-jsonpatch 0 1.1 10.4.1 noarch
python3-cryptography 0 2.8 7.37.8 x86_64
libauparse0 0 2.8.1 10.11.1 x86_64
telnet 0 1.2 165.63 x86_64
libirs161 0 9.11.22 3.37.1 x86_64
dbus-1 0 1.8.22 35.2 x86_64
openslp 0 2.0.0 24.2.1 x86_64
systemd-sysvinit 0 228 157.33.1 x86_64
kmod-compat 0 25 3.4.1 x86_64
python3-urllib3 0 1.25.10 3.31.2 noarch
cyrus-sasl-gssapi 0 2.1.26 14.2.1 x86_64
python-botocore 0 1.20.9 28.30.2 noarch
libefivar1 0 31 1.13 x86_64
libcryptmount0 0 2.14 13.11 x86_64
efibootmgr 0 14 1.13 x86_64" http://localhost:5515/vuls
```
</div></details>

<details><summary>Response</summary><div>

```
[
  {
    "jsonVersion": 0,
    "lang": "",
    "serverUUID": "",
    "serverName": "ip-192-168-0-181",
    "family": "suse.linux.enterprise.server",
    "release": "12.5",
    "container": {
      "containerID": "",
      "name": "",
      "image": "",
      "type": "",
      "uuid": ""
    },
    "platform": {
      "name": "",
      "instanceID": ""
    },
    "scannedAt": "0001-01-01T00:00:00Z",
    "scanMode": "",
    "scannedVersion": "",
    "scannedRevision": "",
    "scannedBy": "",
    "scannedVia": "",
    "reportedAt": "2022-04-04T12:24:59.4883703+09:00",
    "reportedVersion": "",
    "reportedRevision": "",
    "reportedBy": "",
    "errors": null,
    "warnings": null,
    "scannedCves": {
      "CVE-2020-25717": {
        "cveID": "CVE-2020-25717",
        "confidences": [
          {
            "score": 100,
            "detectionMethod": "OvalMatch"
          }
        ],
        "affectedPackages": [
          {
            "name": "libdcerpc0",
            "fixedIn": "0:4.10.18+git.344.93a2ffaacec-3.44.2"
          }
        ],
        "cveContents": {
          "suse": [
            {
              "type": "suse",
              "cveID": "CVE-2020-25717",
              "title": "CVE-2020-25717",
              "summary": "\n    A flaw was found in the way Samba maps domain users to local users. An authenticated attacker could use this flaw to cause possible privilege escalation.\n    ",
              "cvss2Score": 0,
              "cvss2Vector": "",
              "cvss2Severity": "",
              "cvss3Score": 8.1,
              "cvss3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N",
              "cvss3Severity": "important",
              "sourceLink": "https://www.suse.com/security/cve/CVE-2020-25717.html",
              "references": [
                {
                  "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25717",
                  "source": "CVE",
                  "refID": "Mitre CVE-2020-25717"
                },
                {
                  "link": "https://www.suse.com/security/cve/CVE-2020-25717",
                  "source": "SUSE CVE",
                  "refID": "SUSE CVE-2020-25717"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2021-December/009831.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2021:770-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2021-December/009832.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2021:771-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2021-December/009833.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2021:772-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/009963.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:1-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/010136.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:148-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/010137.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:149-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/009964.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:2-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/010128.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:28-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/010129.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:29-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/009965.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:3-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/010130.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:30-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/010138.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:49-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2021-November/009716.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2021:3647-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2021-November/009713.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2021:3649-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2021-November/009714.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2021:3650-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2021-November/009724.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2021:3662-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2021-November/009731.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2021:3673-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2021-November/009729.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2021:3674-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2021-November/009750.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2021:3746-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2021-November/009748.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2021:3747-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010209.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2022:0361-1"
                },
                {
                  "link": "https://www.suse.com/support/kb/doc/?id=000020533",
                  "source": "SUSE-SU",
                  "refID": "TID000020533"
                },
                {
                  "link": "https://www.suse.com/support/kb/doc/?id=000020593",
                  "source": "SUSE-SU",
                  "refID": "TID000020593"
                },
                {
                  "link": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/6W4QSQCTUGSIZCTRT4FGJNMRLZDUZS6Y/",
                  "source": "SUSE-SU",
                  "refID": "openSUSE-SU-2021:1471-1"
                },
                {
                  "link": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/36K5HNX67LYX5XOVQRL3MSIC5YSJ5M5W/",
                  "source": "SUSE-SU",
                  "refID": "openSUSE-SU-2021:3647-1"
                },
                {
                  "link": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/7ZU5FWTEOBTHR7WNP3HEICT3NJTBNV2V/",
                  "source": "SUSE-SU",
                  "refID": "openSUSE-SU-2021:3650-1"
                },
                {
                  "link": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/DJMHDQABDOOUGOYNHF2X56XA57GXYYSN/",
                  "source": "SUSE-SU",
                  "refID": "openSUSE-SU-2021:3662-1"
                },
                {
                  "link": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/ZYEHJEQQ7LEL2T775B7QLR3IFR6LJGLZ/",
                  "source": "SUSE-SU",
                  "refID": "openSUSE-SU-2021:3674-1"
                },
                {
                  "link": "https://lists.suse.com/archive/suse-security-announce/2007-Jun/0001.html",
                  "source": "SUSE-SU",
                  "refID": "unknown"
                }
              ],
              "published": "0001-01-01T00:00:00Z",
              "lastModified": "0001-01-01T00:00:00Z"
            }
          ]
        },
        "alertDict": {
          "cisa": null,
          "jpcert": null,
          "uscert": null
        }
      },
      "CVE-2021-25220": {
        "cveID": "CVE-2021-25220",
        "confidences": [
          {
            "score": 100,
            "detectionMethod": "OvalMatch"
          }
        ],
        "affectedPackages": [
          {
            "name": "libirs161",
            "fixedIn": "0:9.11.22-3.40.1"
          }
        ],
        "cveContents": {
          "suse": [
            {
              "type": "suse",
              "cveID": "CVE-2021-25220",
              "title": "CVE-2021-25220",
              "summary": "\n    BIND 9.11.0 -> 9.11.36 9.12.0 -> 9.16.26 9.17.0 -> 9.18.0 BIND Supported Preview Editions: 9.11.4-S1 -> 9.11.36-S1 9.16.8-S1 -> 9.16.26-S1 Versions of BIND 9 earlier than those shown - back to 9.1.0, including Supported Preview Editions - are also believed to be affected but have not been tested as they are EOL. The cache could become poisoned with incorrect records leading to queries being made to the wrong servers, which might also result in false information being returned to clients.\n    ",
              "cvss2Score": 0,
              "cvss2Vector": "",
              "cvss2Severity": "",
              "cvss3Score": 6.8,
              "cvss3Vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:C/C:N/I:H/A:N",
              "cvss3Severity": "moderate",
              "sourceLink": "https://www.suse.com/security/cve/CVE-2021-25220.html",
              "references": [
                {
                  "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-25220",
                  "source": "CVE",
                  "refID": "Mitre CVE-2021-25220"
                },
                {
                  "link": "https://www.suse.com/security/cve/CVE-2021-25220",
                  "source": "SUSE CVE",
                  "refID": "SUSE CVE-2021-25220"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010486.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2022:0908-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010511.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2022:0945-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010510.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2022:0946-1"
                },
                {
                  "link": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/CMT7WJZ5DRHFL7RDXL4VX4ECRDHO6Z74/",
                  "source": "SUSE-SU",
                  "refID": "openSUSE-SU-2022:0945-1"
                },
                {
                  "link": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/H45VCAWRRO6SPMMAFDPU45PJLVOMA44Y/",
                  "source": "SUSE-SU",
                  "refID": "openSUSE-SU-2022:0946-1"
                }
              ],
              "published": "0001-01-01T00:00:00Z",
              "lastModified": "0001-01-01T00:00:00Z"
            }
          ]
        },
        "alertDict": {
          "cisa": null,
          "jpcert": null,
          "uscert": null
        }
      },
      "CVE-2021-3800": {
        "cveID": "CVE-2021-3800",
        "confidences": [
          {
            "score": 100,
            "detectionMethod": "OvalMatch"
          }
        ],
        "affectedPackages": [
          {
            "name": "glib2-tools",
            "fixedIn": "0:2.48.2-12.25.1"
          }
        ],
        "cveContents": {
          "suse": [
            {
              "type": "suse",
              "cveID": "CVE-2021-3800",
              "title": "CVE-2021-3800",
              "summary": "\n    ** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided.\n    ",
              "cvss2Score": 0,
              "cvss2Vector": "",
              "cvss2Severity": "",
              "cvss3Score": 4.7,
              "cvss3Vector": "CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N",
              "cvss3Severity": "moderate",
              "sourceLink": "https://www.suse.com/security/cve/CVE-2021-3800.html",
              "references": [
                {
                  "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3800",
                  "source": "CVE",
                  "refID": "Mitre CVE-2021-3800"
                },
                {
                  "link": "https://www.suse.com/security/cve/CVE-2021-3800",
                  "source": "SUSE CVE",
                  "refID": "SUSE CVE-2021-3800"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010435.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2022:0828-1"
                }
              ],
              "published": "0001-01-01T00:00:00Z",
              "lastModified": "0001-01-01T00:00:00Z"
            }
          ]
        },
        "alertDict": {
          "cisa": null,
          "jpcert": null,
          "uscert": null
        }
      },
      "CVE-2021-43784": {
        "cveID": "CVE-2021-43784",
        "confidences": [
          {
            "score": 100,
            "detectionMethod": "OvalMatch"
          }
        ],
        "affectedPackages": [
          {
            "name": "runc",
            "fixedIn": "0:1.0.3-16.18.1"
          }
        ],
        "cveContents": {
          "suse": [
            {
              "type": "suse",
              "cveID": "CVE-2021-43784",
              "title": "CVE-2021-43784",
              "summary": "\n    runc is a CLI tool for spawning and running containers on Linux according to the OCI specification. In runc, netlink is used internally as a serialization system for specifying the relevant container configuration to the `C` portion of the code (responsible for the based namespace setup of containers). In all versions of runc prior to 1.0.3, the encoder did not handle the possibility of an integer overflow in the 16-bit length field for the byte array attribute type, meaning that a large enough malicious byte array attribute could result in the length overflowing and the attribute contents being parsed as netlink messages for container configuration. This vulnerability requires the attacker to have some control over the configuration of the container and would allow the attacker to bypass the namespace restrictions of the container by simply adding their own netlink payload which disables all namespaces. The main users impacted are those who allow untrusted images with untrusted configurations to run on their machines (such as with shared cloud infrastructure). runc version 1.0.3 contains a fix for this bug. As a workaround, one may try disallowing untrusted namespace paths from your container. It should be noted that untrusted namespace paths would allow the attacker to disable namespace protections entirely even in the absence of this bug.\n    ",
              "cvss2Score": 0,
              "cvss2Vector": "",
              "cvss2Severity": "",
              "cvss3Score": 0,
              "cvss3Vector": "",
              "cvss3Severity": "moderate",
              "sourceLink": "https://www.suse.com/security/cve/CVE-2021-43784.html",
              "references": [
                {
                  "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43784",
                  "source": "CVE",
                  "refID": "Mitre CVE-2021-43784"
                },
                {
                  "link": "https://www.suse.com/security/cve/CVE-2021-43784",
                  "source": "SUSE CVE",
                  "refID": "SUSE CVE-2021-43784"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/009963.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:1-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/010136.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:148-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/010137.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:149-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/009964.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:2-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010178.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:237-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/010128.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:28-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/010129.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:29-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/009965.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:3-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/010130.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:30-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-January/010138.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:49-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2021-December/009902.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2021:4059-1"
                },
                {
                  "link": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/XCIUJE3F5UEWI5TYYL5CQ7SCQZU5V76Q/",
                  "source": "SUSE-SU",
                  "refID": "openSUSE-SU-2021:1625-1"
                },
                {
                  "link": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/6DD7LA7CG2OYZJT2SOA3MHVO7GOW3ANO/",
                  "source": "SUSE-SU",
                  "refID": "openSUSE-SU-2021:4171-1"
                }
              ],
              "published": "0001-01-01T00:00:00Z",
              "lastModified": "0001-01-01T00:00:00Z"
            }
          ]
        },
        "alertDict": {
          "cisa": null,
          "jpcert": null,
          "uscert": null
        }
      },
      "CVE-2022-24407": {
        "cveID": "CVE-2022-24407",
        "confidences": [
          {
            "score": 100,
            "detectionMethod": "OvalMatch"
          }
        ],
        "affectedPackages": [
          {
            "name": "cyrus-sasl-gssapi",
            "fixedIn": "0:2.1.26-14.5.1"
          }
        ],
        "cveContents": {
          "suse": [
            {
              "type": "suse",
              "cveID": "CVE-2022-24407",
              "title": "CVE-2022-24407",
              "summary": "\n    In Cyrus SASL 2.1.17 through 2.1.27 before 2.1.28, plugins/sql.c does not escape the password for a SQL INSERT or UPDATE statement.\n    ",
              "cvss2Score": 0,
              "cvss2Vector": "",
              "cvss2Severity": "",
              "cvss3Score": 8.8,
              "cvss3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
              "cvss3Severity": "important",
              "sourceLink": "https://www.suse.com/security/cve/CVE-2022-24407.html",
              "references": [
                {
                  "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24407",
                  "source": "CVE",
                  "refID": "Mitre CVE-2022-24407"
                },
                {
                  "link": "https://www.suse.com/security/cve/CVE-2022-24407",
                  "source": "SUSE CVE",
                  "refID": "SUSE CVE-2022-24407"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010325.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:241-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010346.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:244-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010373.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:246-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010374.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:248-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010375.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:252-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010385.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:264-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010386.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:268-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010474.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:302-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010475.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:303-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010477.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:308-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010478.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:309-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010479.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:310-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010480.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:312-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010481.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:313-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010482.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:314-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010483.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:315-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010484.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:316-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010512.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:317-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010513.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:318-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010514.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:319-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010515.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:320-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010517.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:343-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010518.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:344-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010519.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:345-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010520.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:346-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010521.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:347-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010522.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:348-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010523.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:349-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010524.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:350-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010525.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:351-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010526.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:352-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010527.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:353-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010528.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:362-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010529.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:363-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010530.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:364-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010533.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:370-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010534.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:371-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010535.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:372-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010536.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:373-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010537.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:374-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010538.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:376-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010539.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:404-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010540.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:405-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010541.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:406-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010542.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:407-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010543.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:414-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010544.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-CU-2022:415-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-updates/2022-March/022067.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:357-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-updates/2022-March/022068.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:358-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010422.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-IU-2022:359-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010322.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2022:0653-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010337.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2022:0693-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010340.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2022:0702-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-March/010383.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2022:0743-1"
                },
                {
                  "link": "https://lists.suse.com/pipermail/sle-security-updates/2022-February/010287.html",
                  "source": "SUSE-SU",
                  "refID": "SUSE-SU-2022:14894-1"
                },
                {
                  "link": "https://lists.opensuse.org/archives/list/security-announce@lists.opensuse.org/thread/BPABQLPWLWVSDVE54YNNZUHMKWEV6F3X/",
                  "source": "SUSE-SU",
                  "refID": "openSUSE-SU-2022:0743-1"
                }
              ],
              "published": "0001-01-01T00:00:00Z",
              "lastModified": "0001-01-01T00:00:00Z"
            }
          ]
        },
        "alertDict": {
          "cisa": null,
          "jpcert": null,
          "uscert": null
        }
      }
    },
    "runningKernel": {
      "release": "4.12.14-122.103-default",
      "version": "",
      "rebootRequired": false
    },
    "packages": {
      "binutils": {
        "name": "binutils",
        "version": "2.37",
        "release": "9.44.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "ca-certificates-mozilla": {
        "name": "ca-certificates-mozilla",
        "version": "2.44",
        "release": "12.34.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "noarch",
        "repository": ""
      },
      "cyrus-sasl-gssapi": {
        "name": "cyrus-sasl-gssapi",
        "version": "2.1.26",
        "release": "14.2.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "dbus-1": {
        "name": "dbus-1",
        "version": "1.8.22",
        "release": "35.2",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "efibootmgr": {
        "name": "efibootmgr",
        "version": "14",
        "release": "1.13",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "elfutils": {
        "name": "elfutils",
        "version": "0.158",
        "release": "7.13.3",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "glib2-tools": {
        "name": "glib2-tools",
        "version": "2.48.2",
        "release": "12.22.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "growpart": {
        "name": "growpart",
        "version": "0.31",
        "release": "4.14.2",
        "newVersion": "",
        "newRelease": "",
        "arch": "noarch",
        "repository": ""
      },
      "kmod-compat": {
        "name": "kmod-compat",
        "version": "25",
        "release": "3.4.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "libauparse0": {
        "name": "libauparse0",
        "version": "2.8.1",
        "release": "10.11.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "libcryptmount0": {
        "name": "libcryptmount0",
        "version": "2.14",
        "release": "13.11",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "libdcerpc0": {
        "name": "libdcerpc0",
        "version": "4.10.18+git.339.c912385a5e1",
        "release": "3.41.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "libefivar1": {
        "name": "libefivar1",
        "version": "31",
        "release": "1.13",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "libicu52_1": {
        "name": "libicu52_1",
        "version": "52.1",
        "release": "8.10.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "libirs161": {
        "name": "libirs161",
        "version": "9.11.22",
        "release": "3.37.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "libnl3-200": {
        "name": "libnl3-200",
        "version": "3.2.23",
        "release": "4.4.6",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "libsmbconf0": {
        "name": "libsmbconf0",
        "version": "4.10.18+git.339.c912385a5e1",
        "release": "3.41.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "libsmbldap2": {
        "name": "libsmbldap2",
        "version": "4.10.18+git.339.c912385a5e1",
        "release": "3.41.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "mozilla-nspr": {
        "name": "mozilla-nspr",
        "version": "4.32",
        "release": "19.18.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "netcfg": {
        "name": "netcfg",
        "version": "11.5",
        "release": "29.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "noarch",
        "repository": ""
      },
      "openslp": {
        "name": "openslp",
        "version": "2.0.0",
        "release": "24.2.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "pciutils-ids": {
        "name": "pciutils-ids",
        "version": "2019.08.30",
        "release": "12.6.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "noarch",
        "repository": ""
      },
      "python-botocore": {
        "name": "python-botocore",
        "version": "1.20.9",
        "release": "28.30.2",
        "newVersion": "",
        "newRelease": "",
        "arch": "noarch",
        "repository": ""
      },
      "python-futures": {
        "name": "python-futures",
        "version": "3.0.2",
        "release": "15.3.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "noarch",
        "repository": ""
      },
      "python-simplejson": {
        "name": "python-simplejson",
        "version": "3.8.2",
        "release": "12.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "python3-cryptography": {
        "name": "python3-cryptography",
        "version": "2.8",
        "release": "7.37.8",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "python3-jsonpatch": {
        "name": "python3-jsonpatch",
        "version": "1.1",
        "release": "10.4.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "noarch",
        "repository": ""
      },
      "python3-jsonpointer": {
        "name": "python3-jsonpointer",
        "version": "1.0",
        "release": "10.3.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "noarch",
        "repository": ""
      },
      "python3-setuptools": {
        "name": "python3-setuptools",
        "version": "40.6.2",
        "release": "4.18.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "noarch",
        "repository": ""
      },
      "python3-urllib3": {
        "name": "python3-urllib3",
        "version": "1.25.10",
        "release": "3.31.2",
        "newVersion": "",
        "newRelease": "",
        "arch": "noarch",
        "repository": ""
      },
      "ruby2.1-rubygem-cheetah": {
        "name": "ruby2.1-rubygem-cheetah",
        "version": "0.5.0",
        "release": "4.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "ruby2.1-rubygem-docker-api": {
        "name": "ruby2.1-rubygem-docker-api",
        "version": "1.31.0",
        "release": "11.2",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "ruby2.1-rubygem-ruby-dbus": {
        "name": "ruby2.1-rubygem-ruby-dbus",
        "version": "0.9.3",
        "release": "3.6",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "ruby2.1-rubygem-thor": {
        "name": "ruby2.1-rubygem-thor",
        "version": "0.19.1",
        "release": "1.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "runc": {
        "name": "runc",
        "version": "1.0.2",
        "release": "16.14.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "suse-build-key": {
        "name": "suse-build-key",
        "version": "12.0",
        "release": "7.12.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "noarch",
        "repository": ""
      },
      "systemd-sysvinit": {
        "name": "systemd-sysvinit",
        "version": "228",
        "release": "157.33.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "telnet": {
        "name": "telnet",
        "version": "1.2",
        "release": "165.63",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "timezone": {
        "name": "timezone",
        "version": "2021e",
        "release": "74.55.1",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      },
      "yast2-country-data": {
        "name": "yast2-country-data",
        "version": "3.2.18",
        "release": "1.7",
        "newVersion": "",
        "newRelease": "",
        "arch": "x86_64",
        "repository": ""
      }
    },
    "config": {
      "scan": {
        "logJSON": false,
        "default": {},
        "cveDict": {
          "Name": "",
          "Type": "",
          "SQLite3Path": "",
          "DebugSQL": false
        },
        "ovalDict": {
          "Name": "",
          "Type": "",
          "SQLite3Path": "",
          "DebugSQL": false
        },
        "gost": {
          "Name": "",
          "Type": "",
          "SQLite3Path": "",
          "DebugSQL": false
        },
        "exploit": {
          "Name": "",
          "Type": "",
          "SQLite3Path": "",
          "DebugSQL": false
        },
        "metasploit": {
          "Name": "",
          "Type": "",
          "SQLite3Path": "",
          "DebugSQL": false
        },
        "kevuln": {
          "Name": "",
          "Type": "",
          "SQLite3Path": "",
          "DebugSQL": false
        }
      },
      "report": {
        "logJSON": false,
        "default": {},
        "cveDict": {
          "Name": "",
          "Type": "",
          "SQLite3Path": "",
          "DebugSQL": false
        },
        "ovalDict": {
          "Name": "",
          "Type": "",
          "SQLite3Path": "",
          "DebugSQL": false
        },
        "gost": {
          "Name": "",
          "Type": "",
          "SQLite3Path": "",
          "DebugSQL": false
        },
        "exploit": {
          "Name": "",
          "Type": "",
          "SQLite3Path": "",
          "DebugSQL": false
        },
        "metasploit": {
          "Name": "",
          "Type": "",
          "SQLite3Path": "",
          "DebugSQL": false
        },
        "kevuln": {
          "Name": "",
          "Type": "",
          "SQLite3Path": "",
          "DebugSQL": false
        }
      }
    }
  }
]
```
</div></details>

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

