### PR TITLE
feat(scanner): skip ssh config validation if G option is unknown option

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -419,6 +419,10 @@ func validateSSHConfig(c *config.ServerInfo) error {
 	logging.Log.Debugf("Executing... %s", strings.Replace(sshConfigCmd, "\n", "", -1))
 	configResult := localExec(*c, sshConfigCmd, noSudo)
 	if !configResult.isSuccess() {
+		if strings.Contains(configResult.Stderr, "unknown option -- G") {
+			logging.Log.Warn("SSH configuration validation is skipped. To enable validation, G option introduced in OpenSSH 6.8 must be enabled.")
+			return nil
+		}
 		return xerrors.Errorf("Failed to print SSH configuration. err: %w", configResult.Error)
 	}
 	sshConfig := parseSSHConfiguration(configResult.Stdout)


### PR DESCRIPTION
# What did you implement:

The `G` option to the ssh command was introduced in OpenSSH 6.8.
Under OpenSSH 6.8, there was a issue that prevented scanning even though the SSH connection was properly configured.
With this PR, when G is an unknown option (= less than OpenSSH 6.8), SSH configuration validation is skipped.

>  * ssh(1): Add a -G option to ssh that causes it to parse its
   configuration and dump the result to stdout, similar to "sshd -T".

REF: https://www.openssh.com/txt/release-6.8

Fixes #1631 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## OpenSSH 6.6 Environment
```console
root@1e3a45606d6c:/# ssh -V
OpenSSH_6.6.1p1 Ubuntu-2ubuntu2.13, OpenSSL 1.0.1f 6 Jan 2014
root@1e3a45606d6c:/# ssh -G 127.0.0.1
unknown option -- G
usage: ssh [-1246AaCfgKkMNnqsTtVvXxYy] [-b bind_address] [-c cipher_spec]
           [-D [bind_address:]port] [-E log_file] [-e escape_char]
           [-F configfile] [-I pkcs11] [-i identity_file]
           [-L [bind_address:]port:host:hostport] [-l login_name] [-m mac_spec]
           [-O ctl_cmd] [-o option] [-p port]
           [-Q cipher | cipher-auth | mac | kex | key]
           [-R [bind_address:]port:host:hostport] [-S ctl_path] [-W host:port]
           [-w local_tun[:remote_tun]] [user@]hostname [command]
```

## before
```console
root@1e3a45606d6c:/# vuls scan -debug
...
[Apr  3 16:39:02] DEBUG [localhost] Validating SSH Settings for Server:localhost ...
[Apr  3 16:39:02] DEBUG [localhost] Executing... /usr/bin/ssh -G -i /root/.ssh/id_rsa -p 22 -l root 127.0.0.1
[Apr  3 16:39:02] ERROR [localhost] (1/1) Failed: localhost, err: [Failed to print SSH configuration. err:
    github.com/future-architect/vuls/scanner.validateSSHConfig
        /home/runner/work/vuls/vuls/scanner/scanner.go:354
  - exit status 255]
[Apr  3 16:39:02] ERROR [localhost] Failed to scan: Failed to init servers. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/runner/work/vuls/vuls/scanner/scanner.go:89
  - No scannable host OS:
    github.com/future-architect/vuls/scanner.Scanner.initServers
        /home/runner/work/vuls/vuls/scanner/scanner.go:253
```

## after
```console
root@1e3a45606d6c:/# vuls scan -debug
...
[Apr  3 16:39:44] DEBUG [localhost] Validating SSH Settings for Server:localhost ...
[Apr  3 16:39:44] DEBUG [localhost] Executing... /usr/bin/ssh -G -i /root/.ssh/id_rsa -p 22 -l root 127.0.0.1
[Apr  3 16:39:44]  WARN [localhost] SSH configuration validation is skipped. To enable validation, G option introduced in OpenSSH 6.8 must be enabled.
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

