### PR TITLE
chore(rocky): set Rocky Linux 9 EOL

### DIFF
--- a/config/os.go
+++ b/config/os.go
@@ -87,7 +87,7 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 	case constant.Rocky:
 		eol, found = map[string]EOL{
 			"8": {StandardSupportUntil: time.Date(2029, 5, 31, 23, 59, 59, 0, time.UTC)},
-			// "9": {StandardSupportUntil: time.Date(2032, 5, 31, 23, 59, 59, 0, time.UTC)},
+			"9": {StandardSupportUntil: time.Date(2032, 5, 31, 23, 59, 59, 0, time.UTC)},
 		}[major(release)]
 	case constant.Oracle:
 		eol, found = map[string]EOL{

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -178,8 +178,16 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			found:    true,
 		},
 		{
-			name:     "Rocky Linux 9 Not Found",
+			name:     "Rocky Linux 9 supported",
 			fields:   fields{family: Rocky, release: "9"},
+			now:      time.Date(2021, 7, 2, 23, 59, 59, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    true,
+		},
+		{
+			name:     "Rocky Linux 10 Not Found",
+			fields:   fields{family: Rocky, release: "10"},
 			now:      time.Date(2021, 7, 2, 23, 59, 59, 0, time.UTC),
 			stdEnded: false,
 			extEnded: false,


### PR DESCRIPTION
# What did you implement:
Rocky Linux 9.0 is now GA and EOL is set.
https://rockylinux.org/news/rocky-linux-9-0-ga-release/

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
## before
```console
$ vuls scan
[Jul 19 10:00:41]  INFO [localhost] vuls-v0.19.8-build-20220719_095936_d1a617c
[Jul 19 10:00:41]  INFO [localhost] Start scanning
[Jul 19 10:00:41]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Jul 19 10:00:41]  INFO [localhost] Validating config...
[Jul 19 10:00:41]  INFO [localhost] Detecting Server/Container OS... 
[Jul 19 10:00:41]  INFO [localhost] Detecting OS of servers... 
[Jul 19 10:00:42]  INFO [localhost] (1/1) Detected: vuls-target: rocky 9.0
[Jul 19 10:00:42]  INFO [localhost] Detecting OS of containers... 
[Jul 19 10:00:42]  INFO [localhost] Checking Scan Modes... 
[Jul 19 10:00:42]  INFO [localhost] Detecting Platforms... 
[Jul 19 10:00:43]  INFO [localhost] (1/1) vuls-target is running on other
[Jul 19 10:00:43]  INFO [vuls-target] Scanning OS pkg in fast mode
[Jul 19 10:00:47]  WARN [localhost] Some warnings occurred during scanning on vuls-target. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family: rocky Release: 9.0`]


Scan Summary
================
vuls-target	rocky9.0	175 installed, 0 updatable

Warning: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family: rocky Release: 9.0`]



To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

## after
```console
$ vuls scan
[Jul 19 10:08:19]  INFO [localhost] vuls-v0.19.8-build-20220719_100638_a7879f33
[Jul 19 10:08:19]  INFO [localhost] Start scanning
[Jul 19 10:08:19]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Jul 19 10:08:19]  INFO [localhost] Validating config...
[Jul 19 10:08:19]  INFO [localhost] Detecting Server/Container OS... 
[Jul 19 10:08:19]  INFO [localhost] Detecting OS of servers... 
[Jul 19 10:08:20]  INFO [localhost] (1/1) Detected: vuls-target: rocky 9.0
[Jul 19 10:08:20]  INFO [localhost] Detecting OS of containers... 
[Jul 19 10:08:20]  INFO [localhost] Checking Scan Modes... 
[Jul 19 10:08:20]  INFO [localhost] Detecting Platforms... 
[Jul 19 10:08:21]  INFO [localhost] (1/1) vuls-target is running on other
[Jul 19 10:08:21]  INFO [vuls-target] Scanning OS pkg in fast mode


Scan Summary
================
vuls-target	rocky9.0	175 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://rockylinux.org/news/rocky-linux-9-0-ga-release/
* https://github.com/vulsdoc/vuls/pull/210

