### PR TITLE
feat(os): support Alpine Linux 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV REPOSITORY github.com/future-architect/vuls
 COPY . $GOPATH/src/$REPOSITORY
 RUN cd $GOPATH/src/$REPOSITORY && make install
 
-FROM alpine:3.15
+FROM alpine:3.16
 
 ENV LOGDIR /var/log/vuls
 ENV WORKDIR /vuls

--- a/config/os.go
+++ b/config/os.go
@@ -257,6 +257,7 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 			"3.13": {StandardSupportUntil: time.Date(2022, 11, 1, 23, 59, 59, 0, time.UTC)},
 			"3.14": {StandardSupportUntil: time.Date(2023, 5, 1, 23, 59, 59, 0, time.UTC)},
 			"3.15": {StandardSupportUntil: time.Date(2023, 11, 1, 23, 59, 59, 0, time.UTC)},
+			"3.16": {StandardSupportUntil: time.Date(2024, 5, 23, 23, 59, 59, 0, time.UTC)},
 		}[majorDotMinor(release)]
 	case constant.FreeBSD:
 		// https://www.freebsd.org/security/

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -406,8 +406,16 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			found:    true,
 		},
 		{
-			name:     "Alpine 3.16 not found",
+			name:     "Alpine 3.16 supported",
 			fields:   fields{family: Alpine, release: "3.16"},
+			now:      time.Date(2024, 5, 23, 23, 59, 59, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    true,
+		},
+		{
+			name:     "Alpine 3.17 not found",
+			fields:   fields{family: Alpine, release: "3.17"},
 			now:      time.Date(2022, 1, 14, 23, 59, 59, 0, time.UTC),
 			stdEnded: false,
 			extEnded: false,


### PR DESCRIPTION
# What did you implement:

support Alpine Linux 3.16.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
```console
$ vuls scan
[Jun 14 22:45:16]  INFO [localhost] vuls-v0.19.7-build-20220614_225652_f571918c
[Jun 14 22:45:16]  INFO [localhost] Start scanning
[Jun 14 22:45:16]  INFO [localhost] config: ./config.toml
[Jun 14 22:45:16]  INFO [localhost] Validating config...
[Jun 14 22:45:16]  INFO [localhost] Detecting Server/Container OS... 
[Jun 14 22:45:16]  INFO [localhost] Detecting OS of servers... 
[Jun 14 22:45:16]  INFO [localhost] (1/1) Detected: vuls-target: alpine 3.16.0
[Jun 14 22:45:16]  INFO [localhost] Detecting OS of containers... 
[Jun 14 22:45:16]  INFO [localhost] Checking Scan Modes... 
[Jun 14 22:45:16]  INFO [localhost] Detecting Platforms... 
[Jun 14 22:45:16]  INFO [localhost] (1/1) vuls-target is running on other
[Jun 14 22:45:16]  INFO [vuls-target] Scanning OS pkg in fast mode


Scan Summary
================
vuls-target	alpine3.16.0	23 installed, 5 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ vuls report
[Jun 14 22:45:18]  INFO [localhost] vuls-v0.19.7-build-20220614_225652_f571918c
[Jun 14 22:45:18]  INFO [localhost] Validating config...
[Jun 14 22:45:18]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Jun 14 22:45:18]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/usr/share/vuls-data/oval.sqlite3
[Jun 14 22:45:18]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/usr/share/vuls-data/gost.sqlite3
[Jun 14 22:45:18]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Jun 14 22:45:18]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Jun 14 22:45:18]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/usr/share/vuls-data/go-kev.sqlite3
[Jun 14 22:45:18]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2022-06-14T22:45:16+09:00
[Jun 14 22:45:18]  INFO [localhost] OVAL alpine 3.16.0 found. defs: 4601
[Jun 14 22:45:18]  INFO [localhost] OVAL alpine 3.16.0 is fresh. lastModified: 2022-06-14T22:37:53+09:00
[Jun 14 22:45:18]  INFO [localhost] vuls-target: 13 CVEs are detected with OVAL
[Jun 14 22:45:18]  INFO [localhost] vuls-target: 0 unfixed CVEs are detected with gost
[Jun 14 22:45:18]  INFO [localhost] vuls-target: 0 CVEs are detected with CPE
[Jun 14 22:45:19]  INFO [localhost] vuls-target: 2 PoC are detected
[Jun 14 22:45:19]  INFO [localhost] vuls-target: 0 exploits are detected
[Jun 14 22:45:19]  INFO [localhost] vuls-target: total 13 CVEs detected
[Jun 14 22:45:19]  INFO [localhost] vuls-target: 0 CVEs filtered by --confidence-over=80
vuls-target (alpine3.16.0)
==========================
Total: 13 (Critical:0 High:8 Medium:5 Low:0 ?:0)
13/13 Fixed, 2 poc, 0 exploits, cisa: 0, uscert: 1, jpcert: 0 alerts
23 installed

+----------------+------+--------+-----+-----------+---------+----------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  | PACKAGES |
+----------------+------+--------+-----+-----------+---------+----------+
| CVE-2021-3518  |  8.8 |  AV:N  |     |           |   fixed | libxml2  |
+----------------+------+--------+-----+-----------+---------+----------+
| CVE-2021-3517  |  8.6 |  AV:N  |     |           |   fixed | libxml2  |
+----------------+------+--------+-----+-----------+---------+----------+
| CVE-2022-23308 |  8.1 |  AV:N  |     |           |   fixed | libxml2  |
+----------------+------+--------+-----+-----------+---------+----------+
| CVE-2018-14404 |  7.5 |  AV:N  |     |           |   fixed | libxml2  |
+----------------+------+--------+-----+-----------+---------+----------+
| CVE-2019-20388 |  7.5 |  AV:N  |     |           |   fixed | libxml2  |
+----------------+------+--------+-----+-----------+---------+----------+
| CVE-2020-7595  |  7.5 |  AV:N  |     |      CERT |   fixed | libxml2  |
+----------------+------+--------+-----+-----------+---------+----------+
| CVE-2021-3537  |  7.5 |  AV:N  |     |           |   fixed | libxml2  |
+----------------+------+--------+-----+-----------+---------+----------+
| CVE-2022-29824 |  7.4 |  AV:N  |     |           |   fixed | libxml2  |
+----------------+------+--------+-----+-----------+---------+----------+
| CVE-2018-14567 |  6.5 |  AV:N  |     |           |   fixed | libxml2  |
+----------------+------+--------+-----+-----------+---------+----------+
| CVE-2020-24977 |  6.5 |  AV:N  | POC |           |   fixed | libxml2  |
+----------------+------+--------+-----+-----------+---------+----------+
| CVE-2021-3541  |  6.5 |  AV:N  |     |           |   fixed | libxml2  |
+----------------+------+--------+-----+-----------+---------+----------+
| CVE-2017-5969  |  5.5 |  AV:L  |     |           |   fixed | libxml2  |
+----------------+------+--------+-----+-----------+---------+----------+
| CVE-2018-9251  |  5.3 |  AV:N  | POC |           |   fixed | libxml2  |
+----------------+------+--------+-----+-----------+---------+----------+
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference
- https://alpinelinux.org/posts/Alpine-3.16.0-released.html
- https://github.com/vulsio/vulsctl/pull/64
