### PR TITLE
feat(os): support Amazon Linux 2023

### DIFF
--- a/config/os.go
+++ b/config/os.go
@@ -41,8 +41,12 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 	case constant.Amazon:
 		eol, found = map[string]EOL{
 			"1":    {StandardSupportUntil: time.Date(2023, 6, 30, 23, 59, 59, 0, time.UTC)},
-			"2":    {StandardSupportUntil: time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC)},
+			"2":    {StandardSupportUntil: time.Date(2025, 6, 30, 23, 59, 59, 0, time.UTC)},
 			"2022": {StandardSupportUntil: time.Date(2026, 6, 30, 23, 59, 59, 0, time.UTC)},
+			"2023": {StandardSupportUntil: time.Date(2027, 6, 30, 23, 59, 59, 0, time.UTC)},
+			"2025": {StandardSupportUntil: time.Date(2029, 6, 30, 23, 59, 59, 0, time.UTC)},
+			"2027": {StandardSupportUntil: time.Date(2031, 6, 30, 23, 59, 59, 0, time.UTC)},
+			"2029": {StandardSupportUntil: time.Date(2033, 6, 30, 23, 59, 59, 0, time.UTC)},
 		}[getAmazonLinuxVersion(release)]
 	case constant.RedHat:
 		// https://access.redhat.com/support/policy/updates/errata
@@ -328,9 +332,25 @@ func majorDotMinor(osVer string) (majorDotMinor string) {
 }
 
 func getAmazonLinuxVersion(osRelease string) string {
-	ss := strings.Fields(osRelease)
-	if len(ss) == 1 {
+	switch s := strings.Fields(osRelease)[0]; s {
+	case "1":
 		return "1"
+	case "2":
+		return "2"
+	case "2022":
+		return "2022"
+	case "2023":
+		return "2023"
+	case "2025":
+		return "2025"
+	case "2027":
+		return "2027"
+	case "2029":
+		return "2029"
+	default:
+		if _, err := time.Parse("2006.01", s); err == nil {
+			return "1"
+		}
+		return "unknown"
 	}
-	return ss[0]
 }

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -54,8 +54,16 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			found:    true,
 		},
 		{
-			name:     "amazon linux 2024 not found",
-			fields:   fields{family: Amazon, release: "2024 (Amazon Linux)"},
+			name:     "amazon linux 2023 supported",
+			fields:   fields{family: Amazon, release: "2023"},
+			now:      time.Date(2023, 7, 1, 23, 59, 59, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    true,
+		},
+		{
+			name:     "amazon linux 2031 not found",
+			fields:   fields{family: Amazon, release: "2031"},
 			now:      time.Date(2023, 7, 1, 23, 59, 59, 0, time.UTC),
 			stdEnded: false,
 			extEnded: false,
@@ -347,6 +355,14 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			stdEnded: false,
 			extEnded: false,
 		},
+		// {
+		// 	name:     "Ubuntu 23.04 supported",
+		// 	fields:   fields{family: Ubuntu, release: "23.04"},
+		// 	now:      time.Date(2023, 3, 16, 23, 59, 59, 0, time.UTC),
+		// 	found:    true,
+		// 	stdEnded: false,
+		// 	extEnded: false,
+		// },
 		//Debian
 		{
 			name:     "Debian 9 supported",
@@ -668,6 +684,61 @@ func Test_majorDotMinor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if gotMajorDotMinor := majorDotMinor(tt.args.osVer); gotMajorDotMinor != tt.wantMajorDotMinor {
 				t.Errorf("majorDotMinor() = %v, want %v", gotMajorDotMinor, tt.wantMajorDotMinor)
+			}
+		})
+	}
+}
+
+func Test_getAmazonLinuxVersion(t *testing.T) {
+	tests := []struct {
+		release string
+		want    string
+	}{
+		{
+			release: "2017.09",
+			want:    "1",
+		},
+		{
+			release: "2018.03",
+			want:    "1",
+		},
+		{
+			release: "1",
+			want:    "1",
+		},
+		{
+			release: "2",
+			want:    "2",
+		},
+		{
+			release: "2022",
+			want:    "2022",
+		},
+		{
+			release: "2023",
+			want:    "2023",
+		},
+		{
+			release: "2025",
+			want:    "2025",
+		},
+		{
+			release: "2027",
+			want:    "2027",
+		},
+		{
+			release: "2029",
+			want:    "2029",
+		},
+		{
+			release: "2031",
+			want:    "unknown",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.release, func(t *testing.T) {
+			if got := getAmazonLinuxVersion(tt.release); got != tt.want {
+				t.Errorf("getAmazonLinuxVersion() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -68,12 +68,15 @@ func (o RedHatBase) FillWithOval(r *models.ScanResult) (nCVEs int, err error) {
 			for _, d := range vuln.DistroAdvisories {
 				if conts, ok := vuln.CveContents[models.Amazon]; ok {
 					for i, cont := range conts {
-						if strings.HasPrefix(d.AdvisoryID, "ALAS2022-") {
-							cont.SourceLink = fmt.Sprintf("https://alas.aws.amazon.com/AL2022/%s.html", strings.ReplaceAll(d.AdvisoryID, "ALAS2022", "ALAS"))
-						} else if strings.HasPrefix(d.AdvisoryID, "ALAS2-") {
-							cont.SourceLink = fmt.Sprintf("https://alas.aws.amazon.com/AL2/%s.html", strings.ReplaceAll(d.AdvisoryID, "ALAS2", "ALAS"))
-						} else if strings.HasPrefix(d.AdvisoryID, "ALAS-") {
+						switch {
+						case strings.HasPrefix(d.AdvisoryID, "ALAS-"):
 							cont.SourceLink = fmt.Sprintf("https://alas.aws.amazon.com/%s.html", d.AdvisoryID)
+						case strings.HasPrefix(d.AdvisoryID, "ALAS2-"):
+							cont.SourceLink = fmt.Sprintf("https://alas.aws.amazon.com/AL2/%s.html", strings.ReplaceAll(d.AdvisoryID, "ALAS2", "ALAS"))
+						case strings.HasPrefix(d.AdvisoryID, "ALAS2022-"):
+							cont.SourceLink = fmt.Sprintf("https://alas.aws.amazon.com/AL2022/%s.html", strings.ReplaceAll(d.AdvisoryID, "ALAS2022", "ALAS"))
+						case strings.HasPrefix(d.AdvisoryID, "ALAS2023-"):
+							cont.SourceLink = fmt.Sprintf("https://alas.aws.amazon.com/AL2023/%s.html", strings.ReplaceAll(d.AdvisoryID, "ALAS2023", "ALAS"))
 						}
 						vuln.CveContents[models.Amazon][i] = cont
 					}

--- a/oval/util.go
+++ b/oval/util.go
@@ -112,13 +112,25 @@ func getDefsByPackNameViaHTTP(r *models.ScanResult, url string) (relatedDefs ova
 	case constant.CentOS:
 		ovalRelease = strings.TrimPrefix(r.Release, "stream")
 	case constant.Amazon:
-		switch strings.Fields(r.Release)[0] {
-		case "2022":
-			ovalRelease = "2022"
+		switch s := strings.Fields(r.Release)[0]; s {
+		case "1":
+			ovalRelease = "1"
 		case "2":
 			ovalRelease = "2"
+		case "2022":
+			ovalRelease = "2022"
+		case "2023":
+			ovalRelease = "2023"
+		case "2025":
+			ovalRelease = "2025"
+		case "2027":
+			ovalRelease = "2027"
+		case "2029":
+			ovalRelease = "2029"
 		default:
-			ovalRelease = "1"
+			if _, err := time.Parse("2006.01", s); err == nil {
+				ovalRelease = "1"
+			}
 		}
 	}
 
@@ -274,13 +286,25 @@ func getDefsByPackNameFromOvalDB(r *models.ScanResult, driver ovaldb.DB) (relate
 	case constant.CentOS:
 		ovalRelease = strings.TrimPrefix(r.Release, "stream")
 	case constant.Amazon:
-		switch strings.Fields(r.Release)[0] {
-		case "2022":
-			ovalRelease = "2022"
+		switch s := strings.Fields(r.Release)[0]; s {
+		case "1":
+			ovalRelease = "1"
 		case "2":
 			ovalRelease = "2"
+		case "2022":
+			ovalRelease = "2022"
+		case "2023":
+			ovalRelease = "2023"
+		case "2025":
+			ovalRelease = "2025"
+		case "2027":
+			ovalRelease = "2027"
+		case "2029":
+			ovalRelease = "2029"
 		default:
-			ovalRelease = "1"
+			if _, err := time.Parse("2006.01", s); err == nil {
+				ovalRelease = "1"
+			}
 		}
 	}
 


### PR DESCRIPTION
# What did you implement:

support Amazon Linux 2023

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
```console
$ docker build -t vuls-target:amzn2023 -f Dockerfile .
$ docker run --rm -itd -p 2222:22 --name vuls-target vuls-target:amzn2023
$ ssh -i /home/mainek00n/.ssh/id_rsa -p 2222 root@127.0.0.1
[root@51484e96c59a ~]# dnf install -y vim-common-2:9.0.1160-1.amzn2023.0.2.x86_64
[root@51484e96c59a ~]# exit
$ vuls scan
...
[Mar 16 16:55:03]  INFO [localhost] Validating config...
[Mar 16 16:55:03]  INFO [localhost] Detecting Server/Container OS... 
[Mar 16 16:55:03]  INFO [localhost] Detecting OS of servers... 
[Mar 16 16:55:03]  INFO [localhost] (1/1) Detected: docker: amazon 2023
[Mar 16 16:55:03]  INFO [localhost] Detecting OS of containers... 
[Mar 16 16:55:03]  INFO [localhost] Checking Scan Modes... 
[Mar 16 16:55:03]  INFO [localhost] Detecting Platforms... 
[Mar 16 16:55:05]  INFO [localhost] (1/1) docker is running on other
[Mar 16 16:55:05]  INFO [docker] Scanning OS pkg in fast mode


Scan Summary
================
docker	amazon2023	161 installed, 2 updatable

$ vuls report
...
[Mar 16 16:55:35]  INFO [localhost] OVAL amazon 2023 found. defs: 1557
[Mar 16 16:55:35]  INFO [localhost] OVAL amazon 2023 is fresh. lastModified: 2023-03-16T16:52:12+09:00
[Mar 16 16:55:35]  INFO [localhost] docker: 2 CVEs are detected with OVAL
[Mar 16 16:55:35]  INFO [localhost] docker: 0 unfixed CVEs are detected with gost
[Mar 16 16:55:35]  INFO [localhost] docker: 0 CVEs are detected with CPE
[Mar 16 16:55:35]  INFO [localhost] docker: 0 PoC are detected
[Mar 16 16:55:35]  INFO [localhost] docker: 0 exploits are detected
[Mar 16 16:55:35]  INFO [localhost] docker: Known Exploited Vulnerabilities are detected for 0 CVEs
[Mar 16 16:55:35]  INFO [localhost] docker: Cyber Threat Intelligences are detected for 0 CVEs
[Mar 16 16:55:35]  INFO [localhost] docker: total 0 CVEs detected
[Mar 16 16:55:35]  INFO [localhost] docker: 0 CVEs filtered by --confidence-over=80

docker (amazon2023)
===================
Total: 2 (Critical:0 High:0 Medium:2 Low:0 ?:0)
2/2 Fixed, 0 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
161 installed

+---------------+------+--------+-----+-----------+---------+----------------------+
|    CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |       PACKAGES       |
+---------------+------+--------+-----+-----------+---------+----------------------+
| CVE-2022-4292 |  6.9 |        |     |           |   fixed | vim-common, vim-data |
+---------------+------+--------+-----+-----------+---------+----------------------+
| CVE-2023-0049 |  6.9 |        |     |           |   fixed | vim-common, vim-data |
+---------------+------+--------+-----+-----------+---------+----------------------+
```

- Dockerfile
```Dockerfile
FROM public.ecr.aws/amazonlinux/amazonlinux:2023

RUN dnf -y upgrade && dnf -y install openssh-server glibc-langpack-en
RUN mkdir /var/run/sshd

RUN sed -i 's/#\?PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
RUN sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd

ENV NOTVISIBLE "in users profile"
RUN echo "export VISIBLE=now" >> /etc/profile

COPY .ssh/id_rsa.pub /root/authorized_keys
RUN mkdir -p ~/.ssh && \
    mv ~/authorized_keys ~/.ssh/authorized_keys && \
    chmod 0600 ~/.ssh/authorized_keys

RUN ssh-keygen -A
RUN rm -rf /run/nologin

EXPOSE 22

# Vuls Setting
RUN dnf -y install dnf-utils which lsof iproute

CMD ["/usr/sbin/sshd", "-D"]
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://github.com/vulsdoc/vuls/pull/229