### PR TITLE
fix(configtest): amazon linux 2022, 2023 require dnf-utils

### DIFF
--- a/scanner/amazon.go
+++ b/scanner/amazon.go
@@ -1,10 +1,14 @@
 package scanner
 
 import (
+	"strings"
+	"time"
+
+	"golang.org/x/xerrors"
+
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
-	"golang.org/x/xerrors"
 )
 
 // inherit OsTypeInterface
@@ -50,12 +54,26 @@ func (o *amazon) depsFast() []string {
 		return []string{}
 	}
 	// repoquery
-	return []string{"yum-utils"}
+	switch s := strings.Fields(o.getDistro().Release)[0]; s {
+	case "1", "2":
+		return []string{"yum-utils"}
+	default:
+		if _, err := time.Parse("2006.01", s); err == nil {
+			return []string{"yum-utils"}
+		}
+		return []string{"dnf-utils"}
+	}
 }
 
 func (o *amazon) depsFastRoot() []string {
-	return []string{
-		"yum-utils",
+	switch s := strings.Fields(o.getDistro().Release)[0]; s {
+	case "1", "2":
+		return []string{"yum-utils"}
+	default:
+		if _, err := time.Parse("2006.01", s); err == nil {
+			return []string{"yum-utils"}
+		}
+		return []string{"dnf-utils"}
 	}
 }
 


### PR DESCRIPTION
# What did you implement:

In amazon linux 2022, 2023, repoquery is provided by dnf-utils, not yum-utils.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Amazon Linux 2022
### before
```
$ vuls configtest
[Apr 10 09:00:11]  INFO [localhost] vuls-0.23.0-abdb081af78974b6650cc9f00cfabecea8a67703-2023-04-04T09:50:17Z
[Apr 10 09:00:11]  INFO [localhost] Validating config...
[Apr 10 09:00:11]  INFO [localhost] Detecting Server/Container OS... 
[Apr 10 09:00:11]  INFO [localhost] Detecting OS of servers... 
[Apr 10 09:00:11]  INFO [localhost] (1/1) Detected: docker: amazon 2022
[Apr 10 09:00:11]  INFO [localhost] Detecting OS of containers... 
[Apr 10 09:00:11]  INFO [localhost] Checking Scan Modes...
[Apr 10 09:00:11]  INFO [localhost] Checking dependencies...
[Apr 10 09:00:11] ERROR [docker] yum-utils is not installed
[Apr 10 09:00:11] ERROR [localhost] Error on docker, err: [yum-utils is not installed:
    github.com/future-architect/vuls/scanner.(*redhatBase).execCheckDeps
        /go/src/github.com/future-architect/vuls/scanner/redhatbase.go:374]
[Apr 10 09:00:11]  INFO [localhost] Checking sudo settings...
[Apr 10 09:00:11]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Apr 10 09:00:11] ERROR [localhost] Failed to configtest: No scannable servers:
    github.com/future-architect/vuls/scanner.Scanner.Configtest
        /go/src/github.com/future-architect/vuls/scanner/scanner.go:134
```

### after
```
$ vuls configtest
[Apr 10 09:00:17]  INFO [localhost] vuls-v0.23.0-build-20230410_085410_abdb081
[Apr 10 09:00:17]  INFO [localhost] Validating config...
[Apr 10 09:00:17]  INFO [localhost] Detecting Server/Container OS... 
[Apr 10 09:00:17]  INFO [localhost] Detecting OS of servers... 
[Apr 10 09:00:17]  INFO [localhost] (1/1) Detected: docker: amazon 2022
[Apr 10 09:00:17]  INFO [localhost] Detecting OS of containers... 
[Apr 10 09:00:17]  INFO [localhost] Checking Scan Modes...
[Apr 10 09:00:17]  INFO [localhost] Checking dependencies...
[Apr 10 09:00:17]  INFO [docker] Dependencies ... Pass
[Apr 10 09:00:17]  INFO [localhost] Checking sudo settings...
[Apr 10 09:00:17]  INFO [docker] Sudo... Pass
[Apr 10 09:00:17]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Apr 10 09:00:17]  INFO [localhost] Scannable servers are below...
docker
```

## Amazon Linux 2023
### before
```
$ vuls configtest
[Apr 10 08:58:05]  INFO [localhost] vuls-0.23.0-abdb081af78974b6650cc9f00cfabecea8a67703-2023-04-04T09:50:17Z
[Apr 10 08:58:05]  INFO [localhost] Validating config...
[Apr 10 08:58:05]  INFO [localhost] Detecting Server/Container OS... 
[Apr 10 08:58:05]  INFO [localhost] Detecting OS of servers... 
[Apr 10 08:58:05]  INFO [localhost] (1/1) Detected: docker: amazon 2023
[Apr 10 08:58:05]  INFO [localhost] Detecting OS of containers... 
[Apr 10 08:58:05]  INFO [localhost] Checking Scan Modes...
[Apr 10 08:58:05]  INFO [localhost] Checking dependencies...
[Apr 10 08:58:05] ERROR [docker] yum-utils is not installed
[Apr 10 08:58:05] ERROR [localhost] Error on docker, err: [yum-utils is not installed:
    github.com/future-architect/vuls/scanner.(*redhatBase).execCheckDeps
        /go/src/github.com/future-architect/vuls/scanner/redhatbase.go:374]
[Apr 10 08:58:05]  INFO [localhost] Checking sudo settings...
[Apr 10 08:58:05]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Apr 10 08:58:05] ERROR [localhost] Failed to configtest: No scannable servers:
    github.com/future-architect/vuls/scanner.Scanner.Configtest
        /go/src/github.com/future-architect/vuls/scanner/scanner.go:134
```

### after
```
$ vuls configtest
[Apr 10 08:58:12]  INFO [localhost] vuls-v0.23.0-build-20230410_085410_abdb081
[Apr 10 08:58:12]  INFO [localhost] Validating config...
[Apr 10 08:58:12]  INFO [localhost] Detecting Server/Container OS... 
[Apr 10 08:58:12]  INFO [localhost] Detecting OS of servers... 
[Apr 10 08:58:12]  INFO [localhost] (1/1) Detected: docker: amazon 2023
[Apr 10 08:58:12]  INFO [localhost] Detecting OS of containers... 
[Apr 10 08:58:12]  INFO [localhost] Checking Scan Modes...
[Apr 10 08:58:12]  INFO [localhost] Checking dependencies...
[Apr 10 08:58:12]  INFO [docker] Dependencies ... Pass
[Apr 10 08:58:12]  INFO [localhost] Checking sudo settings...
[Apr 10 08:58:12]  INFO [docker] Sudo... Pass
[Apr 10 08:58:12]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Apr 10 08:58:12]  INFO [localhost] Scannable servers are below...
docker
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

