### PR TITLE
refactor: judge by scannedVia

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -262,8 +262,8 @@ func isPkgCvesDetactable(r *models.ScanResult) bool {
 		return false
 	}
 
-	if r.ScannedBy == "trivy" {
-		logging.Log.Infof("r.ScannedBy is trivy. Skip OVAL and gost detection")
+	if r.ScannedVia == "trivy" {
+		logging.Log.Infof("r.ScannedVia is trivy. Skip OVAL and gost detection")
 		return false
 	}
 


### PR DESCRIPTION
# What did you implement:

Currently, we use '.ScanndeBy' in order to judge the result was scanned by trivy. But '.ScannedBy' may have been changed when the result was  scanned by trivy indirectly. So I guess that we should use '.ScannedVia' to judge it is scanned by trivy.  
refs:  https://github.com/future-architect/vuls/pull/1444

## Type of change

- [x] Refactor (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run at local

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  