### PR TITLE
fix(ms): always sets isPkgCvesDetactable to true

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -261,21 +261,23 @@ func DetectPkgCves(r *models.ScanResult, ovalCnf config.GovalDictConf, gostCnf c
 
 // isPkgCvesDetactable checks whether CVEs is detactable with gost and oval from the result
 func isPkgCvesDetactable(r *models.ScanResult) bool {
-	if r.Release == "" {
-		logging.Log.Infof("r.Release is empty. Skip OVAL and gost detection")
-		return false
-	}
-
-	if r.ScannedVia == "trivy" {
-		logging.Log.Infof("r.ScannedVia is trivy. Skip OVAL and gost detection")
-		return false
-	}
-
 	switch r.Family {
 	case constant.FreeBSD, constant.ServerTypePseudo:
 		logging.Log.Infof("%s type. Skip OVAL and gost detection", r.Family)
 		return false
+	case constant.Windows:
+		return true
 	default:
+		if r.ScannedVia == "trivy" {
+			logging.Log.Infof("r.ScannedVia is trivy. Skip OVAL and gost detection")
+			return false
+		}
+
+		if r.Release == "" {
+			logging.Log.Infof("r.Release is empty. Skip OVAL and gost detection")
+			return false
+		}
+
 		if len(r.Packages)+len(r.SrcPackages) == 0 {
 			logging.Log.Infof("Number of packages is 0. Skip OVAL and gost detection")
 			return false


### PR DESCRIPTION
# What did you implement:
When family is windows, always set isPkgCvesDetactable to true.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
