### PR TITLE
feat(wp): support csh, no sudo scan

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -278,6 +278,7 @@ type WordPressConf struct {
 	OSUser  string `toml:"osUser,omitempty" json:"osUser,omitempty"`
 	DocRoot string `toml:"docRoot,omitempty" json:"docRoot,omitempty"`
 	CmdPath string `toml:"cmdPath,omitempty" json:"cmdPath,omitempty"`
+	NoSudo  bool   `toml:"noSudo,omitempty" json:"noSudo,omitempty"`
 }
 
 // IsZero return  whether this struct is not specified in config.toml

--- a/config/config_windows.go
+++ b/config/config_windows.go
@@ -276,6 +276,7 @@ type WordPressConf struct {
 	OSUser  string `toml:"osUser,omitempty" json:"osUser,omitempty"`
 	DocRoot string `toml:"docRoot,omitempty" json:"docRoot,omitempty"`
 	CmdPath string `toml:"cmdPath,omitempty" json:"cmdPath,omitempty"`
+	NoSudo  bool   `toml:"noSudo,omitempty" json:"noSudo,omitempty"`
 }
 
 // IsZero return  whether this struct is not specified in config.toml

--- a/subcmds/discover.go
+++ b/subcmds/discover.go
@@ -240,6 +240,7 @@ host                = "{{$ip}}"
 #cmdPath = "/usr/local/bin/wp"
 #osUser = "wordpress"
 #docRoot = "/path/to/DocumentRoot/"
+#noSudo = false
 
 #[servers.{{index $names $i}}.portscan]
 #scannerBinPath = "/usr/bin/nmap"


### PR DESCRIPTION
# What did you implement:

Support for environments where sudo cannot be used or when the shell is csh, so that users of the following rental servers can use WordPress scan.
https://help.sakura.ad.jp/rs/2251/?article_anchor=js-nav-3

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
## Setup
```console
$ pwd 
/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress
$ vagrant up
$ vagrant ssh-config
Host default
  HostName 127.0.0.1
  User vagrant
  Port 2222
  UserKnownHostsFile /dev/null
  StrictHostKeyChecking no
  PasswordAuthentication no
  IdentityFile /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key
  IdentitiesOnly yes
  LogLevel FATAL
$ ssh -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -p 2222 vagrant@127.0.0.1
```

## When sudo can be used(ServerInfo.User's Shell is ash)
### config.toml
```toml
[servers.wordpress]
host                = "127.0.0.1"
port               = "2222"
user               = "root"
keyPath            = "/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key"
scanMode           = ["fast"]
scanModules = ["wordpress"]

[servers.wordpress.wordpress]
cmdPath     = "/usr/local/bin/wp"
osUser      = "vuls"
docRoot     = "/var/www/html"
noSudo      = false
```

### before
```console
$ vuls scan --debug
[Sep  6 13:20:42]  INFO [localhost] vuls-v0.20.0-build-20220808_180441_1e45732
...
[Sep  6 13:20:43]  INFO [localhost] (1/1) wordpress is running on other
[Sep  6 13:20:43]  INFO [wordpress] Scanning WordPress...
[Sep  6 13:20:43] DEBUG [localhost] Executing... sudo -u vuls -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root
[Sep  6 13:20:43] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; sudo -u vuls -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root
  exitstatus: 0
  stdout: 6.0.2

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:20:43] DEBUG [localhost] Executing... sudo -u vuls -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root 2>/dev/null
[Sep  6 13:20:43] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; sudo -u vuls -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root 2>/dev/null
  exitstatus: 0
  stdout: 6.0.2

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:20:43] DEBUG [localhost] Executing... sudo -u vuls -i -- /usr/local/bin/wp theme list --path=/var/www/html --format=json --allow-root 2>/dev/null
[Sep  6 13:20:45] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; sudo -u vuls -i -- /usr/local/bin/wp theme list --path=/var/www/html --format=json --allow-root 2>/dev/null
  exitstatus: 0
  stdout: [{"name":"twentytwenty","status":"inactive","update":"none","version":"2.0"},{"name":"twentytwentyone","status":"inactive","update":"none","version":"1.6"},{"name":"twentytwentytwo","status":"active","update":"none","version":"1.2"}]
  stderr: 
  err: %!s(<nil>)
[Sep  6 13:20:45] DEBUG [localhost] Executing... sudo -u vuls -i -- /usr/local/bin/wp plugin list --path=/var/www/html --format=json --allow-root 2>/dev/null
[Sep  6 13:20:45] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; sudo -u vuls -i -- /usr/local/bin/wp plugin list --path=/var/www/html --format=json --allow-root 2>/dev/null
  exitstatus: 0
  stdout: [{"name":"akismet","status":"inactive","update":"none","version":"5.0"},{"name":"hello","status":"inactive","update":"none","version":"1.7.2"}]
  stderr: 
  err: %!s(<nil>)


Scan Summary
================
wordpress	ubuntu20.04	0 installed	6 WordPress pkgs
```

### after
```console
$ vuls scan --debug
[Sep  6 13:21:43]  INFO [localhost] vuls-v0.20.2-build-20220906_135127_c380c10
...
[Sep  6 13:21:45]  INFO [localhost] (1/1) wordpress is running on other
[Sep  6 13:21:45] DEBUG [wordpress] Executing... printenv SHELL
[Sep  6 13:21:45] DEBUG [wordpress] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; printenv SHELL
  exitstatus: 0
  stdout: /bin/bash

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:21:45]  INFO [wordpress] Scanning WordPress...
[Sep  6 13:21:45] DEBUG [localhost] Executing... sudo -u vuls -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root
[Sep  6 13:21:45] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; sudo -u vuls -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root
  exitstatus: 0
  stdout: 6.0.2

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:21:45] DEBUG [localhost] Executing... sudo -u vuls -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root 2>/dev/null
[Sep  6 13:21:45] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; sudo -u vuls -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root 2>/dev/null
  exitstatus: 0
  stdout: 6.0.2

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:21:45] DEBUG [localhost] Executing... sudo -u vuls -i -- /usr/local/bin/wp theme list --format=json --path=/var/www/html --allow-root 2>/dev/null
[Sep  6 13:21:46] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; sudo -u vuls -i -- /usr/local/bin/wp theme list --format=json --path=/var/www/html --allow-root 2>/dev/null
  exitstatus: 0
  stdout: [{"name":"twentytwenty","status":"inactive","update":"none","version":"2.0"},{"name":"twentytwentyone","status":"inactive","update":"none","version":"1.6"},{"name":"twentytwentytwo","status":"active","update":"none","version":"1.2"}]
  stderr: 
  err: %!s(<nil>)
[Sep  6 13:21:46] DEBUG [localhost] Executing... sudo -u vuls -i -- /usr/local/bin/wp plugin list --format=json --path=/var/www/html --allow-root 2>/dev/null
[Sep  6 13:21:47] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; sudo -u vuls -i -- /usr/local/bin/wp plugin list --format=json --path=/var/www/html --allow-root 2>/dev/null
  exitstatus: 0
  stdout: [{"name":"akismet","status":"inactive","update":"none","version":"5.0"},{"name":"hello","status":"inactive","update":"none","version":"1.7.2"}]
  stderr: 
  err: %!s(<nil>)


Scan Summary
================
wordpress	ubuntu20.04	0 installed	6 WordPress pkgs
```

## When sudo cannot be used(ServerInfo.User == ServerInfo.WordPress.OSUser, ServerInfo.User's Shell is csh)
### config.toml
```toml
[servers.wordpress]
host                = "127.0.0.1"
port               = "2222"
user               = "vuls"
keyPath            = "/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key"
scanMode           = ["fast"]
scanModules = ["wordpress"]

[servers.wordpress.wordpress]
cmdPath     = "/usr/local/bin/wp"
osUser      = "vuls"
docRoot     = "/var/www/html"
noSudo      = true
```

### before
```console
$ vuls scan --debug
[Sep  6 13:23:32]  INFO [localhost] vuls-v0.20.0-build-20220808_180441_1e45732
...
[Sep  6 13:23:32]  INFO [localhost] (1/1) wordpress is running on other
[Sep  6 13:23:32]  INFO [wordpress] Scanning WordPress...
[Sep  6 13:23:32] DEBUG [localhost] Executing... sudo -u vuls -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root
[Sep  6 13:23:32] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l vuls -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; sudo -u vuls -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root
  exitstatus: 1
  stdout: vuls is not in the sudoers file.  This incident will be reported.

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:23:32] ERROR [localhost] Error on wordpress, err: [Failed to scan WordPress:
    github.com/future-architect/vuls/scanner.Scanner.getScanResults.func1
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/scanner.go:883
  - Failed to exec `sudo -u vuls -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root`. Check the OS user, command path of wp-cli, DocRoot and permission: &config.WordPressConf{OSUser:"vuls", DocRoot:"/var/www/html", CmdPath:"/usr/local/bin/wp"}:
    github.com/future-architect/vuls/scanner.(*base).scanWordPress
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/base.go:793]


Scan Summary
================
wordpress	Error		Use configtest subcommand or scan with --debug to view the details
```

### after
```console
$ vuls scan --debug
[Sep  6 13:24:24]  INFO [localhost] vuls-v0.20.2-build-20220906_135127_c380c10
...
[Sep  6 13:24:24]  INFO [localhost] (1/1) wordpress is running on other
[Sep  6 13:24:24] DEBUG [wordpress] Executing... printenv SHELL
[Sep  6 13:24:24] DEBUG [wordpress] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l vuls -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; printenv SHELL
  exitstatus: 0
  stdout: /usr/bin/csh

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:24:24]  INFO [wordpress] Scanning WordPress...
[Sep  6 13:24:24] DEBUG [localhost] Executing... /usr/local/bin/wp core version --path=/var/www/html
[Sep  6 13:24:24] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l vuls -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; /usr/local/bin/wp core version --path=/var/www/html
  exitstatus: 0
  stdout: 6.0.2

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:24:24] DEBUG [localhost] Executing... ( /usr/local/bin/wp core version --path=/var/www/html > /dev/tty ) >& /dev/null
[Sep  6 13:24:24] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l vuls -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; ( /usr/local/bin/wp core version --path=/var/www/html > /dev/tty ) >& /dev/null
  exitstatus: 0
  stdout: 6.0.2

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:24:24] DEBUG [localhost] Executing... ( /usr/local/bin/wp theme list --format=json --path=/var/www/html > /dev/tty ) >& /dev/null
[Sep  6 13:24:26] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l vuls -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; ( /usr/local/bin/wp theme list --format=json --path=/var/www/html > /dev/tty ) >& /dev/null
  exitstatus: 0
  stdout: [{"name":"twentytwenty","status":"inactive","update":"none","version":"2.0"},{"name":"twentytwentyone","status":"inactive","update":"none","version":"1.6"},{"name":"twentytwentytwo","status":"active","update":"none","version":"1.2"}]
  stderr: 
  err: %!s(<nil>)
[Sep  6 13:24:26] DEBUG [localhost] Executing... ( /usr/local/bin/wp plugin list --format=json --path=/var/www/html > /dev/tty ) >& /dev/null
[Sep  6 13:24:26] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l vuls -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; ( /usr/local/bin/wp plugin list --format=json --path=/var/www/html > /dev/tty ) >& /dev/null
  exitstatus: 0
  stdout: [{"name":"akismet","status":"inactive","update":"none","version":"5.0"},{"name":"hello","status":"inactive","update":"none","version":"1.7.2"}]
  stderr: 
  err: %!s(<nil>)


Scan Summary
================
wordpress	ubuntu20.04	0 installed	6 WordPress pkgs
```

### after(ServerInfo.User's Shell is bash)
#### config.toml
```toml
[servers.wordpress]
host                = "127.0.0.1"
port               = "2222"
user               = "vagrant"
keyPath            = "/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key"
scanMode           = ["fast"]
scanModules = ["wordpress"]

[servers.wordpress.wordpress]
cmdPath     = "/usr/local/bin/wp"
osUser      = "vagrant"
docRoot     = "/var/www/html"
noSudo      = true
```

```console
$ vuls scan --debug
[Sep  6 13:27:53]  INFO [localhost] vuls-v0.20.2-build-20220906_135127_c380c10
...
[Sep  6 13:27:56]  INFO [localhost] (1/1) wordpress is running on other
[Sep  6 13:27:56] DEBUG [wordpress] Executing... printenv SHELL
[Sep  6 13:27:56] DEBUG [wordpress] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l vagrant -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; printenv SHELL
  exitstatus: 0
  stdout: /bin/bash

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:27:56]  INFO [wordpress] Scanning WordPress...
[Sep  6 13:27:56] DEBUG [localhost] Executing... /usr/local/bin/wp core version --path=/var/www/html
[Sep  6 13:27:56] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l vagrant -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; /usr/local/bin/wp core version --path=/var/www/html
  exitstatus: 0
  stdout: 6.0.2

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:27:56] DEBUG [localhost] Executing... /usr/local/bin/wp core version --path=/var/www/html 2>/dev/null
[Sep  6 13:27:56] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l vagrant -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; /usr/local/bin/wp core version --path=/var/www/html 2>/dev/null
  exitstatus: 0
  stdout: 6.0.2

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:27:56] DEBUG [localhost] Executing... /usr/local/bin/wp theme list --format=json --path=/var/www/html 2>/dev/null
[Sep  6 13:27:58] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l vagrant -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; /usr/local/bin/wp theme list --format=json --path=/var/www/html 2>/dev/null
  exitstatus: 0
  stdout: [{"name":"twentytwenty","status":"inactive","update":"none","version":"2.0"},{"name":"twentytwentyone","status":"inactive","update":"none","version":"1.6"},{"name":"twentytwentytwo","status":"active","update":"none","version":"1.2"}]
  stderr: 
  err: %!s(<nil>)
[Sep  6 13:27:58] DEBUG [localhost] Executing... /usr/local/bin/wp plugin list --format=json --path=/var/www/html 2>/dev/null
[Sep  6 13:27:58] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l vagrant -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; /usr/local/bin/wp plugin list --format=json --path=/var/www/html 2>/dev/null
  exitstatus: 0
  stdout: [{"name":"akismet","status":"inactive","update":"none","version":"5.0"},{"name":"hello","status":"inactive","update":"none","version":"1.7.2"}]
  stderr: 
  err: %!s(<nil>)


Scan Summary
================
wordpress	ubuntu20.04	0 installed	6 WordPress pkgs
```

## When sudo cannot be used(ServerInfo.User != ServerInfo.WordPress.OSUser, ServerInfo.User's Shell is bash)
### setup only for this case
```console
$ ssh -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -p 2222 root@127.0.0.1 apt-get purge -y sudo
```

### config.toml
```toml
[servers.wordpress]
host                = "127.0.0.1"
port               = "2222"
user               = "root"
keyPath            = "/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key"
scanMode           = ["fast"]
scanModules = ["wordpress"]

[servers.wordpress.wordpress]
cmdPath     = "/usr/local/bin/wp"
osUser      = "vagrant"
docRoot     = "/var/www/html"
noSudo      = true
```

### before
```console
$ vuls scan --debug
[Sep  6 13:35:08]  INFO [localhost] vuls-v0.20.0-build-20220808_180441_1e45732
...
[Sep  6 13:35:10]  INFO [localhost] (1/1) wordpress is running on other
[Sep  6 13:35:10]  INFO [wordpress] Scanning WordPress...
[Sep  6 13:35:10] DEBUG [localhost] Executing... sudo -u vagrant -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root
[Sep  6 13:35:10] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; sudo -u vagrant -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root
  exitstatus: 127
  stdout: bash: sudo: command not found

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:35:10] ERROR [localhost] Error on wordpress, err: [Failed to scan WordPress:
    github.com/future-architect/vuls/scanner.Scanner.getScanResults.func1
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/scanner.go:883
  - Failed to exec `sudo -u vagrant -i -- /usr/local/bin/wp core version --path=/var/www/html --allow-root`. Check the OS user, command path of wp-cli, DocRoot and permission: &config.WordPressConf{OSUser:"vagrant", DocRoot:"/var/www/html", CmdPath:"/usr/local/bin/wp"}:
    github.com/future-architect/vuls/scanner.(*base).scanWordPress
        /home/mainek00n/go/src/github.com/future-architect/vuls/scanner/base.go:793]


Scan Summary
================
wordpress	Error		Use configtest subcommand or scan with --debug to view the details
```

### after
```console
$ vuls scan --debug
[Sep  6 13:37:33]  INFO [localhost] vuls-v0.20.2-build-20220906_135127_c380c10
...
[Sep  6 13:37:35]  INFO [localhost] (1/1) wordpress is running on other
[Sep  6 13:37:35] DEBUG [wordpress] Executing... printenv SHELL
[Sep  6 13:37:35] DEBUG [wordpress] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; printenv SHELL
  exitstatus: 0
  stdout: /bin/bash

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:37:35]  INFO [wordpress] Scanning WordPress...
[Sep  6 13:37:35] DEBUG [wordpress] Executing... timeout 2 su vagrant -c exit
[Sep  6 13:37:35] DEBUG [wordpress] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; timeout 2 su vagrant -c exit
  exitstatus: 0
  stdout: 
  stderr: 
  err: %!s(<nil>)
[Sep  6 13:37:35] DEBUG [localhost] Executing... su vagrant -c '/usr/local/bin/wp core version --path=/var/www/html'
[Sep  6 13:37:35] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; su vagrant -c '/usr/local/bin/wp core version --path=/var/www/html'
  exitstatus: 0
  stdout: 6.0.2

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:37:35] DEBUG [localhost] Executing... su vagrant -c '/usr/local/bin/wp core version --path=/var/www/html' 2>/dev/null
[Sep  6 13:37:35] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; su vagrant -c '/usr/local/bin/wp core version --path=/var/www/html' 2>/dev/null
  exitstatus: 0
  stdout: 6.0.2

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:37:35] DEBUG [localhost] Executing... su vagrant -c '/usr/local/bin/wp theme list --format=json --path=/var/www/html' 2>/dev/null
[Sep  6 13:37:37] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; su vagrant -c '/usr/local/bin/wp theme list --format=json --path=/var/www/html' 2>/dev/null
  exitstatus: 0
  stdout: [{"name":"twentytwenty","status":"inactive","update":"none","version":"2.0"},{"name":"twentytwentyone","status":"inactive","update":"none","version":"1.6"},{"name":"twentytwentytwo","status":"active","update":"none","version":"1.2"}]
  stderr: 
  err: %!s(<nil>)
[Sep  6 13:37:37] DEBUG [localhost] Executing... su vagrant -c '/usr/local/bin/wp plugin list --format=json --path=/var/www/html' 2>/dev/null
[Sep  6 13:37:37] DEBUG [localhost] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; su vagrant -c '/usr/local/bin/wp plugin list --format=json --path=/var/www/html' 2>/dev/null
  exitstatus: 0
  stdout: [{"name":"akismet","status":"inactive","update":"none","version":"5.0"},{"name":"hello","status":"inactive","update":"none","version":"1.7.2"}]
  stderr: 
  err: %!s(<nil>)


Scan Summary
================
wordpress	ubuntu20.04	0 installed	6 WordPress pkgs
```

### after(If the Switch User requires a Password)
#### config.toml
```toml
[servers.wordpress]
host                = "127.0.0.1"
port               = "2222"
user               = "vagrant"
keyPath            = "/home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key"
scanMode           = ["fast"]
scanModules = ["wordpress"]

[servers.wordpress.wordpress]
cmdPath     = "/usr/local/bin/wp"
osUser      = "vuls"
docRoot     = "/var/www/html"
noSudo      = true
```

```console
$ vuls scan --debug
[Sep  6 13:38:55]  INFO [localhost] vuls-v0.20.2-build-20220906_135127_c380c10
...
[Sep  6 13:38:57]  INFO [localhost] (1/1) wordpress is running on other
[Sep  6 13:38:57] DEBUG [wordpress] Executing... printenv SHELL
[Sep  6 13:38:57] DEBUG [wordpress] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l vagrant -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; printenv SHELL
  exitstatus: 0
  stdout: /bin/bash

  stderr: 
  err: %!s(<nil>)
[Sep  6 13:38:57]  INFO [wordpress] Scanning WordPress...
[Sep  6 13:38:57] DEBUG [wordpress] Executing... timeout 2 su vuls -c exit
[Sep  6 13:38:59] DEBUG [wordpress] execResult: servername: wordpress
  cmd: /usr/bin/ssh -tt -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/controlmaster-%r-wordpress.%p -o Controlpersist=10m -l vagrant -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/wordpress/.vagrant/machines/default/virtualbox/private_key -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; timeout 2 su vuls -c exit
  exitstatus: 124
  stdout: 
  stderr: 
  err: %!s(<nil>)
[Sep  6 13:38:59] ERROR [localhost] Error on wordpress, err: [Failed to scan WordPress:
    github.com/future-architect/vuls/scanner.Scanner.getScanResults.func1
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/scanner.go:883
  - Failed to switch user without password. err: please configure to switch users without password:
    github.com/future-architect/vuls/scanner.(*base).scanWordPress
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/base.go:829]


Scan Summary
================
wordpress	Error		Use configtest subcommand or scan with --debug to view the details
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://github.com/vulsdoc/vuls/pull/214