### PR TITLE
refactor(reporter): refactoring TelegramWriter, GoogleChatWriter

### DIFF
--- a/reporter/googlechat.go
+++ b/reporter/googlechat.go
@@ -73,11 +73,10 @@ func (w GoogleChatWriter) Write(rs ...models.ScanResult) (err error) {
 }
 
 func (w GoogleChatWriter) postMessage(message string) error {
-	uri := fmt.Sprintf("%s", w.Cnf.WebHookURL)
 	payload := `{"text": "` + message + `" }`
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uri, bytes.NewBuffer([]byte(payload)))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.Cnf.WebHookURL, bytes.NewBuffer([]byte(payload)))
 	defer cancel()
 	if err != nil {
 		return err
@@ -88,7 +87,7 @@ func (w GoogleChatWriter) postMessage(message string) error {
 		return err
 	}
 	resp, err := client.Do(req)
-	if checkResponse(resp) != nil && err != nil {
+	if w.checkResponse(resp) != nil && err != nil {
 		return err
 	}
 	defer resp.Body.Close()

--- a/reporter/googlechat.go
+++ b/reporter/googlechat.go
@@ -26,7 +26,7 @@ func (w GoogleChatWriter) Write(rs ...models.ScanResult) (err error) {
 	re := regexp.MustCompile(w.Cnf.ServerNameRegexp)
 
 	for _, r := range rs {
-		if re.Match([]byte(r.FormatServerName())) {
+		if re.MatchString(r.FormatServerName()) {
 			continue
 		}
 		msgs := []string{fmt.Sprintf("*%s*\n%s\t%s\t%s",

--- a/reporter/telegram.go
+++ b/reporter/telegram.go
@@ -75,14 +75,14 @@ func (w TelegramWriter) sendMessage(chatID, token, message string) error {
 		return err
 	}
 	resp, err := client.Do(req)
-	if checkResponse(resp) != nil && err != nil {
+	if w.checkResponse(resp) != nil && err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 	return nil
 }
 
-func checkResponse(r *http.Response) error {
+func (w TelegramWriter) checkResponse(r *http.Response) error {
 	if c := r.StatusCode; 200 <= c && c <= 299 {
 		return nil
 	}

--- a/scanner/windows.go
+++ b/scanner/windows.go
@@ -552,7 +552,6 @@ func parseRegistry(stdout, arch string) (osInfo, error) {
 }
 
 func detectOSName(osInfo osInfo) (string, error) {
-
 	osName, err := detectOSNameFromOSInfo(osInfo)
 	if err != nil {
 		return "", xerrors.Errorf("Failed to detect OS Name from OSInfo: %+v, err: %w", osInfo, err)


### PR DESCRIPTION
# What did you implement:

refactoring TelegramWriter, GoogleChatWriter
use regexp.MatchString instead of regexp.Match
remove unnecessary line break

## Type of change

# How Has This Been Tested?

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

