### PR TITLE
feat(report): Include dependencies into scan result and cyclondex for supply chain security on Integration with GitHub Security Alerts

### DIFF
--- a/cache/bolt.go
+++ b/cache/bolt.go
@@ -48,7 +48,7 @@ func (b Bolt) Close() error {
 	return b.db.Close()
 }
 
-//  CreateBucketIfNotExists creates a bucket that is specified by arg.
+// CreateBucketIfNotExists creates a bucket that is specified by arg.
 func (b *Bolt) createBucketIfNotExists(name string) error {
 	return b.db.Update(func(tx *bolt.Tx) error {
 		_, err := tx.CreateBucketIfNotExists([]byte(name))

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ var Revision string
 // Conf has Configuration
 var Conf Config
 
-//Config is struct of Configuration
+// Config is struct of Configuration
 type Config struct {
 	logging.LogOpts
 

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -305,7 +305,7 @@ func DetectGitHubCves(r *models.ScanResult, githubConfs map[string]config.GitHub
 			r.FormatServerName(), n, owner, repo)
 
 		if err = DetectGitHubDependencyGraph(r, owner, repo, setting.Token); err != nil {
-			return xerrors.Errorf("Filed to access GitHub Dependency graph: %w", err)
+			return xerrors.Errorf("Failed to access GitHub Dependency graph: %w", err)
 		}
 	}
 	return nil

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -303,6 +303,10 @@ func DetectGitHubCves(r *models.ScanResult, githubConfs map[string]config.GitHub
 		}
 		logging.Log.Infof("%s: %d CVEs detected with GHSA %s/%s",
 			r.FormatServerName(), n, owner, repo)
+
+		if err = DetectGitHubDependencyGraph(r, owner, repo, setting.Token); err != nil {
+			return xerrors.Errorf("Filed to access GitHub Dependency graph: %w", err)
+		}
 	}
 	return nil
 }

--- a/detector/github.go
+++ b/detector/github.go
@@ -271,7 +271,7 @@ func fetchDependencyGraph(r *models.ScanResult, httpClient *http.Client, owner, 
 		manifest, ok := r.GitHubManifests[m.Node.Filename]
 		if !ok {
 			manifest = models.DependencyGraphManifest{
-				Lockfile:     m.Node.Filename,
+				Filename:     m.Node.Filename,
 				Repository:   m.Node.Repository.URL,
 				Dependencies: []models.Dependency{},
 			}

--- a/detector/github.go
+++ b/detector/github.go
@@ -265,33 +265,23 @@ func DetectGitHubDependencyGraph(r *models.ScanResult, owner, repo, token string
 
 		dependenciesAfter = ""
 		for _, m := range graph.Data.Repository.DependencyGraphManifests.Edges {
-			if val, ok := r.GitHubManifests[m.Node.Filename]; ok {
-				for _, d := range m.Node.Dependencies.Edges {
-					val.Dependencies = append(val.Dependencies, models.Dependency{
-						PackageName:    d.Node.PackageName,
-						PackageManager: d.Node.PackageManager,
-						Repository:     d.Node.Repository.URL,
-						Requirements:   d.Node.Requirements,
-					})
-				}
-				r.GitHubManifests[m.Node.Filename] = val
-			} else {
-				manifest := models.DependencyGraphManifest{
+			manifest, ok := r.GitHubManifests[m.Node.Filename]
+			if !ok {
+				manifest = models.DependencyGraphManifest{
 					Lockfile:     m.Node.Filename,
 					Repository:   m.Node.Repository.URL,
 					Dependencies: []models.Dependency{},
 				}
-
-				for _, d := range m.Node.Dependencies.Edges {
-					manifest.Dependencies = append(manifest.Dependencies, models.Dependency{
-						PackageName:    d.Node.PackageName,
-						PackageManager: d.Node.PackageManager,
-						Repository:     d.Node.Repository.URL,
-						Requirements:   d.Node.Requirements,
-					})
-				}
-				r.GitHubManifests[m.Node.Filename] = manifest
 			}
+			for _, d := range m.Node.Dependencies.Edges {
+				manifest.Dependencies = append(manifest.Dependencies, models.Dependency{
+					PackageName:    d.Node.PackageName,
+					PackageManager: d.Node.PackageManager,
+					Repository:     d.Node.Repository.URL,
+					Requirements:   d.Node.Requirements,
+				})
+			}
+			r.GitHubManifests[m.Node.Filename] = manifest
 
 			if m.Node.Dependencies.PageInfo.HasNextPage {
 				dependenciesAfter = fmt.Sprintf(`(after: \"%s\")`, m.Node.Dependencies.PageInfo.EndCursor)

--- a/detector/github.go
+++ b/detector/github.go
@@ -79,11 +79,11 @@ func DetectGitHubSecurityAlerts(r *models.ScanResult, owner, repo, token string,
 				continue
 			}
 
-			repoUrlPkgName := fmt.Sprintf("%s %s",
+			repoURLPkgName := fmt.Sprintf("%s %s",
 				alerts.Data.Repository.URL, v.Node.SecurityVulnerability.Package.Name)
 
 			m := models.GitHubSecurityAlert{
-				PackageName: repoUrlPkgName,
+				PackageName: repoURLPkgName,
 				Repository:  alerts.Data.Repository.URL,
 				Package: models.GSAVulnerablePackage{
 					Name:             v.Node.SecurityVulnerability.Package.Name,

--- a/detector/wordpress.go
+++ b/detector/wordpress.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-//WpCveInfos is for wpscan json
+// WpCveInfos is for wpscan json
 type WpCveInfos struct {
 	ReleaseDate  string `json:"release_date"`
 	ChangelogURL string `json:"changelog_url"`
@@ -33,7 +33,7 @@ type WpCveInfos struct {
 	Error           string      `json:"error"`
 }
 
-//WpCveInfo is for wpscan json
+// WpCveInfo is for wpscan json
 type WpCveInfo struct {
 	ID         string     `json:"id"`
 	Title      string     `json:"title"`
@@ -44,7 +44,7 @@ type WpCveInfo struct {
 	FixedIn    string     `json:"fixed_in"`
 }
 
-//References is for wpscan json
+// References is for wpscan json
 type References struct {
 	URL     []string `json:"url"`
 	Cve     []string `json:"cve"`

--- a/logging/logutil.go
+++ b/logging/logutil.go
@@ -15,7 +15,7 @@ import (
 	formatter "github.com/kotakanbe/logrus-prefixed-formatter"
 )
 
-//LogOpts has options for logging
+// LogOpts has options for logging
 type LogOpts struct {
 	Debug     bool   `json:"debug,omitempty"`
 	DebugSQL  bool   `json:"debugSQL,omitempty"`

--- a/logging/logutil.go
+++ b/logging/logutil.go
@@ -45,7 +45,6 @@ func NewNormalLogger() Logger {
 	return Logger{Entry: logrus.Entry{Logger: logrus.New()}}
 }
 
-// NewNormalLogger creates normal logger
 func NewIODiscardLogger() Logger {
 	l := logrus.New()
 	l.Out = io.Discard

--- a/models/github.go
+++ b/models/github.go
@@ -1,5 +1,10 @@
 package models
 
+import (
+	"regexp"
+	"strings"
+)
+
 // key: Lockfile
 type DependencyGraphManifests map[string]DependencyGraphManifest
 
@@ -13,10 +18,52 @@ func (m DependencyGraphManifest) Ecosystem() string {
 	if len(m.Dependencies) > 0 {
 		return m.Dependencies[0].PackageManager
 	}
-	// TODO: convert from lock filename?
+
 	// https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#supported-package-ecosystems
-	//switch case strings.Contains(m.Lockfile, "go.sum"): return "GO"
-	return "UNKNOWN"
+	switch {
+	case strings.HasSuffix(m.Lockfile, "Cargo.lock"),
+		strings.HasSuffix(m.Lockfile, "Cargo.toml"):
+		return "RUST" // Rust
+	case strings.HasSuffix(m.Lockfile, "composer.lock"),
+		strings.HasSuffix(m.Lockfile, "composer.json"):
+		return "COMPOSER" // PHP
+	case strings.HasSuffix(m.Lockfile, ".csproj"),
+		strings.HasSuffix(m.Lockfile, ".vbproj"),
+		strings.HasSuffix(m.Lockfile, ".nuspec"),
+		strings.HasSuffix(m.Lockfile, ".vcxproj"),
+		strings.HasSuffix(m.Lockfile, ".fsproj"),
+		strings.HasSuffix(m.Lockfile, "packages.config"):
+		return "NUGET" // .NET languages (C#, F#, VB), C++
+	case strings.HasSuffix(m.Lockfile, "go.sum"),
+		strings.HasSuffix(m.Lockfile, "go.mod"):
+		return "GO" // Go
+	case strings.HasSuffix(m.Lockfile, "pom.xml"):
+		return "MAVEN" // Java, Scala
+	case strings.HasSuffix(m.Lockfile, "package-lock.json"),
+		strings.HasSuffix(m.Lockfile, "yarn.lock"),
+		strings.HasSuffix(m.Lockfile, "package.json"):
+		return "NPM" // JavaScript
+	case strings.HasSuffix(m.Lockfile, "requirements.txt"),
+		strings.HasSuffix(m.Lockfile, "requirements-dev.txt"),
+		strings.HasSuffix(m.Lockfile, "Pipfile.lock"),
+		strings.HasSuffix(m.Lockfile, "Pipfile"),
+		strings.HasSuffix(m.Lockfile, "setup.py"),
+		strings.HasSuffix(m.Lockfile, "poetry.lock"),
+		strings.HasSuffix(m.Lockfile, "pyproject.toml"):
+		return "PIP" // Python
+	case strings.HasSuffix(m.Lockfile, "Gemfile.lock"),
+		strings.HasSuffix(m.Lockfile, "Gemfile"),
+		strings.HasSuffix(m.Lockfile, ".gemspec"):
+		return "RUBYGEMS" // Ruby
+	case strings.HasSuffix(m.Lockfile, "pubspec.lock"),
+		strings.HasSuffix(m.Lockfile, "pubspec.yaml"):
+		return "PUB" // Dart
+	case strings.HasSuffix(m.Lockfile, ".yml"),
+		strings.HasSuffix(m.Lockfile, ".yaml"):
+		return "ACTIONS" // GitHub Actions workflows
+	default:
+		return "UNKNOWN"
+	}
 }
 
 // equal to DependencyGraphDependency
@@ -27,7 +74,11 @@ type Dependency struct {
 	Requirements   string `json:"requirements"`
 }
 
+var reDepReq = regexp.MustCompile(`^= ([a-z\d\-\.\+]+)$`)
+
 func (d Dependency) Version() string {
-	// TODO: convert requirements to version
-	return d.Requirements
+	if match := reDepReq.FindStringSubmatch(d.Requirements); len(match) == 2 {
+		return match[1]
+	}
+	return ""
 }

--- a/models/github.go
+++ b/models/github.go
@@ -15,10 +15,6 @@ type DependencyGraphManifest struct {
 }
 
 func (m DependencyGraphManifest) Ecosystem() string {
-	if len(m.Dependencies) > 0 {
-		return m.Dependencies[0].PackageManager
-	}
-
 	// https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#supported-package-ecosystems
 	switch {
 	case strings.HasSuffix(m.Lockfile, "Cargo.lock"),
@@ -74,7 +70,7 @@ type Dependency struct {
 	Requirements   string `json:"requirements"`
 }
 
-var reDepReq = regexp.MustCompile(`^= ([a-z\d\-\.\+]+)$`)
+var reDepReq = regexp.MustCompile(`^= (.+)$`)
 
 func (d Dependency) Version() string {
 	if match := reDepReq.FindStringSubmatch(d.Requirements); len(match) == 2 {

--- a/models/github.go
+++ b/models/github.go
@@ -79,6 +79,5 @@ func (d Dependency) Version() string {
 	if len(s) == 2 && s[0] == "=" {
 		return s[1]
 	}
-	// TODO: return d.Requirements?
 	return ""
 }

--- a/models/github.go
+++ b/models/github.go
@@ -1,0 +1,33 @@
+package models
+
+// key: Lockfile
+type DependencyGraphManifests map[string]DependencyGraphManifest
+
+type DependencyGraphManifest struct {
+	Lockfile     string       `json:"lockfile"`
+	Repository   string       `json:"repository"`
+	Dependencies []Dependency `json:"dependencies"`
+}
+
+func (m DependencyGraphManifest) Ecosystem() string {
+	if len(m.Dependencies) > 0 {
+		return m.Dependencies[0].PackageManager
+	}
+	// TODO: convert from lock filename?
+	// https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#supported-package-ecosystems
+	//switch case strings.Contains(m.Lockfile, "go.sum"): return "GO"
+	return "UNKNOWN"
+}
+
+// equal to DependencyGraphDependency
+type Dependency struct {
+	PackageName    string `json:"packageName"`
+	PackageManager string `json:"packageManager"`
+	Repository     string `json:"repository"`
+	Requirements   string `json:"requirements"`
+}
+
+func (d Dependency) Version() string {
+	// TODO: convert requirements to version
+	return d.Requirements
+}

--- a/models/github.go
+++ b/models/github.go
@@ -5,68 +5,69 @@ import (
 	"strings"
 )
 
-// key: Lockfile
+// DependencyGraphManifests has a map of DependencyGraphManifest
+// key: Filename
 type DependencyGraphManifests map[string]DependencyGraphManifest
 
 type DependencyGraphManifest struct {
-	Lockfile     string       `json:"lockfile"`
+	Filename     string       `json:"filename"`
 	Repository   string       `json:"repository"`
 	Dependencies []Dependency `json:"dependencies"`
 }
 
+// Ecosystem returns a name of ecosystem(or package manager) of manifest(lock) file in trivy way
+// https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#supported-package-ecosystems
 func (m DependencyGraphManifest) Ecosystem() string {
-	// https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph#supported-package-ecosystems
 	switch {
-	case strings.HasSuffix(m.Lockfile, "Cargo.lock"),
-		strings.HasSuffix(m.Lockfile, "Cargo.toml"):
+	case strings.HasSuffix(m.Filename, "Cargo.lock"),
+		strings.HasSuffix(m.Filename, "Cargo.toml"):
 		return ftypes.Cargo // Rust
-	case strings.HasSuffix(m.Lockfile, "composer.lock"),
-		strings.HasSuffix(m.Lockfile, "composer.json"):
+	case strings.HasSuffix(m.Filename, "composer.lock"),
+		strings.HasSuffix(m.Filename, "composer.json"):
 		return ftypes.Composer // PHP
-	case strings.HasSuffix(m.Lockfile, ".csproj"),
-		strings.HasSuffix(m.Lockfile, ".vbproj"),
-		strings.HasSuffix(m.Lockfile, ".nuspec"),
-		strings.HasSuffix(m.Lockfile, ".vcxproj"),
-		strings.HasSuffix(m.Lockfile, ".fsproj"),
-		strings.HasSuffix(m.Lockfile, "packages.config"):
+	case strings.HasSuffix(m.Filename, ".csproj"),
+		strings.HasSuffix(m.Filename, ".vbproj"),
+		strings.HasSuffix(m.Filename, ".nuspec"),
+		strings.HasSuffix(m.Filename, ".vcxproj"),
+		strings.HasSuffix(m.Filename, ".fsproj"),
+		strings.HasSuffix(m.Filename, "packages.config"):
 		return ftypes.NuGet // .NET languages (C#, F#, VB), C++
-	case strings.HasSuffix(m.Lockfile, "go.sum"),
-		strings.HasSuffix(m.Lockfile, "go.mod"):
+	case strings.HasSuffix(m.Filename, "go.sum"),
+		strings.HasSuffix(m.Filename, "go.mod"):
 		return ftypes.GoModule // Go
-	case strings.HasSuffix(m.Lockfile, "pom.xml"):
+	case strings.HasSuffix(m.Filename, "pom.xml"):
 		return ftypes.Pom // Java, Scala
-	case strings.HasSuffix(m.Lockfile, "package-lock.json"),
-		strings.HasSuffix(m.Lockfile, "package.json"):
+	case strings.HasSuffix(m.Filename, "package-lock.json"),
+		strings.HasSuffix(m.Filename, "package.json"):
 		return ftypes.Npm // JavaScript
-	case strings.HasSuffix(m.Lockfile, "yarn.lock"):
+	case strings.HasSuffix(m.Filename, "yarn.lock"):
 		return ftypes.Yarn // JavaScript
-	case strings.HasSuffix(m.Lockfile, "requirements.txt"),
-		strings.HasSuffix(m.Lockfile, "requirements-dev.txt"),
-		strings.HasSuffix(m.Lockfile, "setup.py"):
+	case strings.HasSuffix(m.Filename, "requirements.txt"),
+		strings.HasSuffix(m.Filename, "requirements-dev.txt"),
+		strings.HasSuffix(m.Filename, "setup.py"):
 		return ftypes.Pip // Python
-	case strings.HasSuffix(m.Lockfile, "Pipfile.lock"),
-		strings.HasSuffix(m.Lockfile, "Pipfile"):
+	case strings.HasSuffix(m.Filename, "Pipfile.lock"),
+		strings.HasSuffix(m.Filename, "Pipfile"):
 		return ftypes.Pipenv // Python
-	case strings.HasSuffix(m.Lockfile, "poetry.lock"),
-		strings.HasSuffix(m.Lockfile, "pyproject.toml"):
+	case strings.HasSuffix(m.Filename, "poetry.lock"),
+		strings.HasSuffix(m.Filename, "pyproject.toml"):
 		return ftypes.Poetry // Python
-	case strings.HasSuffix(m.Lockfile, "Gemfile.lock"),
-		strings.HasSuffix(m.Lockfile, "Gemfile"):
+	case strings.HasSuffix(m.Filename, "Gemfile.lock"),
+		strings.HasSuffix(m.Filename, "Gemfile"):
 		return ftypes.Bundler // Ruby
-	case strings.HasSuffix(m.Lockfile, ".gemspec"):
+	case strings.HasSuffix(m.Filename, ".gemspec"):
 		return ftypes.GemSpec // Ruby
-	case strings.HasSuffix(m.Lockfile, "pubspec.lock"),
-		strings.HasSuffix(m.Lockfile, "pubspec.yaml"):
+	case strings.HasSuffix(m.Filename, "pubspec.lock"),
+		strings.HasSuffix(m.Filename, "pubspec.yaml"):
 		return "pub" // Dart
-	case strings.HasSuffix(m.Lockfile, ".yml"),
-		strings.HasSuffix(m.Lockfile, ".yaml"):
+	case strings.HasSuffix(m.Filename, ".yml"),
+		strings.HasSuffix(m.Filename, ".yaml"):
 		return "actions" // GitHub Actions workflows
 	default:
 		return "unknown"
 	}
 }
 
-// equal to DependencyGraphDependency
 type Dependency struct {
 	PackageName    string `json:"packageName"`
 	PackageManager string `json:"packageManager"`
@@ -79,5 +80,6 @@ func (d Dependency) Version() string {
 	if len(s) == 2 && s[0] == "=" {
 		return s[1]
 	}
+	// in case of ranged version
 	return ""
 }

--- a/models/github.go
+++ b/models/github.go
@@ -1,8 +1,9 @@
 package models
 
 import (
-	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"strings"
+
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 )
 
 // DependencyGraphManifests has a map of DependencyGraphManifest

--- a/models/scanresults.go
+++ b/models/scanresults.go
@@ -51,7 +51,7 @@ type ScanResult struct {
 	SrcPackages       SrcPackages              `json:",omitempty"`
 	EnabledDnfModules []string                 `json:"enabledDnfModules,omitempty"` // for dnf modules
 	WordPressPackages WordPressPackages        `json:",omitempty"`
-	GitHubPackages    DependencyGraphManifests `json:"gitHubPackages,omitempty"`
+	GitHubManifests   DependencyGraphManifests `json:"gitHubManifests,omitempty"`
 	LibraryScanners   LibraryScanners          `json:"libraries,omitempty"`
 	CweDict           CweDict                  `json:"cweDict,omitempty"`
 	Optional          map[string]interface{}   `json:",omitempty"`

--- a/models/scanresults.go
+++ b/models/scanresults.go
@@ -45,15 +45,16 @@ type ScanResult struct {
 	Errors           []string          `json:"errors"`
 	Warnings         []string          `json:"warnings"`
 
-	ScannedCves       VulnInfos              `json:"scannedCves"`
-	RunningKernel     Kernel                 `json:"runningKernel"`
-	Packages          Packages               `json:"packages"`
-	SrcPackages       SrcPackages            `json:",omitempty"`
-	EnabledDnfModules []string               `json:"enabledDnfModules,omitempty"` // for dnf modules
-	WordPressPackages WordPressPackages      `json:",omitempty"`
-	LibraryScanners   LibraryScanners        `json:"libraries,omitempty"`
-	CweDict           CweDict                `json:"cweDict,omitempty"`
-	Optional          map[string]interface{} `json:",omitempty"`
+	ScannedCves       VulnInfos                `json:"scannedCves"`
+	RunningKernel     Kernel                   `json:"runningKernel"`
+	Packages          Packages                 `json:"packages"`
+	SrcPackages       SrcPackages              `json:",omitempty"`
+	EnabledDnfModules []string                 `json:"enabledDnfModules,omitempty"` // for dnf modules
+	WordPressPackages WordPressPackages        `json:",omitempty"`
+	GitHubPackages    DependencyGraphManifests `json:"gitHubPackages,omitempty"`
+	LibraryScanners   LibraryScanners          `json:"libraries,omitempty"`
+	CweDict           CweDict                  `json:"cweDict,omitempty"`
+	Optional          map[string]interface{}   `json:",omitempty"`
 	Config            struct {
 		Scan   config.Config `json:"scan"`
 		Report config.Config `json:"report"`

--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -284,7 +284,7 @@ type GitHubSecurityAlerts []GitHubSecurityAlert
 // Add adds given arg to the slice and return the slice (immutable)
 func (g GitHubSecurityAlerts) Add(alert GitHubSecurityAlert) GitHubSecurityAlerts {
 	for _, a := range g {
-		if a.RepoUrlPackageName() == alert.RepoUrlPackageName() {
+		if a.RepoURLPackageName() == alert.RepoURLPackageName() {
 			return g
 		}
 	}
@@ -294,7 +294,7 @@ func (g GitHubSecurityAlerts) Add(alert GitHubSecurityAlert) GitHubSecurityAlert
 // Names return a slice of lib names
 func (g GitHubSecurityAlerts) Names() (names []string) {
 	for _, a := range g {
-		names = append(names, a.RepoUrlPackageName())
+		names = append(names, a.RepoURLPackageName())
 	}
 	return names
 }
@@ -312,7 +312,7 @@ type GitHubSecurityAlert struct {
 	DismissReason string               `json:"dismissReason"`
 }
 
-func (a GitHubSecurityAlert) RepoUrlPackageName() string {
+func (a GitHubSecurityAlert) RepoURLPackageName() string {
 	return fmt.Sprintf("%s %s", a.Repository, a.Package.Name)
 }
 

--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -284,7 +284,7 @@ type GitHubSecurityAlerts []GitHubSecurityAlert
 // Add adds given arg to the slice and return the slice (immutable)
 func (g GitHubSecurityAlerts) Add(alert GitHubSecurityAlert) GitHubSecurityAlerts {
 	for _, a := range g {
-		if a.PackageName == alert.PackageName {
+		if a.RepoUrlPackageName() == alert.RepoUrlPackageName() {
 			return g
 		}
 	}
@@ -294,7 +294,7 @@ func (g GitHubSecurityAlerts) Add(alert GitHubSecurityAlert) GitHubSecurityAlert
 // Names return a slice of lib names
 func (g GitHubSecurityAlerts) Names() (names []string) {
 	for _, a := range g {
-		names = append(names, a.PackageName)
+		names = append(names, a.RepoUrlPackageName())
 	}
 	return names
 }
@@ -302,6 +302,7 @@ func (g GitHubSecurityAlerts) Names() (names []string) {
 // GitHubSecurityAlert has detected CVE-ID, PackageName, Status fetched via GitHub API
 type GitHubSecurityAlert struct {
 	PackageName   string               `json:"packageName"`
+	Repository    string               `json:"repository"`
 	Package       GSAVulnerablePackage `json:"package,omitempty"`
 	FixedIn       string               `json:"fixedIn"`
 	AffectedRange string               `json:"affectedRange"`
@@ -310,9 +311,16 @@ type GitHubSecurityAlert struct {
 	DismissReason string               `json:"dismissReason"`
 }
 
+func (a GitHubSecurityAlert) RepoUrlPackageName() string {
+	return fmt.Sprintf("%s %s", a.Repository, a.Package.Name)
+}
+
 type GSAVulnerablePackage struct {
-	Name      string `json:"name"`
-	Ecosystem string `json:"ecosystem"`
+	Name             string `json:"name"`
+	Ecosystem        string `json:"ecosystem"`
+	ManifestFilename string `json:"manifestFilename"`
+	ManifestPath     string `json:"manifestPath"`
+	Requirements     string `json:"requirements"`
 }
 
 // LibraryFixedIns is a list of Library's FixedIn

--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -301,6 +301,7 @@ func (g GitHubSecurityAlerts) Names() (names []string) {
 
 // GitHubSecurityAlert has detected CVE-ID, PackageName, Status fetched via GitHub API
 type GitHubSecurityAlert struct {
+	// TODO: PackageName deprecated. it will be removed next time.
 	PackageName   string               `json:"packageName"`
 	Repository    string               `json:"repository"`
 	Package       GSAVulnerablePackage `json:"package,omitempty"`

--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -301,12 +301,18 @@ func (g GitHubSecurityAlerts) Names() (names []string) {
 
 // GitHubSecurityAlert has detected CVE-ID, PackageName, Status fetched via GitHub API
 type GitHubSecurityAlert struct {
-	PackageName   string    `json:"packageName"`
-	FixedIn       string    `json:"fixedIn"`
-	AffectedRange string    `json:"affectedRange"`
-	Dismissed     bool      `json:"dismissed"`
-	DismissedAt   time.Time `json:"dismissedAt"`
-	DismissReason string    `json:"dismissReason"`
+	PackageName   string               `json:"packageName"`
+	Package       GSAVulnerablePackage `json:"package,omitempty"`
+	FixedIn       string               `json:"fixedIn"`
+	AffectedRange string               `json:"affectedRange"`
+	Dismissed     bool                 `json:"dismissed"`
+	DismissedAt   time.Time            `json:"dismissedAt"`
+	DismissReason string               `json:"dismissReason"`
+}
+
+type GSAVulnerablePackage struct {
+	Name      string `json:"name"`
+	Ecosystem string `json:"ecosystem"`
 }
 
 // LibraryFixedIns is a list of Library's FixedIn

--- a/reporter/sbom/cyclonedx.go
+++ b/reporter/sbom/cyclonedx.go
@@ -86,7 +86,7 @@ func cdxComponents(result models.ScanResult, metaBomRef string) (*[]cdx.Componen
 
 	ghpkgToPURL := map[string]map[string]string{}
 	for _, ghm := range result.GitHubManifests {
-		ghpkgToPURL[ghm.Lockfile] = map[string]string{}
+		ghpkgToPURL[ghm.Filename] = map[string]string{}
 
 		ghpkgComps := ghpkgToCdxComponents(ghm, ghpkgToPURL)
 		bomRefs[metaBomRef] = append(bomRefs[metaBomRef], ghpkgComps[0].BOMRef)
@@ -275,7 +275,7 @@ func ghpkgToCdxComponents(m models.DependencyGraphManifest, ghpkgToPURL map[stri
 		{
 			BOMRef: uuid.NewString(),
 			Type:   cdx.ComponentTypeApplication,
-			Name:   m.Lockfile,
+			Name:   m.Filename,
 			Properties: &[]cdx.Property{
 				{
 					Name:  "future-architect:vuls:Type",
@@ -286,7 +286,7 @@ func ghpkgToCdxComponents(m models.DependencyGraphManifest, ghpkgToPURL map[stri
 	}
 
 	for _, dep := range m.Dependencies {
-		purl := packageurl.NewPackageURL(m.Ecosystem(), "", dep.PackageName, dep.Version(), packageurl.Qualifiers{{Key: "file_path", Value: m.Lockfile}}, "").ToString()
+		purl := packageurl.NewPackageURL(m.Ecosystem(), "", dep.PackageName, dep.Version(), packageurl.Qualifiers{{Key: "file_path", Value: m.Filename}}, "").ToString()
 		components = append(components, cdx.Component{
 			BOMRef:     purl,
 			Type:       cdx.ComponentTypeLibrary,
@@ -295,7 +295,7 @@ func ghpkgToCdxComponents(m models.DependencyGraphManifest, ghpkgToPURL map[stri
 			PackageURL: purl,
 		})
 
-		ghpkgToPURL[m.Lockfile][dep.PackageName] = purl
+		ghpkgToPURL[m.Filename][dep.PackageName] = purl
 	}
 
 	return components
@@ -495,9 +495,9 @@ func cdxAffects(cve models.VulnInfo, ospkgToPURL map[string]string, libpkgToPURL
 		})
 	}
 	for _, alert := range cve.GitHubSecurityAlerts {
+		// TODO: not in dependency graph
 		if purl, ok := ghpkgToPURL[alert.Package.ManifestPath][alert.Package.Name]; ok {
 			affects = append(affects, cdx.Affects{
-				// TODO: case on exist in GSA, but not in dependency graph
 				Ref: purl,
 			})
 		}

--- a/reporter/sbom/cyclonedx.go
+++ b/reporter/sbom/cyclonedx.go
@@ -287,7 +287,6 @@ func ghpkgToCdxComponents(ghpkg models.DependencyGraphManifest, ghpkgToPURL map[
 	}
 
 	for _, dep := range ghpkg.Dependencies {
-		// TODO: check dependency to PackageURL
 		purl := packageurl.NewPackageURL(dep.PackageManager, "", dep.PackageName, dep.Version(), packageurl.Qualifiers{{Key: "file_path", Value: ghpkg.Lockfile}}, "").ToString()
 		components = append(components, cdx.Component{
 			BOMRef:     purl,

--- a/reporter/sbom/cyclonedx.go
+++ b/reporter/sbom/cyclonedx.go
@@ -495,10 +495,12 @@ func cdxAffects(cve models.VulnInfo, ospkgToPURL map[string]string, libpkgToPURL
 		})
 	}
 	for _, alert := range cve.GitHubSecurityAlerts {
-		affects = append(affects, cdx.Affects{
-			// TODO: not sure
-			Ref: ghpkgToPURL[alert.Package.ManifestPath][alert.Package.Name],
-		})
+		if purl, ok := ghpkgToPURL[alert.Package.ManifestPath][alert.Package.Name]; ok {
+			affects = append(affects, cdx.Affects{
+				// TODO: case on exist in GSA, but not in dependency graph
+				Ref: purl,
+			})
+		}
 	}
 	for _, wppack := range cve.WpPackageFixStats {
 		affects = append(affects, cdx.Affects{

--- a/reporter/sbom/cyclonedx.go
+++ b/reporter/sbom/cyclonedx.go
@@ -395,7 +395,7 @@ func toPkgPURL(osFamily, osVersion, packName, packVersion, packRelease, packArch
 	return packageurl.NewPackageURL(purlType, osFamily, packName, version, qualifiers, "").ToString()
 }
 
-func cdxVulnerabilities(result models.ScanResult, ospkgToPURL map[string]string, libpkgToPURL map[string]map[string]string, ghpkgToPURL map[string]map[string]string, wppkgToPURL map[string]string) *[]cdx.Vulnerability {
+func cdxVulnerabilities(result models.ScanResult, ospkgToPURL map[string]string, libpkgToPURL, ghpkgToPURL map[string]map[string]string, wppkgToPURL map[string]string) *[]cdx.Vulnerability {
 	vulnerabilities := make([]cdx.Vulnerability, 0, len(result.ScannedCves))
 	for _, cve := range result.ScannedCves {
 		vulnerabilities = append(vulnerabilities, cdx.Vulnerability{
@@ -476,7 +476,7 @@ func cdxCVSS3Rating(source, vector string, score float64, severity string) cdx.V
 	return r
 }
 
-func cdxAffects(cve models.VulnInfo, ospkgToPURL map[string]string, libpkgToPURL map[string]map[string]string, ghpkgToPURL map[string]map[string]string, wppkgToPURL map[string]string) *[]cdx.Affects {
+func cdxAffects(cve models.VulnInfo, ospkgToPURL map[string]string, libpkgToPURL, ghpkgToPURL map[string]map[string]string, wppkgToPURL map[string]string) *[]cdx.Affects {
 	affects := make([]cdx.Affects, 0, len(cve.AffectedPackages)+len(cve.CpeURIs)+len(cve.LibraryFixedIns)+len(cve.WpPackageFixStats))
 
 	for _, p := range cve.AffectedPackages {

--- a/reporter/slack.go
+++ b/reporter/slack.go
@@ -195,7 +195,7 @@ func (w SlackWriter) toSlackAttachments(r models.ScanResult) (attaches []slack.A
 			candidate = append(candidate, "?")
 		}
 		for _, n := range vinfo.GitHubSecurityAlerts {
-			installed = append(installed, n.PackageName)
+			installed = append(installed, n.RepoUrlPackageName())
 			candidate = append(candidate, "?")
 		}
 

--- a/reporter/slack.go
+++ b/reporter/slack.go
@@ -195,7 +195,7 @@ func (w SlackWriter) toSlackAttachments(r models.ScanResult) (attaches []slack.A
 			candidate = append(candidate, "?")
 		}
 		for _, n := range vinfo.GitHubSecurityAlerts {
-			installed = append(installed, n.RepoUrlPackageName())
+			installed = append(installed, n.RepoURLPackageName())
 			candidate = append(candidate, "?")
 		}
 

--- a/reporter/util.go
+++ b/reporter/util.go
@@ -404,7 +404,7 @@ No CVE-IDs are found in updatable packages.
 		}
 
 		for _, alert := range vuln.GitHubSecurityAlerts {
-			data = append(data, []string{"GitHub", alert.PackageName})
+			data = append(data, []string{"GitHub", alert.RepoUrlPackageName()})
 		}
 
 		for _, wp := range vuln.WpPackageFixStats {

--- a/reporter/util.go
+++ b/reporter/util.go
@@ -404,7 +404,7 @@ No CVE-IDs are found in updatable packages.
 		}
 
 		for _, alert := range vuln.GitHubSecurityAlerts {
-			data = append(data, []string{"GitHub", alert.RepoUrlPackageName()})
+			data = append(data, []string{"GitHub", alert.RepoURLPackageName()})
 		}
 
 		for _, wp := range vuln.WpPackageFixStats {

--- a/scanner/executil.go
+++ b/scanner/executil.go
@@ -62,7 +62,7 @@ const sudo = true
 // noSudo is Const value for normal user mode
 const noSudo = false
 
-//  Issue commands to the target servers in parallel via SSH or local execution.  If execution fails, the server will be excluded from the target server list(servers) and added to the error server list(errServers).
+// Issue commands to the target servers in parallel via SSH or local execution.  If execution fails, the server will be excluded from the target server list(servers) and added to the error server list(errServers).
 func parallelExec(fn func(osTypeInterface) error, timeoutSec ...int) {
 	resChan := make(chan osTypeInterface, len(servers))
 	defer close(resChan)

--- a/scanner/freebsd.go
+++ b/scanner/freebsd.go
@@ -34,7 +34,7 @@ func newBsd(c config.ServerInfo) *bsd {
 	return d
 }
 
-//https://github.com/mizzy/specinfra/blob/master/lib/specinfra/helper/detect_os/freebsd.rb
+// https://github.com/mizzy/specinfra/blob/master/lib/specinfra/helper/detect_os/freebsd.rb
 func detectFreebsd(c config.ServerInfo) (bool, osTypeInterface) {
 	// Prevent from adding `set -o pipefail` option
 	c.Distro = config.Distro{Family: constant.FreeBSD}

--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -801,7 +801,7 @@ func (o *redhatBase) parseNeedsRestarting(stdout string) (procs []models.NeedRes
 	return
 }
 
-//TODO refactor
+// TODO refactor
 // procPathToFQPN returns Fully-Qualified-Package-Name from the command
 func (o *redhatBase) procPathToFQPN(execCommand string) (string, error) {
 	execCommand = strings.Replace(execCommand, "\x00", " ", -1) // for CentOS6.9

--- a/scanner/redhatbase_test.go
+++ b/scanner/redhatbase_test.go
@@ -603,7 +603,7 @@ func Test_redhatBase_parseRpmQfLine(t *testing.T) {
 		{
 			name:   "valid line",
 			fields: fields{base: base{}},
-			args: args{line: "Percona-Server-shared-56	1	5.6.19	rel67.0.el6 x86_64"},
+			args:   args{line: "Percona-Server-shared-56	1	5.6.19	rel67.0.el6 x86_64"},
 			wantPkg: &models.Package{
 				Name:    "Percona-Server-shared-56",
 				Version: "1:5.6.19",

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -745,7 +745,7 @@ func setChangelogLayout(g *gocui.Gui) error {
 		}
 
 		for _, alert := range vinfo.GitHubSecurityAlerts {
-			lines = append(lines, "* "+alert.PackageName)
+			lines = append(lines, "* "+alert.RepoUrlPackageName())
 		}
 
 		r := currentScanResult

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -745,7 +745,7 @@ func setChangelogLayout(g *gocui.Gui) error {
 		}
 
 		for _, alert := range vinfo.GitHubSecurityAlerts {
-			lines = append(lines, "* "+alert.RepoUrlPackageName())
+			lines = append(lines, "* "+alert.RepoURLPackageName())
 		}
 
 		r := currentScanResult


### PR DESCRIPTION
# What did you implement:

- When you integrate with GitHub Security Alerts, Vuls did NOT take non-vulnerable packages in SBOM
- From now on SBOM reporting, it fetches Dependency graph together with GitHub Security Alerts
- And that becomes components and dependencies
- Also, Package URL of vulnerable packages are linked to vulnerabilities in affects

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
$ vuls report -to-localfile -format-cyclonedx-json
or 
$ vuls report -to-localfile -format-cyclonedx-xml
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph
