### PR TITLE
feat(cwe): add cwe top25 2022

### DIFF
--- a/cwe/cwe.go
+++ b/cwe/cwe.go
@@ -5,6 +5,7 @@ var CweTopTwentyfives = map[string]map[string]string{
 	"2019": cweTopTwentyfive2019,
 	"2020": cweTopTwentyfive2020,
 	"2021": cweTopTwentyfive2021,
+	"2022": cweTopTwentyfive2022,
 }
 
 var cweTopTwentyfive2019 = map[string]string{
@@ -91,9 +92,38 @@ var cweTopTwentyfive2021 = map[string]string{
 	"77":  "25",
 }
 
+var cweTopTwentyfive2022 = map[string]string{
+	"787": "1",
+	"79":  "2",
+	"89":  "3",
+	"20":  "4",
+	"125": "5",
+	"78":  "6",
+	"416": "7",
+	"22":  "8",
+	"352": "9",
+	"434": "10",
+	"476": "11",
+	"502": "12",
+	"190": "13",
+	"287": "14",
+	"798": "16",
+	"862": "16",
+	"77":  "17",
+	"306": "18",
+	"119": "19",
+	"276": "20",
+	"918": "21",
+	"362": "22",
+	"400": "23",
+	"611": "24",
+	"94":  "25",
+}
+
 // CweTopTwentyfiveURLs has CWE Top25 links
 var CweTopTwentyfiveURLs = map[string]string{
 	"2019": "https://cwe.mitre.org/top25/archive/2019/2019_cwe_top25.html",
 	"2020": "https://cwe.mitre.org/top25/archive/2020/2020_cwe_top25.html",
 	"2021": "https://cwe.mitre.org/top25/archive/2021/2021_cwe_top25.html",
+	"2022": "https://cwe.mitre.org/top25/archive/2022/2022_cwe_top25.html",
 }


### PR DESCRIPTION
# What did you implement:
add cwe top25 2022.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ vuls report --format-full-text
...
+------------------------+----------------------------------------------------------------------------------+
| CVE-2020-25743         | UNFIXED                                                                          |
+------------------------+----------------------------------------------------------------------------------+
| Max Score              | 3.9 LOW (ubuntu)                                                                 |
| nvd                    | 3.2/CVSS:3.1/AV:L/AC:L/PR:H/UI:N/S:C/C:N/I:N/A:L LOW                             |
| jvn                    | 3.2/CVSS:3.0/AV:L/AC:L/PR:H/UI:N/S:C/C:N/I:N/A:L LOW                             |
| ubuntu                 | 0.1-3.9 LOW                                                                      |
| nvd                    | 2.1/AV:L/AC:L/Au:N/C:N/I:N/A:P LOW                                               |
| jvn                    | 2.1/AV:L/AC:L/Au:N/C:N/I:N/A:P LOW                                               |
| Summary                | hw/ide/pci.c in QEMU before 5.1.1 can trigger a NULL pointer dereference because |
|                        | it lacks a pointer check before an ide_cancel_dma_sync call.                     |
| Primary Src            | https://nvd.nist.gov/vuln/detail/CVE-2020-25743                                  |
| Primary Src            | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2020-25743                     |
| Patch                  | http://www.openwall.com/lists/oss-security/2020/09/29/1                          |
| Patch                  | https://bugzilla.redhat.com/show_bug.cgi?id=1881409                              |
| Patch                  | https://lists.nongnu.org/archive/html/qemu-devel/2020-09/msg05967.html           |
| Affected Pkg           | qemu-1:4.2-3ubuntu6.23 -> Not fixed yet                                          |
| Confidence             | 100 / OvalMatch                                                                  |
| CWE                    | [CWE(2019) Top14] CWE-476: NULL Pointer Dereference (nvd)                        |
| CWE                    | [CWE(2020) Top13] CWE-476: NULL Pointer Dereference (nvd)                        |
| CWE                    | [CWE(2021) Top16] CWE-476: NULL Pointer Dereference (nvd)                        |
| CWE                    | [CWE(2022) Top11] CWE-476: NULL Pointer Dereference (nvd)                        |
| CWE                    | [CWE/SANS(latest) Top14]  CWE-476: NULL Pointer Dereference (nvd)                |
| CWE                    | https://cwe.mitre.org/data/definitions/CWE-476.html                              |
| CWE(2019) Top25        | https://cwe.mitre.org/top25/archive/2019/2019_cwe_top25.html                     |
| CWE(2020) Top25        | https://cwe.mitre.org/top25/archive/2020/2020_cwe_top25.html                     |
| CWE(2021) Top25        | https://cwe.mitre.org/top25/archive/2021/2021_cwe_top25.html                     |
| CWE(2022) Top25        | https://cwe.mitre.org/top25/archive/2022/2022_cwe_top25.html                     |
| SANS/CWE(latest) Top25 | https://www.sans.org/top25-software-errors/                                      |
+------------------------+----------------------------------------------------------------------------------+
...
```
# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
