### PR TITLE
fix(scan): false positives in Debian Pkg for CVE-IDs already detected by Trivy

### DIFF
--- a/gost/debian.go
+++ b/gost/debian.go
@@ -165,7 +165,6 @@ func (deb Debian) detectCVEsWithFixState(r *models.ScanResult, fixStatus string)
 				v = models.VulnInfo{
 					CveID:       cve.CveID,
 					CveContents: models.NewCveContents(cve),
-					Confidences: models.Confidences{models.DebianSecurityTrackerMatch},
 				}
 				nCVEs++
 			}
@@ -193,7 +192,6 @@ func (deb Debian) detectCVEsWithFixState(r *models.ScanResult, fixStatus string)
 					continue
 				}
 			}
-			v.Confidences = models.Confidences{models.DebianSecurityTrackerMatch}
 
 			names := []string{}
 			if p.isSrcPack {
@@ -229,6 +227,7 @@ func (deb Debian) detectCVEsWithFixState(r *models.ScanResult, fixStatus string)
 				}
 			}
 
+			v.Confidences.AppendIfMissing(models.DebianSecurityTrackerMatch)
 			r.ScannedCves[cve.CveID] = v
 		}
 	}

--- a/gost/debian.go
+++ b/gost/debian.go
@@ -74,12 +74,12 @@ func (deb Debian) DetectCVEs(r *models.ScanResult, _ bool) (nCVEs int, err error
 	if stashLinuxPackage.Name != "" {
 		r.Packages["linux"] = stashLinuxPackage
 	}
-	// nUnfixedCVEs, err := deb.detectCVEsWithFixState(r, "open")
-	// if err != nil {
-	// 	return 0, xerrors.Errorf("Failed to detect unfixed CVEs. err: %w", err)
-	// }
+	nUnfixedCVEs, err := deb.detectCVEsWithFixState(r, "open")
+	if err != nil {
+		return 0, xerrors.Errorf("Failed to detect unfixed CVEs. err: %w", err)
+	}
 
-	return (nFixedCVEs + 0), nil
+	return (nFixedCVEs + nUnfixedCVEs), nil
 }
 
 func (deb Debian) detectCVEsWithFixState(r *models.ScanResult, fixStatus string) (nCVEs int, err error) {


### PR DESCRIPTION
# What did you implement:

Fix the bug that causes false positives in the vulnerability detection process of Debian packages.

The issue occurs under the following conditions:

- When scanning Debian
- When scanning libraries
- During the vulnerability detection process of the package, searching the package list from Gost's vulnerability database. If the vulnerability detected in the library is included in Gost's search results
In this case, since the version comparison process for affected packages is skipped, it is considered detected in Gost as well

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

confirmed the diff in the Scan Result containing the following package information:

```
   "runningKernel": {
        "release": "8.19.0-23-cloud-amd64",
        "version": "8.19.269-1",
        "rebootRequired": false
    },
    "packages": {
        "zlib1g": {
            "name": "zlib1g",
            "version": "1:1.2.11.dfsg-1+deb10u2",
            "release": "",
            "newVersion": "",
            "newRelease": "",
            "arch": "",
            "repository": ""
        }
    },
    "SrcPackages": {
        "zlib": {
            "name": "zlib",
            "version": "1:1.2.11.dfsg-1+deb10u2",
            "arch": "",
            "binaryNames": [
                "zlib1g"
            ]
        }
    },
    "libraries": [
        {
            "Type": "bundler",
            "Libs": [
                {
                    "Name": "nokogiri",
                    "Version": "1.10.10",
                    "FilePath": ""
                }
            ],
            "path": "/home/admin/Gemfile.lock"
        }
    ],
```


By checking the diff, I verified that the false positives, which had been detected by Gost and erroneously included Debian package information in the affectedPackages, have been fixed.

```
diff localhost.json localhost.json.new                                                                                        INT ✘ 
33c33
<     "reportedAt": "2023-04-15T14:22:51.210993022+09:00",
---
>     "reportedAt": "2023-04-15T14:21:14.256507738+09:00",
35c35
<     "reportedRevision": "build-20230413_082522_ac82901",
---
>     "reportedRevision": "build-20230415_140328_f4519b7",
3467,3473c3467
<                     "detectionMethod": "DebianSecurityTrackerMatch"
<                 }
<             ],
<             "affectedPackages": [
<                 {
<                     "name": "zlib1g",
<                     "fixedIn": "1:1.2.11.dfsg-1+deb10u1"
---
>                     "detectionMethod": "TrivyMatch"
```

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
