### PR TITLE
fix(saas): panic: runtime error: comparing uncomparable type config.PortScanConf

### DIFF
--- a/saas/uuid.go
+++ b/saas/uuid.go
@@ -103,6 +103,9 @@ func writeToFile(cnf config.Config, path string) error {
 	if cnf.Default.WordPress != nil && cnf.Default.WordPress.IsZero() {
 		cnf.Default.WordPress = nil
 	}
+	if cnf.Default.PortScan != nil && cnf.Default.PortScan.IsZero() {
+		cnf.Default.PortScan = nil
+	}
 
 	c := struct {
 		Saas    *config.SaasConf             `toml:"saas"`
@@ -195,6 +198,12 @@ func cleanForTOMLEncoding(server config.ServerInfo, def config.ServerInfo) confi
 	if server.WordPress != nil {
 		if server.WordPress.IsZero() || reflect.DeepEqual(server.WordPress, def.WordPress) {
 			server.WordPress = nil
+		}
+	}
+
+	if server.PortScan != nil {
+		if server.PortScan.IsZero() || reflect.DeepEqual(server.PortScan, def.PortScan) {
+			server.PortScan = nil
 		}
 	}
 


### PR DESCRIPTION
# What did you implement:

```
panic: runtime error: comparing uncomparable type config.PortScanConf [recovered]
	panic: runtime error: comparing uncomparable type config.PortScanConf

goroutine 1 [running]:
github.com/BurntSushi/toml.(*Encoder).safeEncode.func1()
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:152 +0x78
panic({0xece920, 0xc002cb4380})
	/opt/hostedtoolcache/go/1.18.6/x64/src/runtime/panic.go:838 +0x207
github.com/BurntSushi/toml.isEmpty({0xf77940?, 0xc000078460?, 0x0?})
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:656 +0xf9
github.com/BurntSushi/toml.(*Encoder).eStruct.func2({0xc0000a5380?, 0x3, 0xfc7100?})
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:507 +0x23e
github.com/BurntSushi/toml.(*Encoder).eStruct(0xc0031b8e00, {0xc0000a8e80, 0x2, 0x2}, {0xfc7100?, 0xc002a27340?, 0x1?}, 0x0)
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:529 +0x266
github.com/BurntSushi/toml.(*Encoder).eMapOrStruct(0xc0031b8e00?, {0xc0000a8e80?, 0x2?, 0x0?}, {0xfc7100?, 0xc002a27340?, 0xfc7100?}, 0xc8?)
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:370 +0x4e
github.com/BurntSushi/toml.(*Encoder).eTable(0xc0031b8e00, {0xc0000a8e80, 0x2, 0x2}, {0xfc7100?, 0xc002a27340?, 0xc002a27340?})
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:362 +0x1a5
github.com/BurntSushi/toml.(*Encoder).encode(0xfc7100?, {0xc0000a8e80, 0x2, 0x2}, {0xfc7100?, 0xc002a27340?, 0x7f2357bd9498?})
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:202 +0x399
github.com/BurntSushi/toml.(*Encoder).eMap.func1({0xc002c47cf0, 0x1, 0x1d?}, 0x0)
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:409 +0x32f
github.com/BurntSushi/toml.(*Encoder).eMap(0xc0031b8e00, {0xc002c47ca0, 0x1, 0x1}, {0xec7200?, 0xc002a27078?, 0x1?}, 0x0)
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:418 +0x256
github.com/BurntSushi/toml.(*Encoder).eMapOrStruct(0xc0031b8e00?, {0xc002c47ca0?, 0x1?, 0x0?}, {0xec7200?, 0xc002a27078?, 0xec7200?}, 0xc8?)
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:368 +0x58
github.com/BurntSushi/toml.(*Encoder).eTable(0xc0031b8e00, {0xc002c47ca0, 0x1, 0x1}, {0xec7200?, 0xc002a27078?, 0xe868c0?})
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:362 +0x1a5
github.com/BurntSushi/toml.(*Encoder).encode(0xe370a6?, {0xc002c47ca0, 0x1, 0x1}, {0xec7200?, 0xc002a27078?, 0xe370a6?})
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:195 +0x1c5
github.com/BurntSushi/toml.(*Encoder).eStruct.func2({0xc0000a5200?, 0x3, 0xf27ba0?})
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:520 +0x425
github.com/BurntSushi/toml.(*Encoder).eStruct(0xc0031b8e00, {0x1d87300, 0x0, 0x0}, {0xf27ba0?, 0xc002a26dc0?, 0xe79ee0?}, 0x0)
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:529 +0x266
github.com/BurntSushi/toml.(*Encoder).eMapOrStruct(0xc0031b8348?, {0x1d87300?, 0xedd5c0?, 0xf27ba0?}, {0xf27ba0?, 0xc002a26dc0?, 0xf27ba0?}, 0x88?)
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:370 +0x4e
github.com/BurntSushi/toml.(*Encoder).eTable(0xc0031b8e00, {0x1d87300, 0x0, 0x0}, {0xf27ba0?, 0xc002a26dc0?, 0x43e225?})
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:362 +0x1a5
github.com/BurntSushi/toml.(*Encoder).encode(0xc002a26dc0?, {0x1d87300, 0x0, 0x0}, {0xf27ba0?, 0xc002a26dc0?, 0xc002c4cae0?})
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:202 +0x399
github.com/BurntSushi/toml.(*Encoder).safeEncode(0xf27ba0?, {0x1d87300?, 0xc0031b8548?, 0x40b04b?}, {0xf27ba0?, 0xc002a26dc0?, 0xc0031b9440?})
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:155 +0x77
github.com/BurntSushi/toml.(*Encoder).Encode(0xc0031b8e00, {0xf27ba0?, 0xc002a26dc0?})
	/home/runner/go/pkg/mod/github.com/!burnt!sushi/toml@v1.2.0/encode.go:139 +0xc8
github.com/future-architect/vuls/saas.writeToFile({{0x0, 0x0, 0x0, {0xfe87a1, 0xd}, 0x0, 0x0}, {0x0, 0x0}, {0xc0023fd908, ...}, ...}, ...)
	/home/runner/work/futurevuls-backend/futurevuls-backend/scanner-src/saas/uuid.go:133 +0x6be
github.com/future-architect/vuls/saas.EnsureUUIDs(0xc00329db00?, {0xc002538700, 0x1a}, {0xc00328d300?, 0xc0031bb420?, 0xc001e5aff0?})
	/home/runner/work/futurevuls-backend/futurevuls-backend/scanner-src/saas/uuid.go:29 +0xd6
github.com/future-architect/vuls/subcmds.(*SaaSCmd).Execute(0xc002951e30, {0xc0000a8010?, 0xc0031bdd78?}, 0xc0000a4cc0, {0x1?, 0xe7d5c0?, 0x1?})
	/home/runner/work/futurevuls-backend/futurevuls-backend/scanner-src/subcmds/saas.go:113 +0x6d7
github.com/google/subcommands.(*Commander).Execute(0xc0000e9880, {0x137dc60, 0xc0000aa000}, {0x0, 0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/google/subcommands@v1.2.0/subcommands.go:209 +0x3bc
github.com/google/subcommands.Execute(...)
	/home/runner/go/pkg/mod/github.com/google/subcommands@v1.2.0/subcommands.go:492
main.main()
	/home/runner/work/futurevuls-backend/futurevuls-backend/scanner-src/cmd/scanner/main.go:35 +0x12c8
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES

