### PR TITLE
fix(scanner/windows): support installationType Domain Controller

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -170,6 +170,7 @@ func ViaHTTP(header http.Header, body string, toLocalFile bool) (models.ScanResu
 
 		release := header.Get("X-Vuls-OS-Release")
 		if release == "" {
+			logging.Log.Debugf("osInfo(systeminfo.exe): %+v", osInfo)
 			release, err = detectOSName(osInfo)
 			if err != nil {
 				return models.ScanResult{}, xerrors.Errorf("Failed to detect os name. err: %w", err)

--- a/scanner/windows_test.go
+++ b/scanner/windows_test.go
@@ -18,7 +18,7 @@ func Test_parseSystemInfo(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "happy",
+			name: "Workstation",
 			args: `
 Host Name:                 DESKTOP
 OS Name:                   Microsoft Windows 10 Pro
@@ -82,6 +82,120 @@ Hyper-V Requirements:      VM Monitor Mode Extensions: Yes
 				installationType: "Client",
 			},
 			kbs: []string{"5012117", "4562830", "5003791", "5007401", "5012599", "5011651", "5005699"},
+		},
+		{
+			name: "Server",
+			args: `
+Host Name:                 WIN-RIBN7SM07BK
+OS Name:                   Microsoft Windows Server 2022 Standard
+OS Version:                10.0.20348 N/A Build 20348
+OS Manufacturer:           Microsoft Corporation
+OS Configuration:          Standalone Server
+OS Build Type:             Multiprocessor Free
+Registered Owner:          Windows User
+Registered Organization:   
+Product ID:                00454-10000-00001-AA483
+Original Install Date:     10/1/2021, 4:15:34 PM
+System Boot Time:          10/22/2021, 8:36:55 AM
+System Manufacturer:       Microsoft Corporation
+System Model:              Virtual Machine
+System Type:               x64-based PC
+Processor(s):              1 Processor(s) Installed.
+						   [01]: Intel64 Family 6 Model 158 Stepping 9 GenuineIntel ~2808 Mhz
+BIOS Version:              Microsoft Corporation Hyper-V UEFI Release v4.0, 12/17/2019
+Windows Directory:         C:\Windows
+System Directory:          C:\Windows\system32
+Boot Device:               \Device\HarddiskVolume1
+System Locale:             en-us;English (United States)
+Input Locale:              en-us;English (United States)
+Time Zone:                 (UTC-08:00) Pacific Time (US & Canada)
+Total Physical Memory:     2,047 MB
+Available Physical Memory: 900 MB
+Virtual Memory: Max Size:  3,199 MB
+Virtual Memory: Available: 2,143 MB
+Virtual Memory: In Use:    1,056 MB
+Page File Location(s):     C:\pagefile.sys
+Domain:                    WORKGROUP
+Logon Server:              \\WIN-RIBN7SM07BK
+Hotfix(s):                 3 Hotfix(s) Installed.
+						   [01]: KB5004330
+						   [02]: KB5005039
+						   [03]: KB5005552
+Network Card(s):           1 NIC(s) Installed.
+						   [01]: Microsoft Hyper-V Network Adapter
+								 Connection Name: Ethernet
+								 DHCP Enabled:    Yes
+								 DHCP Server:     192.168.254.254
+								 IP address(es)
+								 [01]: 192.168.254.172
+								 [02]: fe80::b4a1:11cc:2c4:4f57
+Hyper-V Requirements:      A hypervisor has been detected. Features required for Hyper-V will not be displayed.
+`,
+			osInfo: osInfo{
+				productName:      "Microsoft Windows Server 2022 Standard",
+				version:          "10.0",
+				build:            "20348",
+				revision:         "",
+				edition:          "",
+				servicePack:      "",
+				arch:             "x64-based",
+				installationType: "Server",
+			},
+			kbs: []string{"5004330", "5005039", "5005552"},
+		},
+		{
+			name: "Domain Controller",
+			args: `
+Host Name:                 vuls
+OS Name:                   Microsoft Windows Server 2019 Datacenter
+OS Version:                10.0.17763 N/A Build 17763
+OS Manufacturer:           Microsoft Corporation
+OS Configuration:          Primary Domain Controller
+OS Build Type:             Multiprocessor Free
+Registered Owner:          N/A
+Registered Organization:   N/A
+Product ID:                00430-00000-00000-AA602
+Original Install Date:     1/16/2023, 10:04:07 AM
+System Boot Time:          3/28/2023, 8:37:14 AM
+System Manufacturer:       Microsoft Corporation
+System Model:              Virtual Machine
+System Type:               x64-based PC
+Processor(s):              1 Processor(s) Installed.
+						   [01]: Intel64 Family 6 Model 85 Stepping 4 GenuineIntel ~2095 Mhz
+BIOS Version:              Microsoft Corporation Hyper-V UEFI Release v4.1, 5/9/2022
+Windows Directory:         C:\Windows
+System Directory:          C:\Windows\system32
+Boot Device:               \Device\HarddiskVolume3
+System Locale:             en-us;English (United States)
+Input Locale:              en-us;English (United States)
+Time Zone:                 (UTC) Coordinated Universal Time
+Total Physical Memory:     16,383 MB
+Available Physical Memory: 13,170 MB
+Virtual Memory: Max Size:  18,431 MB
+Virtual Memory: Available: 15,208 MB
+Virtual Memory: In Use:    3,223 MB
+Page File Location(s):     C:\pagefile.sys
+Domain:                    vuls
+Logon Server:              \\vuls
+Hotfix(s):                 5 Hotfix(s) Installed.
+						   [01]: KB5022511
+						   [02]: KB5012170
+						   [03]: KB5023702
+						   [04]: KB5020374
+						   [05]: KB5023789
+Hyper-V Requirements:      A hypervisor has been detected. Features required for Hyper-V will not be displayed.
+`,
+			osInfo: osInfo{
+				productName:      "Microsoft Windows Server 2019 Datacenter",
+				version:          "10.0",
+				build:            "17763",
+				revision:         "",
+				edition:          "",
+				servicePack:      "",
+				arch:             "x64-based",
+				installationType: "Domain Controller",
+			},
+			kbs: []string{"5022511", "5012170", "5023702", "5020374", "5023789"},
 		},
 	}
 	for _, tt := range tests {
@@ -290,6 +404,20 @@ func Test_detectOSName(t *testing.T) {
 				installationType: "Server",
 			},
 			want: "Windows Server 2022",
+		},
+		{
+			name: "Windows Server 2019",
+			args: osInfo{
+				productName:      "Microsoft Windows Server 2019 Datacenter",
+				version:          "10.0",
+				build:            "17763",
+				revision:         "",
+				edition:          "",
+				servicePack:      "",
+				arch:             "x64-based",
+				installationType: "Domain Controller",
+			},
+			want: "Windows Server 2019",
 		},
 		{
 			name: "err",


### PR DESCRIPTION
# What did you implement:

support installationType Domain Controller

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- systeminfo.txt
```txt

Host Name:                 vuls
OS Name:                   Microsoft Windows Server 2019 Datacenter
OS Version:                10.0.17763 N/A Build 17763
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Primary Domain Controller
OS Build Type:             Multiprocessor Free
Registered Owner:          N/A
Registered Organization:   N/A
Product ID:                00430-00000-00000-AA602
Original Install Date:     1/16/2023, 10:04:07 AM
System Boot Time:          3/28/2023, 8:37:14 AM
System Manufacturer:       Microsoft Corporation
System Model:              Virtual Machine
System Type:               x64-based PC
Processor(s):              1 Processor(s) Installed.
						   [01]: Intel64 Family 6 Model 85 Stepping 4 GenuineIntel ~2095 Mhz
BIOS Version:              Microsoft Corporation Hyper-V UEFI Release v4.1, 5/9/2022
Windows Directory:         C:\Windows
System Directory:          C:\Windows\system32
Boot Device:               \Device\HarddiskVolume3
System Locale:             en-us;English (United States)
Input Locale:              en-us;English (United States)
Time Zone:                 (UTC) Coordinated Universal Time
Total Physical Memory:     16,383 MB
Available Physical Memory: 13,170 MB
Virtual Memory: Max Size:  18,431 MB
Virtual Memory: Available: 15,208 MB
Virtual Memory: In Use:    3,223 MB
Page File Location(s):     C:\pagefile.sys
Domain:                    vuls
Logon Server:              \\vuls
Hotfix(s):                 5 Hotfix(s) Installed.
						   [01]: KB5022511
						   [02]: KB5012170
						   [03]: KB5023702
						   [04]: KB5020374
						   [05]: KB5023789
Hyper-V Requirements:      A hypervisor has been detected. Features required for Hyper-V will not be displayed.

```

## before
```console
$ vuls server
[Mar 28 20:21:34]  INFO [localhost] vuls-v0.22.2-build-20230328_202031_de1ed8e
...
[Mar 28 20:21:34]  INFO [localhost] Listening on localhost:5515
[Mar 28 20:21:46] ERROR [localhost] Failed to parse systeminfo.exe. err: Failed to detect installation type. line: OS Configuration:          Primary Domain Controller

$ curl -X POST -H "Content-Type: text/plain" -H "X-Vuls-OS-Family: windows" --data-binary @systeminfo.txt http://localhost:5515/vuls
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1883  100   132  100  1751  76610   992k --:--:-- --:--:-- --:--:-- 1838k
parse error: Invalid numeric literal at line 1, column 7
```

## after
```console
$ vuls server
[Mar 28 20:22:45]  INFO [localhost] vuls-v0.22.2-build-20230328_201950_30a3460
...
[Mar 28 20:22:45]  INFO [localhost] Listening on localhost:5515
[Mar 28 20:22:52]  INFO [localhost] : 11 CVEs are detected with gost
[Mar 28 20:22:52]  INFO [localhost] Fill CVE detailed with gost
[Mar 28 20:22:52]  INFO [localhost] Fill CVE detailed with CVE-DB
[Mar 28 20:22:52]  INFO [localhost] : 0 PoC detected
[Mar 28 20:22:52]  INFO [localhost] : 0 exploits are detected
[Mar 28 20:22:52]  INFO [localhost] : Known Exploited Vulnerabilities are detected for 1 CVEs
[Mar 28 20:22:52]  INFO [localhost] : Cyber Threat Intelligences are detected for 2 CVEs

$ curl -X POST -H "Content-Type: text/plain" -H "X-Vuls-OS-Family: windows" --data-binary @systeminfo.txt http://localhost:5515/vuls
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 70832    0 69081  100  1751   264k   6865 --:--:-- --:--:-- --:--:--  272k
[
  {
    "jsonVersion": 0,
    "lang": "",
    "serverUUID": "",
    "serverName": "",
    "family": "windows",
    "release": "Windows Server 2019",
...
```

# Checklist:
- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

