### PR TITLE
Fix func to get EC2 instance ID by IMDSv2.

### DIFF
--- a/scanner/base.go
+++ b/scanner/base.go
@@ -398,10 +398,9 @@ func (l *base) detectRunningOnAws() (ok bool, instanceID string, err error) {
 		r := l.exec(cmd, noSudo)
 		if r.isSuccess() {
 			id := strings.TrimSpace(r.Stdout)
-			if !l.isAwsInstanceID(id) {
-				return false, "", nil
+			if l.isAwsInstanceID(id) {
+				return true, id, nil
 			}
-			return true, id, nil
 		}
 
 		cmd = "curl -X PUT --max-time 1 --noproxy 169.254.169.254 -H \"X-aws-ec2-metadata-token-ttl-seconds: 300\" http://169.254.169.254/latest/api/token"


### PR DESCRIPTION
# What did you implement:

Enable to get EC2 instance ID by IMDSv2.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tried locally the commands that are executed.

```shell
$ curl -X PUT --max-time 1 --noproxy 169.254.169.254 -H "X-aws-ec2-metadata-token-ttl-seconds: 300" http://169.254.169.254/latest/ api/token
XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
$ curl -H "X-aws-ec2-metadata-token: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" --max-time 1 --noproxy 169.254.169. 254 http://169.254.169.254/latest/meta-data/instance-id
i-XXXXXXXXXXXXXXXXX
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

