### PR TITLE
breaking-change(configtest, scan): categorize error

### DIFF
--- a/errof/errof.go
+++ b/errof/errof.go
@@ -5,8 +5,8 @@ type ErrorCode string
 
 // Error is vuls error
 type Error struct {
-	Code    ErrorCode
-	Message string
+	Code    ErrorCode `json:"code"`
+	Message string    `json:"message"`
 }
 
 func (e Error) Error() string {
@@ -14,6 +14,15 @@ func (e Error) Error() string {
 }
 
 var (
+	// ErrIPUnreachable is error that ping is unreachable
+	ErrIPUnreachable ErrorCode = "ErrIPUnreachable"
+
+	// ErrSSHConfig is error of ssh config
+	ErrSSHConfig ErrorCode = "ErrSSHConfig"
+
+	// ErrUncategorized is an uncategorized error other than ErrIPUnreachable and ErrSSHConfig
+	ErrUncategorized ErrorCode = "ErrUncategorized"
+
 	// ErrFailedToAccessGithubAPI is error of github alert's api access
 	ErrFailedToAccessGithubAPI ErrorCode = "ErrFailedToAccessGithubAPI"
 

--- a/models/scanresults.go
+++ b/models/scanresults.go
@@ -11,6 +11,7 @@ import (
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/constant"
 	"github.com/future-architect/vuls/cwe"
+	"github.com/future-architect/vuls/errof"
 	"github.com/future-architect/vuls/logging"
 )
 
@@ -42,7 +43,7 @@ type ScanResult struct {
 	ReportedVersion  string            `json:"reportedVersion"`
 	ReportedRevision string            `json:"reportedRevision"`
 	ReportedBy       string            `json:"reportedBy"`
-	Errors           []string          `json:"errors"`
+	Errors           []errof.Error     `json:"errors"`
 	Warnings         []string          `json:"warnings"`
 
 	ScannedCves       VulnInfos              `json:"scannedCves"`
@@ -341,6 +342,10 @@ func (r ScanResult) ClearFields(targetTagNames []string) ScanResult {
 
 // CheckEOL checks the EndOfLife of the OS
 func (r *ScanResult) CheckEOL() {
+	if len(r.Errors) > 0 {
+		return
+	}
+
 	switch r.Family {
 	case constant.ServerTypePseudo, constant.Raspbian:
 		return

--- a/reporter/stdout.go
+++ b/reporter/stdout.go
@@ -15,6 +15,14 @@ type StdoutWriter struct {
 
 //TODO support -format-jSON
 
+// WriteConfigtestSummary prints Configtest summary at the end of configtest
+func (w StdoutWriter) WriteConfigtestSummary(rs map[string][]error) {
+	fmt.Printf("\n\n")
+	fmt.Println("Configtest Summary")
+	fmt.Println("================")
+	fmt.Printf("%s\n", formatConfigtestSummary(rs))
+}
+
 // WriteScanSummary prints Scan summary at the end of scan
 func (w StdoutWriter) WriteScanSummary(rs ...models.ScanResult) {
 	fmt.Printf("\n\n")

--- a/scanner/base.go
+++ b/scanner/base.go
@@ -18,9 +18,11 @@ import (
 	dio "github.com/aquasecurity/go-dep-parser/pkg/io"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	debver "github.com/knqyf263/go-deb-version"
+	"github.com/pkg/errors"
 
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/constant"
+	"github.com/future-architect/vuls/errof"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
 	"github.com/future-architect/vuls/util"
@@ -456,9 +458,13 @@ func (l *base) convertToModel() models.ScanResult {
 		Type:        ctype,
 	}
 
-	errs, warns := []string{}, []string{}
+	errs, warns := []errof.Error{}, []string{}
 	for _, e := range l.errs {
-		errs = append(errs, fmt.Sprintf("%+v", e))
+		if errWithCode, ok := errors.Cause(e).(errof.Error); ok {
+			errs = append(errs, errof.New(errWithCode.Code, errWithCode.Message))
+		} else {
+			errs = append(errs, errof.New(errof.ErrUncategorized, e.Error()))
+		}
 	}
 	for _, w := range l.warns {
 		warns = append(warns, fmt.Sprintf("%+v", w))

--- a/scanner/utils.go
+++ b/scanner/utils.go
@@ -80,14 +80,5 @@ func writeScanResults(jsonDir string, results models.ScanResults) error {
 
 	reporter.StdoutWriter{}.WriteScanSummary(results...)
 
-	errServerNames := []string{}
-	for _, r := range results {
-		if 0 < len(r.Errors) {
-			errServerNames = append(errServerNames, r.ServerName)
-		}
-	}
-	if 0 < len(errServerNames) {
-		return fmt.Errorf("An error occurred on %s", errServerNames)
-	}
 	return nil
 }

--- a/subcmds/configtest.go
+++ b/subcmds/configtest.go
@@ -115,15 +115,14 @@ func (p *ConfigtestCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interfa
 		return subcommands.ExitUsageError
 	}
 
-	s := scanner.Scanner{
-		TimeoutSec: p.timeoutSec,
-		Targets:    targets,
-	}
-
-	if err := s.Configtest(); err != nil {
+	sc := scanner.Scanner{TimeoutSec: p.timeoutSec, Targets: targets}
+	if err := sc.Configtest(); err != nil {
 		logging.Log.Errorf("Failed to configtest: %+v", err)
 		return subcommands.ExitFailure
 	}
+
+	fmt.Printf("\n\n\n")
+	fmt.Println("To scan the server, run vuls scan.")
 
 	return subcommands.ExitSuccess
 }

--- a/subcmds/report.go
+++ b/subcmds/report.go
@@ -237,14 +237,11 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	logging.Log.Infof("Loaded: %s", dir)
 
 	var res models.ScanResults
-	hasError := false
 	for _, r := range loaded {
 		if len(r.Errors) == 0 {
 			res = append(res, r)
 		} else {
-			logging.Log.Errorf("Ignored since errors occurred during scanning: %s, err: %v",
-				r.ServerName, r.Errors)
-			hasError = true
+			logging.Log.Errorf("Ignored since errors occurred during scanning: %s, err: %v", r.ServerName, r.Errors)
 		}
 	}
 
@@ -359,10 +356,6 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 			logging.Log.Errorf("Failed to report. err: %+v", err)
 			return subcommands.ExitFailure
 		}
-	}
-
-	if hasError {
-		return subcommands.ExitFailure
 	}
 
 	return subcommands.ExitSuccess


### PR DESCRIPTION
# What did you implement:
When scanning servers together in the CIDR Range or when many servers are defined in config.toml, I wanted to classify servers that have been successfully "configtest" or "scan" and those that have not.


## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
## setup
```console
$ vagrant up
$ ssh vagrant@192.168.56.2 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa
vagrant@ubuntu-focal:~$ sudo apt install -y lsof iproute2 debian-goodies
$ ssh vagrant@192.168.56.3 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa
```

- Vagrantfile
```ruby
Vagrant.configure("2") do |config|
    # pass
    config.vm.define "host1" do |host1|
      host1.vm.box = "ubuntu/focal64"
      host1.vm.network :private_network, ip: "192.168.56.2"
    end
  
    # not installed the commands(lsof, iproute2, debian-goodies) required by vuls
    config.vm.define "host2" do |host2|
      host2.vm.box = "ubuntu/focal64"
      host2.vm.network :private_network, ip: "192.168.56.3"
    end

    # ssh config error
    config.vm.define "host3" do |host3|
        host3.vm.box = "ubuntu/focal64"
        host3.vm.network :private_network, ip: "192.168.56.4"
    end
  
    if Vagrant.has_plugin?("vagrant-vbguest")
      config.vbguest.auto_update = false  
    end
  
    config.vm.provision "shell", privileged: false do |s|
      ssh_pub_key = ""
      if File.file?("/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa.pub")
        ssh_pub_key = File.readlines("/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa.pub").first.strip
      else
        puts "No SSH key found. You will need to remedy this before pushing to the repository."
      end
      s.inline = <<-SHELL
        if grep -sq "#{ssh_pub_key}" /home/vagrant/.ssh/authorized_keys; then
          echo "SSH keys already provisioned."
          exit 0;
        fi
        echo "SSH key provisioning."
        mkdir -p /home/vagrant/.ssh/
        touch /home/vagrant/.ssh/authorized_keys
        echo #{ssh_pub_key} >> /home/vagrant/.ssh/authorized_keys
      SHELL
    end
  end
```

## configtest
```console
$ vuls configtest
...
Configtest Summary
==================
localhost                	Pass            
vuls-target(192.168.56.2)	Pass            
vuls-target(192.168.56.3)	ErrUncategorized	debian-goodies is not installed                                                                     
vuls-target(192.168.56.4)	ErrSSHConfig    	Failed to find the host in known_hosts. Please exec `$ /usr/bin/ssh -i                              
                         	                	/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -p 22 -l vagrant        
                         	                	192.168.56.4` or `$ /usr/bin/ssh-keyscan -H -p 22 192.168.56.4 >> ~/.ssh/known_hosts`               
vuls-target(192.168.56.5)	ErrIPUnreachable	dial tcp 192.168.56.5:22: connect: no route to host
```

- config.toml
```toml
[servers.vuls-target]
host                = "192.168.56.0/29"
ignoreIPAddresses = ["192.168.56.1", "192.168.56.6"]
user               = "vagrant"
keyPath            = "/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa"
scanMode           = ["fast-root"]
scanModules        = ["ospkg"]
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

