### PR TITLE
fix(library): fill libraryFixedIns{}.key in ftypes.Pnpm and ftypes.DotNetCore

### DIFF
--- a/models/library.go
+++ b/models/library.go
@@ -129,27 +129,24 @@ func getCveContents(cveID string, vul trivyDBTypes.Vulnerability) (contents map[
 	return contents
 }
 
-// LibraryMap is filename and library type
-var LibraryMap = map[string]string{
-	ftypes.NpmPkgLock:      "node",
-	ftypes.YarnLock:        "node",
-	ftypes.PnpmLock:        "node",
-	ftypes.GemfileLock:     "ruby",
-	ftypes.CargoLock:       "rust",
-	ftypes.ComposerLock:    "php",
-	ftypes.PipRequirements: "python",
-	ftypes.PipfileLock:     "python",
-	ftypes.PoetryLock:      "python",
-	ftypes.NuGetPkgsLock:   ".net",
-	ftypes.NuGetPkgsConfig: ".net",
-	"*.deps.json":          ".net",
-	ftypes.GoMod:           "gomod",
-	ftypes.GoSum:           "gomod",
-	ftypes.MavenPom:        "java",
-	"*.jar":                "java",
-	"*.war":                "java",
-	"*.ear":                "java",
-	"*.par":                "java",
+// FindLockFiles is a list of filenames that is the target of findLock
+var FindLockFiles = []string{
+	// node
+	ftypes.NpmPkgLock, ftypes.YarnLock, ftypes.PnpmLock,
+	// ruby
+	ftypes.GemfileLock,
+	// rust
+	ftypes.CargoLock,
+	// php
+	ftypes.ComposerLock,
+	// python
+	ftypes.PipRequirements, ftypes.PipfileLock, ftypes.PoetryLock,
+	// .net
+	ftypes.NuGetPkgsLock, ftypes.NuGetPkgsConfig, "*.deps.json",
+	// gomod
+	ftypes.GoMod, ftypes.GoSum,
+	// java
+	ftypes.MavenPom, "*.jar", "*.war", "*.ear", "*.par",
 }
 
 // GetLibraryKey returns target library key

--- a/models/library.go
+++ b/models/library.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	"path/filepath"
-
 	"github.com/aquasecurity/trivy-db/pkg/db"
 	trivyDBTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/detector/library"
@@ -135,6 +133,7 @@ func getCveContents(cveID string, vul trivyDBTypes.Vulnerability) (contents map[
 var LibraryMap = map[string]string{
 	ftypes.NpmPkgLock:      "node",
 	ftypes.YarnLock:        "node",
+	ftypes.PnpmLock:        "node",
 	ftypes.GemfileLock:     "ruby",
 	ftypes.CargoLock:       "rust",
 	ftypes.ComposerLock:    "php",
@@ -143,6 +142,7 @@ var LibraryMap = map[string]string{
 	ftypes.PoetryLock:      "python",
 	ftypes.NuGetPkgsLock:   ".net",
 	ftypes.NuGetPkgsConfig: ".net",
+	"*.deps.json":          ".net",
 	ftypes.GoMod:           "gomod",
 	ftypes.GoSum:           "gomod",
 	ftypes.MavenPom:        "java",
@@ -165,20 +165,14 @@ func (s LibraryScanner) GetLibraryKey() string {
 		return "gomod"
 	case ftypes.Jar, ftypes.Pom:
 		return "java"
-	case ftypes.Npm, ftypes.Yarn, ftypes.NodePkg, ftypes.JavaScript:
+	case ftypes.Npm, ftypes.Yarn, ftypes.Pnpm, ftypes.NodePkg, ftypes.JavaScript:
 		return "node"
-	case ftypes.NuGet:
+	case ftypes.NuGet, ftypes.DotNetCore:
 		return ".net"
 	case ftypes.Pipenv, ftypes.Poetry, ftypes.Pip, ftypes.PythonPkg:
 		return "python"
 	default:
-		filename := filepath.Base(s.LockfilePath)
-		switch filepath.Ext(filename) {
-		case ".jar", ".war", ".ear", ".par":
-			return "java"
-		default:
-			return LibraryMap[filename]
-		}
+		return ""
 	}
 }
 

--- a/scanner/base.go
+++ b/scanner/base.go
@@ -592,7 +592,7 @@ func (l *base) scanLibraries() (err error) {
 	// auto detect lockfile
 	if l.ServerInfo.FindLock {
 		findopt := ""
-		for filename := range models.LibraryMap {
+		for _, filename := range models.FindLockFiles {
 			findopt += fmt.Sprintf("-name %q -o ", filename)
 		}
 


### PR DESCRIPTION
# What did you implement:
When vulnerability was detected in pnpm-lock.yaml and *.deps.json, the key of libraryFixedIns in the report result was not set. 
This PR fixes that.

Also, pnpm-lock.yaml and *.deps.json are added to the target of findLock.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
The key of libraryFixedIns in the report result is filled.
## before
```json
"scannedCves": {
  "CVE-2021-23566": {
    "cveID": "CVE-2021-23566",
    "confidences": [
      {
        "score": 100,
        "detectionMethod": "TrivyMatch"
      }
    ],
    "libraryFixedIns": [
      {
        "name": "nanoid",
        "fixedIn": "3.1.31",
        "path": "/home/mainek00n/github/github.com/MaineK00n/vuls/integration/data/lockfile/pnpm-lock.yaml"
      }
    ]
  },
  "GHSA-5crp-9r3c-p9vr": {
    "cveID": "GHSA-5crp-9r3c-p9vr",
    "confidences": [
      {
        "score": 100,
        "detectionMethod": "TrivyMatch"
      }
    ],
    "libraryFixedIns": [
      {
        "name": "Newtonsoft.Json",
        "fixedIn": "13.0.1",
        "path": "/home/mainek00n/github/github.com/MaineK00n/vuls/integration/data/lockfile/datacollector.deps.json"
      }
    ]
  }
}
```

## after
```json
"scannedCves": {
  "CVE-2021-23566": {
    "cveID": "CVE-2021-23566",
    "confidences": [
      {
        "score": 100,
        "detectionMethod": "TrivyMatch"
      }
    ],
    "libraryFixedIns": [
      {
        "key": "node",
        "name": "nanoid",
        "fixedIn": "3.1.31",
        "path": "/home/mainek00n/github/github.com/MaineK00n/vuls/integration/data/lockfile/pnpm-lock.yaml"
      }
    ]
  },
  "GHSA-5crp-9r3c-p9vr": {
    "cveID": "GHSA-5crp-9r3c-p9vr",
    "confidences": [
      {
        "score": 100,
        "detectionMethod": "TrivyMatch"
      }
    ],
    "libraryFixedIns": [
      {
        "key": ".net",
        "name": "Newtonsoft.Json",
        "fixedIn": "13.0.1",
        "path": "/home/mainek00n/github/github.com/MaineK00n/vuls/integration/data/lockfile/datacollector.deps.json"
      }
    ]
  }
}
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

