### PR TITLE
fix(detector/github): Dependency graph API touches fewer data per page than before

### DIFF
--- a/detector/github.go
+++ b/detector/github.go
@@ -242,7 +242,7 @@ func fetchDependencyGraph(r *models.ScanResult, httpClient *http.Client, owner, 
 	req.Header.Set("Accept", "application/vnd.github.hawkgirl-preview+json")
 	req.Header.Set("Content-Type", "application/json")
 
-	graph := DependencyGraph{}
+	var graph DependencyGraph
 	count, retryMax := 0, 10
 	countCheck := func(err error) error {
 		if count == retryMax {
@@ -263,6 +263,7 @@ func fetchDependencyGraph(r *models.ScanResult, httpClient *http.Client, owner, 
 			return countCheck(err)
 		}
 
+		graph = DependencyGraph{}
 		if err := json.Unmarshal(body, &graph); err != nil {
 			return countCheck(err)
 		}

--- a/detector/github.go
+++ b/detector/github.go
@@ -269,7 +269,7 @@ func fetchDependencyGraph(r *models.ScanResult, httpClient *http.Client, owner, 
 
 		if len(graph.Errors) > 0 || graph.Data.Repository.URL == "" {
 			return countCheck(errof.New(errof.ErrFailedToAccessGithubAPI,
-				fmt.Sprintf("Failed to access to GitHub API. Response: %s", string(body))))
+				fmt.Sprintf("Failed to access to GitHub API. Repository: %s/%s; Response: %s", owner, repo, string(body))))
 		}
 
 		return nil

--- a/detector/github.go
+++ b/detector/github.go
@@ -226,7 +226,7 @@ func fetchDependencyGraph(r *models.ScanResult, httpClient *http.Client, owner, 
 	const queryFmt = `{"query":
 	"query { repository(owner:\"%s\", name:\"%s\") { url dependencyGraphManifests(first: %d, withDependencies: true%s) { pageInfo { endCursor hasNextPage } edges { node { blobPath filename repository { url } parseable exceedsMaxSize dependenciesCount dependencies(first: %d%s) { pageInfo { endCursor hasNextPage } edges { node { packageName packageManager repository { url } requirements hasDependencies } } } } } } } }"}`
 
-	queryStr := fmt.Sprintf(queryFmt, owner, repo, 50, after, 100, dependenciesAfter)
+	queryStr := fmt.Sprintf(queryFmt, owner, repo, 10, after, 100, dependenciesAfter)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		"https://api.github.com/graphql",


### PR DESCRIPTION
# What did you implement:

Despite PR #1642, the Dependency graph API call times out. This issue occurs specifically on a big repository that contains numerous manifest files and dependencies.
It suggests the need to further reduce the amount of data per page.

And I have resolved the issue by properly initializing the `graph` variable upon retrying in #1650.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
$ vuls report -to-localfile -format-cyclonedx-json
or 
$ vuls report -to-localfile -format-cyclonedx-xml
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

- #1642 
- #1650 