### PR TITLE
fix(detector/github): Github dependency graph API request will be retried on error

### DIFF
--- a/detector/github.go
+++ b/detector/github.go
@@ -243,7 +243,7 @@ func fetchDependencyGraph(r *models.ScanResult, httpClient *http.Client, owner, 
 	req.Header.Set("Content-Type", "application/json")
 
 	graph := DependencyGraph{}
-	count, retryMax := 0, 3
+	count, retryMax := 0, 10
 	countCheck := func(err error) error {
 		if count == retryMax {
 			return backoff.Permanent(err)

--- a/detector/github.go
+++ b/detector/github.go
@@ -12,7 +12,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/future-architect/vuls/errof"
+	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
 	"golang.org/x/oauth2"
 )
@@ -240,25 +242,44 @@ func fetchDependencyGraph(r *models.ScanResult, httpClient *http.Client, owner, 
 	req.Header.Set("Accept", "application/vnd.github.hawkgirl-preview+json")
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
 	graph := DependencyGraph{}
-	if err := json.Unmarshal(body, &graph); err != nil {
+	count, retryMax := 0, 3
+	countCheck := func(err error) error {
+		if count == retryMax {
+			return backoff.Permanent(err)
+		}
 		return err
 	}
+	operation := func() error {
+		count++
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return countCheck(err)
+		}
+		defer resp.Body.Close()
 
-	if graph.Data.Repository.URL == "" {
-		return errof.New(errof.ErrFailedToAccessGithubAPI,
-			fmt.Sprintf("Failed to access to GitHub API. Response: %s", string(body)))
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return countCheck(err)
+		}
+
+		if err := json.Unmarshal(body, &graph); err != nil {
+			return countCheck(err)
+		}
+
+		if graph.Data.Repository.URL == "" {
+			return countCheck(errof.New(errof.ErrFailedToAccessGithubAPI,
+				fmt.Sprintf("Failed to access to GitHub API. Response: %s", string(body))))
+		}
+
+		return nil
+	}
+	notify := func(err error, t time.Duration) {
+		logging.Log.Warnf("Failed trial (count: %d). retrying in %s. err: %+v", count, t, err)
+	}
+
+	if err = backoff.RetryNotify(operation, backoff.NewExponentialBackOff(), notify); err != nil {
+		return err
 	}
 
 	dependenciesAfter = ""
@@ -340,4 +361,7 @@ type DependencyGraph struct {
 			} `json:"dependencyGraphManifests"`
 		} `json:"repository"`
 	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors,omitempty"`
 }

--- a/detector/github.go
+++ b/detector/github.go
@@ -267,7 +267,7 @@ func fetchDependencyGraph(r *models.ScanResult, httpClient *http.Client, owner, 
 			return countCheck(err)
 		}
 
-		if graph.Data.Repository.URL == "" {
+		if len(graph.Errors) > 0 || graph.Data.Repository.URL == "" {
 			return countCheck(errof.New(errof.ErrFailedToAccessGithubAPI,
 				fmt.Sprintf("Failed to access to GitHub API. Response: %s", string(body))))
 		}
@@ -362,6 +362,12 @@ type DependencyGraph struct {
 		} `json:"repository"`
 	} `json:"data"`
 	Errors []struct {
+		Type      string        `json:"type,omitempty"`
+		Path      []interface{} `json:"path,omitempty"`
+		Locations []struct {
+			Line   int `json:"line"`
+			Column int `json:"column"`
+		} `json:"locations,omitempty"`
 		Message string `json:"message"`
 	} `json:"errors,omitempty"`
 }


### PR DESCRIPTION
# What did you implement:

Dependency graph API request can be failed for some reason like timeout at busy server time.
so this PR gives chances to retry request up to 3 times, and enhanced error handling a little bit.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
$ vuls report -to-localfile -format-cyclonedx-json
or 
$ vuls report -to-localfile -format-cyclonedx-xml
```

## Retrying on timeout (raised on purpose)
<img width="1114" alt="スクリーンショット 2023-04-21 12 17 49" src="https://user-images.githubusercontent.com/26991377/233532765-90a46a01-8073-4a50-9fc7-6ad2abd69ae0.png">

## Retrying on bad request (raised on purpose)
<img width="1440" alt="スクリーンショット 2023-04-21 12 23 13" src="https://user-images.githubusercontent.com/26991377/233533518-90ef7ccd-eafe-4c5f-8362-9a23f279ea31.png">

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

#1642 

