### PR TITLE
fix(lockfiles): fix privileges in lockfile scan

### DIFF
--- a/scanner/base.go
+++ b/scanner/base.go
@@ -776,13 +776,13 @@ func (d *DummyFileInfo) Size() int64 { return d.size }
 // Mode is
 func (d *DummyFileInfo) Mode() os.FileMode { return d.filemode }
 
-//ModTime is
+// ModTime is
 func (d *DummyFileInfo) ModTime() time.Time { return time.Now() }
 
 // IsDir is
 func (d *DummyFileInfo) IsDir() bool { return false }
 
-//Sys is
+// Sys is
 func (d *DummyFileInfo) Sys() interface{} { return nil }
 
 func (l *base) scanWordPress() error {


### PR DESCRIPTION
# What did you implement:
lockfile scan searches for the target lockfile and retrieves its contents from the scan destination.
Until now, even in fast-root mode, all command execution has been done as the executing user.
This PR grants privileges to the command according to its execution mode.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## env
```console
$ vagrant ssh
vagrant@ubuntu-focal:~$ find / -type f -and -name "Cargo.lock" 2>&1 | grep -v "find:"
vagrant@ubuntu-focal:~$ sudo find / -type f -and -name "Cargo.lock" 2>&1 | grep -v "find:"
/root/Cargo.lock
```

### findlock = true
- config.toml
```toml
[servers.vagrant]
host = "127.0.0.1"
port = "2222"
user = "vagrant"
keyPath            = "/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa"
scanMode = ["fast-root"]
scanModules = ["lockfile"]
findLock = true
```

- before
```console
$ vuls scan
[Aug  8 18:07:47]  INFO [localhost] vuls-v0.20.0-build-20220808_180441_1e45732
[Aug  8 18:07:47]  INFO [localhost] Start scanning
[Aug  8 18:07:47]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Aug  8 18:07:47]  INFO [localhost] Validating config...
[Aug  8 18:07:47]  INFO [localhost] Detecting Server/Container OS... 
[Aug  8 18:07:47]  INFO [localhost] Detecting OS of servers... 
[Aug  8 18:07:47]  INFO [localhost] (1/1) Detected: vagrant: ubuntu 20.04
[Aug  8 18:07:47]  INFO [localhost] Detecting OS of containers... 
[Aug  8 18:07:47]  INFO [localhost] Checking Scan Modes... 
[Aug  8 18:07:47]  INFO [localhost] Detecting Platforms... 
[Aug  8 18:07:48]  INFO [localhost] (1/1) vagrant is running on other
[Aug  8 18:07:48]  INFO [vagrant] Scanning Lockfile...


Scan Summary
================
vagrant	ubuntu20.04	0 installed, 0 updatable
```

- after
```console
$ vuls scan
[Aug  8 18:27:44]  INFO [localhost] vuls-v0.20.0-build-20220808_182706_7ae7d4e
[Aug  8 18:27:44]  INFO [localhost] Start scanning
[Aug  8 18:27:44]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Aug  8 18:27:44]  INFO [localhost] Validating config...
[Aug  8 18:27:44]  INFO [localhost] Detecting Server/Container OS... 
[Aug  8 18:27:44]  INFO [localhost] Detecting OS of servers... 
[Aug  8 18:27:45]  INFO [localhost] (1/1) Detected: vagrant: ubuntu 20.04
[Aug  8 18:27:45]  INFO [localhost] Detecting OS of containers... 
[Aug  8 18:27:45]  INFO [localhost] Checking Scan Modes... 
[Aug  8 18:27:45]  INFO [localhost] Detecting Platforms... 
[Aug  8 18:27:46]  INFO [localhost] (1/1) vagrant is running on other
[Aug  8 18:27:46]  INFO [vagrant] Scanning Lockfile...


Scan Summary
================
vagrant	ubuntu20.04	0 installed, 0 updatable	399 libs
```

### specify a path outside of the executing user privileges
- config.toml
```toml
[servers.vagrant]
host = "127.0.0.1"
port = "2222"
user = "vagrant"
keyPath            = "/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa"
scanMode = ["fast-root"]
scanModules = ["lockfile"]
lockfiles = ["/root/Cargo.lock"]
```

- before
```console
$ vuls scan
[Aug  8 18:30:38]  INFO [localhost] vuls-v0.20.0-build-20220808_180441_1e45732
[Aug  8 18:30:38]  INFO [localhost] Start scanning
[Aug  8 18:30:38]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Aug  8 18:30:38]  INFO [localhost] Validating config...
[Aug  8 18:30:38]  INFO [localhost] Detecting Server/Container OS... 
[Aug  8 18:30:38]  INFO [localhost] Detecting OS of servers... 
[Aug  8 18:30:38]  INFO [localhost] (1/1) Detected: vagrant: ubuntu 20.04
[Aug  8 18:30:38]  INFO [localhost] Detecting OS of containers... 
[Aug  8 18:30:38]  INFO [localhost] Checking Scan Modes... 
[Aug  8 18:30:38]  INFO [localhost] Detecting Platforms... 
[Aug  8 18:30:39]  INFO [localhost] (1/1) vagrant is running on other
[Aug  8 18:30:39]  INFO [vagrant] Scanning Lockfile...
[Aug  8 18:30:39] ERROR [localhost] Error on vagrant, err: [Failed to scan Library:
    github.com/future-architect/vuls/scanner.Scanner.getScanResults.func1
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/scanner.go:888
  - Failed to get target file permission: execResult: servername: vagrant
      cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-vagrant.%p -o Controlpersist=10m -l vagrant -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; stat -c "%a" /root/Cargo.lock
      exitstatus: 1
      stdout: stat: cannot stat '/root/Cargo.lock': Permission denied
    
      stderr: 
      err: %!s(<nil>), filepath: /root/Cargo.lock:
    github.com/future-architect/vuls/scanner.(*base).scanLibraries
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/base.go:639]


Scan Summary
================
vagrant	Error		Use configtest subcommand or scan with --debug to view the details


[Aug  8 18:30:39] ERROR [localhost] Failed to scan: Failed to scan. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/scanner.go:106
  - An error occurred on [vagrant]
```

- after
```console
vuls scan
[Aug  8 18:32:33]  INFO [localhost] vuls-v0.20.0-build-20220808_182706_7ae7d4e
[Aug  8 18:32:33]  INFO [localhost] Start scanning
[Aug  8 18:32:33]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Aug  8 18:32:33]  INFO [localhost] Validating config...
[Aug  8 18:32:33]  INFO [localhost] Detecting Server/Container OS... 
[Aug  8 18:32:33]  INFO [localhost] Detecting OS of servers... 
[Aug  8 18:32:33]  INFO [localhost] (1/1) Detected: vagrant: ubuntu 20.04
[Aug  8 18:32:33]  INFO [localhost] Detecting OS of containers... 
[Aug  8 18:32:33]  INFO [localhost] Checking Scan Modes... 
[Aug  8 18:32:33]  INFO [localhost] Detecting Platforms... 
[Aug  8 18:32:34]  INFO [localhost] (1/1) vagrant is running on other
[Aug  8 18:32:34]  INFO [vagrant] Scanning Lockfile...


Scan Summary
================
vagrant	ubuntu20.04	0 installed, 0 updatable	399 libs
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

