### PR TITLE
fix(scan): detect AL2 even when empty /etc/redhat-release

### DIFF
--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -200,68 +200,64 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 		// Fedora release 35 (Thirty Five)
 		if r := exec(c, "cat /etc/redhat-release", noSudo); r.isSuccess() {
 			result := releasePattern.FindStringSubmatch(strings.TrimSpace(r.Stdout))
-			if len(result) != 3 {
-				rhel := newRHEL(c)
-				rhel.setErrs([]error{xerrors.Errorf("Failed to parse /etc/redhat-release. r.Stdout: %s", r.Stdout)})
-				return true, rhel
-			}
-
-			release := result[2]
-			major, err := strconv.Atoi(util.Major(release))
-			if err != nil {
-				rhel := newRHEL(c)
-				rhel.setErrs([]error{xerrors.Errorf("Failed to parse major version from release: %s", release)})
-				return true, rhel
-			}
-			switch strings.ToLower(result[1]) {
-			case "fedora":
-				fed := newFedora(c)
-				if major < 32 {
-					fed.setErrs([]error{xerrors.Errorf("Failed to init Fedora. err: not supported major version. versions prior to Fedora 32 are not supported, detected version is %s", release)})
-					return true, fed
-				}
-				fed.setDistro(constant.Fedora, release)
-				return true, fed
-			case "centos", "centos linux":
-				cent := newCentOS(c)
-				if major < 5 {
-					cent.setErrs([]error{xerrors.Errorf("Failed to init CentOS. err: not supported major version. versions prior to CentOS 5 are not supported, detected version is %s", release)})
-					return true, cent
-				}
-				cent.setDistro(constant.CentOS, release)
-				return true, cent
-			case "centos stream":
-				cent := newCentOS(c)
-				if major < 8 {
-					cent.setErrs([]error{xerrors.Errorf("Failed to init CentOS Stream. err: not supported major version. versions prior to CentOS Stream 8 are not supported, detected version is %s", release)})
-					return true, cent
-				}
-				cent.setDistro(constant.CentOS, fmt.Sprintf("stream%s", release))
-				return true, cent
-			case "alma", "almalinux":
-				alma := newAlma(c)
-				if major < 8 {
-					alma.setErrs([]error{xerrors.Errorf("Failed to init AlmaLinux. err: not supported major version. versions prior to AlmaLinux 8 are not supported, detected version is %s", release)})
-					return true, alma
-				}
-				alma.setDistro(constant.Alma, release)
-				return true, alma
-			case "rocky", "rocky linux":
-				rocky := newRocky(c)
-				if major < 8 {
-					rocky.setErrs([]error{xerrors.Errorf("Failed to init Rocky Linux. err: not supported major version. versions prior to Rocky Linux 8 are not supported, detected version is %s", release)})
-					return true, rocky
-				}
-				rocky.setDistro(constant.Rocky, release)
-				return true, rocky
-			default:
-				rhel := newRHEL(c)
-				if major < 5 {
-					rhel.setErrs([]error{xerrors.Errorf("Failed to init RedHat Enterprise Linux. err: not supported major version. versions prior to RedHat Enterprise Linux 5 are not supported, detected version is %s", release)})
+			if len(result) == 3 {
+				release := result[2]
+				major, err := strconv.Atoi(util.Major(release))
+				if err != nil {
+					rhel := newRHEL(c)
+					rhel.setErrs([]error{xerrors.Errorf("Failed to parse major version from release: %s", release)})
 					return true, rhel
 				}
-				rhel.setDistro(constant.RedHat, release)
-				return true, rhel
+				switch strings.ToLower(result[1]) {
+				case "fedora":
+					fed := newFedora(c)
+					if major < 32 {
+						fed.setErrs([]error{xerrors.Errorf("Failed to init Fedora. err: not supported major version. versions prior to Fedora 32 are not supported, detected version is %s", release)})
+						return true, fed
+					}
+					fed.setDistro(constant.Fedora, release)
+					return true, fed
+				case "centos", "centos linux":
+					cent := newCentOS(c)
+					if major < 5 {
+						cent.setErrs([]error{xerrors.Errorf("Failed to init CentOS. err: not supported major version. versions prior to CentOS 5 are not supported, detected version is %s", release)})
+						return true, cent
+					}
+					cent.setDistro(constant.CentOS, release)
+					return true, cent
+				case "centos stream":
+					cent := newCentOS(c)
+					if major < 8 {
+						cent.setErrs([]error{xerrors.Errorf("Failed to init CentOS Stream. err: not supported major version. versions prior to CentOS Stream 8 are not supported, detected version is %s", release)})
+						return true, cent
+					}
+					cent.setDistro(constant.CentOS, fmt.Sprintf("stream%s", release))
+					return true, cent
+				case "alma", "almalinux":
+					alma := newAlma(c)
+					if major < 8 {
+						alma.setErrs([]error{xerrors.Errorf("Failed to init AlmaLinux. err: not supported major version. versions prior to AlmaLinux 8 are not supported, detected version is %s", release)})
+						return true, alma
+					}
+					alma.setDistro(constant.Alma, release)
+					return true, alma
+				case "rocky", "rocky linux":
+					rocky := newRocky(c)
+					if major < 8 {
+						rocky.setErrs([]error{xerrors.Errorf("Failed to init Rocky Linux. err: not supported major version. versions prior to Rocky Linux 8 are not supported, detected version is %s", release)})
+						return true, rocky
+					}
+					rocky.setDistro(constant.Rocky, release)
+					return true, rocky
+				default:
+					rhel := newRHEL(c)
+					if major < 5 {
+						rhel.setErrs([]error{xerrors.Errorf("Failed to init RedHat Enterprise Linux. err: not supported major version. versions prior to RedHat Enterprise Linux 5 are not supported, detected version is %s", release)})
+						return true, rhel
+					}
+					rhel.setDistro(constant.RedHat, release)
+					return true, rhel
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# What did you implement:

Error in identifying the OS in the scan process when an empty /etc/redhat-release exists on the server.

```
[root@ip-192-168-0-61 etc]# touch /etc/redhat-release
```

```
 ./vuls scan ama
[Sep 29 10:23:25]  INFO [localhost] vuls-v0.20.3-build-20220929_101358_379fc8a
[Sep 29 10:23:25]  INFO [localhost] Start scanning
[Sep 29 10:23:25]  INFO [localhost] config: /home/ubuntu/go/src/github.com/future-architect/vuls/config.toml
[Sep 29 10:23:25]  INFO [localhost] Validating config...
[Sep 29 10:23:25]  INFO [localhost] Detecting Server/Container OS... 
[Sep 29 10:23:25]  INFO [localhost] Detecting OS of servers... 
[Sep 29 10:23:26] ERROR [localhost] (1/1) Failed: ama, err: [Failed to parse /etc/redhat-release. r.Stdout: :
    github.com/future-architect/vuls/scanner.detectRedhat
        /home/ubuntu/go/src/github.com/future-architect/vuls/scanner/redhatbase.go:205]
[Sep 29 10:23:26] ERROR [localhost] Failed to scan: Failed to init servers. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/ubuntu/go/src/github.com/future-architect/vuls/scanner/scanner.go:89
  - No scannable host OS:
    github.com/future-architect/vuls/scanner.Scanner.initServers
        /home/ubuntu/go/src/github.com/future-architect/vuls/scanner/scanner.go:253
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
[root@ip-192-168-0-61 etc]# touch /etc/redhat-release
```

Scan works fine.

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

