### PR TITLE
fix order in identifying amazon linux version

### DIFF
--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -304,10 +304,6 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 				// Amazon Linux AMI release 2017.09
 				// Amazon Linux AMI release 2018.03
 				release = "1"
-			case strings.HasPrefix(r.Stdout, "Amazon Linux 2"), strings.HasPrefix(r.Stdout, "Amazon Linux release 2"):
-				// Amazon Linux 2 (Karoo)
-				// Amazon Linux release 2 (Karoo)
-				release = "2"
 			case strings.HasPrefix(r.Stdout, "Amazon Linux 2022"), strings.HasPrefix(r.Stdout, "Amazon Linux release 2022"):
 				// Amazon Linux 2022 (Amazon Linux)
 				// Amazon Linux release 2022 (Amazon Linux)
@@ -316,6 +312,10 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 				// Amazon Linux 2023 (Amazon Linux)
 				// Amazon Linux release 2023 (Amazon Linux)
 				release = "2023"
+			case strings.HasPrefix(r.Stdout, "Amazon Linux 2"), strings.HasPrefix(r.Stdout, "Amazon Linux release 2"):
+				// Amazon Linux 2 (Karoo)
+				// Amazon Linux release 2 (Karoo)
+				release = "2"
 			default:
 				fields := strings.Fields(r.Stdout)
 				if len(fields) == 5 {


### PR DESCRIPTION
# What did you implement:
fixing the order of determining what is the amazon linux version

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes # (issue)
https://github.com/future-architect/vuls/issues/1651

## Type of change
Bug fix

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES