### PR TITLE
fix(detector/github): Dependency graph API calling uses smaller query at once to avoid timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/d4l3k/messagediff v1.2.2-0.20190829033028-7e0a312ae40b
 	github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21
 	github.com/emersion/go-smtp v0.14.0
+	github.com/google/go-cmp v0.5.9
 	github.com/google/subcommands v1.2.0
 	github.com/google/uuid v1.3.0
 	github.com/gosnmp/gosnmp v1.35.0
@@ -98,7 +99,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-containerregistry v0.12.0 // indirect
 	github.com/google/licenseclassifier/v2 v2.0.0-pre6 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.1 // indirect


### PR DESCRIPTION
# What did you implement:

Dependency Graph API calling has possibility of timeout when query touches a lot of data.
This PR decreases maximum response data of it by 1/5.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
$ vuls report -to-localfile -format-cyclonedx-json
or 
$ vuls report -to-localfile -format-cyclonedx-xml
```

## before (max 100 manifests and 250 dependencies per response)

<img width="913" alt="スクリーンショット 2023-04-14 14 10 09" src="https://user-images.githubusercontent.com/26991377/231948004-a35ba033-9214-4ebd-9cc1-d1d49d2ece33.png">

## after (max 50 manifests and 100 dependencies per response)

<img width="993" alt="スクリーンショット 2023-04-14 14 15 54" src="https://user-images.githubusercontent.com/26991377/231948061-9f3f554d-dc2a-4031-bc07-a5a4f8c42aa3.png">

`...`

<img width="907" alt="スクリーンショット 2023-04-14 14 21 46" src="https://user-images.githubusercontent.com/26991377/231949007-c6f42245-cef9-43ab-b794-78b095a74829.png">


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
