### PR TITLE
docs: update slack invite URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 ![Vuls-logo](img/vuls_logo.png)
 
-Vulnerability scanner for Linux/FreeBSD, agent-less, written in Go.
-We have a slack team. [Join slack team](http://goo.gl/forms/xm5KFo35tu)
+Vulnerability scanner for Linux/FreeBSD, agent-less, written in Go.  
+We have a slack team. [Join slack team](https://join.slack.com/t/vuls-github/shared_invite/zt-1fculjwj4-6nex2JNE7DpOSiKZ1ztDFw)  
 Twitter: [@vuls_en](https://twitter.com/vuls_en)
 
 ![Vuls-Abstract](img/vuls-abstract.png)


### PR DESCRIPTION
# What did you implement:
Invitation to vuls-github slack does not seem to be working properly.
This PR will change from using the google form to using the Slack invite link.

## Type of change

# How Has This Been Tested?

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

