### PR TITLE
chore(ubuntu): set Ubuntu 22.10 EOL

### DIFF
--- a/config/os.go
+++ b/config/os.go
@@ -166,6 +166,9 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 				StandardSupportUntil: time.Date(2027, 4, 1, 23, 59, 59, 0, time.UTC),
 				ExtendedSupportUntil: time.Date(2032, 4, 1, 23, 59, 59, 0, time.UTC),
 			},
+			"22.10": {
+				StandardSupportUntil: time.Date(2023, 7, 20, 23, 59, 59, 0, time.UTC),
+			},
 		}[release]
 	case constant.OpenSUSE:
 		// https://en.opensuse.org/Lifetime

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -339,6 +339,14 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			stdEnded: false,
 			extEnded: false,
 		},
+		{
+			name:     "Ubuntu 22.10 supported",
+			fields:   fields{family: Ubuntu, release: "22.10"},
+			now:      time.Date(2022, 5, 1, 23, 59, 59, 0, time.UTC),
+			found:    true,
+			stdEnded: false,
+			extEnded: false,
+		},
 		//Debian
 		{
 			name:     "Debian 9 supported",


### PR DESCRIPTION
# What did you implement:
set Ubuntu 22.10

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## before
```console
$ vuls scan
[Oct 27 02:14:50]  INFO [localhost] vuls-v0.20.5-build-20221027_015659_6eb4c5a
[Oct 27 02:14:50]  INFO [localhost] Start scanning
[Oct 27 02:14:50]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Oct 27 02:14:50]  INFO [localhost] Validating config...
[Oct 27 02:14:50]  INFO [localhost] Detecting Server/Container OS... 
[Oct 27 02:14:50]  INFO [localhost] Detecting OS of servers... 
[Oct 27 02:14:50]  INFO [localhost] (1/1) Detected: vuls-target: ubuntu 22.10
[Oct 27 02:14:50]  INFO [localhost] Detecting OS of containers... 
[Oct 27 02:14:50]  INFO [localhost] Checking Scan Modes... 
[Oct 27 02:14:50]  INFO [localhost] Detecting Platforms... 
[Oct 27 02:14:52]  INFO [localhost] (1/1) vuls-target is running on other
[Oct 27 02:14:52]  INFO [vuls-target] Scanning OS pkg in fast mode
[Oct 27 02:14:52]  WARN [localhost] Some warnings occurred during scanning on vuls-target. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family: ubuntu Release: 22.10`]


Scan Summary
================
vuls-target	ubuntu22.10	332 installed

Warning: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family: ubuntu Release: 22.10`]



To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

```

## after
```console
$ vuls scan
[Oct 27 02:16:37]  INFO [localhost] vuls-v0.20.5-build-20221027_021533_b26c5b9
[Oct 27 02:16:37]  INFO [localhost] Start scanning
[Oct 27 02:16:37]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Oct 27 02:16:37]  INFO [localhost] Validating config...
[Oct 27 02:16:37]  INFO [localhost] Detecting Server/Container OS... 
[Oct 27 02:16:37]  INFO [localhost] Detecting OS of servers... 
[Oct 27 02:16:37]  INFO [localhost] (1/1) Detected: vuls-target: ubuntu 22.10
[Oct 27 02:16:37]  INFO [localhost] Detecting OS of containers... 
[Oct 27 02:16:37]  INFO [localhost] Checking Scan Modes... 
[Oct 27 02:16:37]  INFO [localhost] Detecting Platforms... 
[Oct 27 02:16:39]  INFO [localhost] (1/1) vuls-target is running on other
[Oct 27 02:16:39]  INFO [vuls-target] Scanning OS pkg in fast mode


Scan Summary
================
vuls-target	ubuntu22.10	332 installed





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

