### PR TITLE
feat(os): support debian 12

### DIFF
--- a/config/os.go
+++ b/config/os.go
@@ -127,7 +127,7 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 			"9":  {StandardSupportUntil: time.Date(2022, 6, 30, 23, 59, 59, 0, time.UTC)},
 			"10": {StandardSupportUntil: time.Date(2024, 6, 30, 23, 59, 59, 0, time.UTC)},
 			"11": {StandardSupportUntil: time.Date(2026, 6, 30, 23, 59, 59, 0, time.UTC)},
-			// "12": {StandardSupportUntil: time.Date(2028, 6, 30, 23, 59, 59, 0, time.UTC)},
+			"12": {StandardSupportUntil: time.Date(2028, 6, 30, 23, 59, 59, 0, time.UTC)},
 			// "13": {StandardSupportUntil: time.Date(2030, 6, 30, 23, 59, 59, 0, time.UTC)},
 			// "14": {StandardSupportUntil: time.Date(2032, 6, 30, 23, 59, 59, 0, time.UTC)},
 		}[major(release)]

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -365,6 +365,14 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 		},
 		//Debian
 		{
+			name:     "Debian 8 supported",
+			fields:   fields{family: Debian, release: "8"},
+			now:      time.Date(2021, 1, 6, 23, 59, 59, 0, time.UTC),
+			stdEnded: true,
+			extEnded: true,
+			found:    true,
+		},
+		{
 			name:     "Debian 9 supported",
 			fields:   fields{family: Debian, release: "9"},
 			now:      time.Date(2021, 1, 6, 23, 59, 59, 0, time.UTC),
@@ -381,14 +389,6 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			found:    true,
 		},
 		{
-			name:     "Debian 8 supported",
-			fields:   fields{family: Debian, release: "8"},
-			now:      time.Date(2021, 1, 6, 23, 59, 59, 0, time.UTC),
-			stdEnded: true,
-			extEnded: true,
-			found:    true,
-		},
-		{
 			name:     "Debian 11 supported",
 			fields:   fields{family: Debian, release: "11"},
 			now:      time.Date(2021, 1, 6, 23, 59, 59, 0, time.UTC),
@@ -397,8 +397,16 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			found:    true,
 		},
 		{
-			name:     "Debian 12 is not supported yet",
+			name:     "Debian 12 supported",
 			fields:   fields{family: Debian, release: "12"},
+			now:      time.Date(2023, 6, 10, 0, 0, 0, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    true,
+		},
+		{
+			name:     "Debian 13 is not supported yet",
+			fields:   fields{family: Debian, release: "13"},
 			now:      time.Date(2021, 1, 6, 23, 59, 59, 0, time.UTC),
 			stdEnded: false,
 			extEnded: false,

--- a/gost/debian.go
+++ b/gost/debian.go
@@ -31,7 +31,7 @@ func (deb Debian) supported(major string) bool {
 		"9":  "stretch",
 		"10": "buster",
 		"11": "bullseye",
-		// "12": "bookworm",
+		"12": "bookworm",
 		// "13": "trixie",
 		// "14": "forky",
 	}[major]

--- a/gost/debian_test.go
+++ b/gost/debian_test.go
@@ -45,9 +45,9 @@ func TestDebian_Supported(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "12 is not supported yet",
+			name: "12 is supported",
 			args: "12",
-			want: false,
+			want: true,
 		},
 		{
 			name: "13 is not supported yet",

--- a/scanner/base.go
+++ b/scanner/base.go
@@ -139,7 +139,6 @@ func (l *base) runningKernel() (release, version string, err error) {
 			version = ss[6]
 		}
 		if _, err := debver.NewVersion(version); err != nil {
-			l.log.Warnf("kernel running version is invalid. skip kernel vulnerability detection. actual kernel version: %s, err: %s", version, err)
 			version = ""
 		}
 	}


### PR DESCRIPTION
because we now rely only in gost and not oval... and debian security tracker has data about debian 12 we can support it

# What did you implement:
support debian 12 in gost

## Type of change
- [X] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
```console
$ vuls scan
[May 13 00:11:58]  INFO [localhost] vuls-v0.23.2-build-20230513_005405_cf5e1bb
[May 13 00:11:58]  INFO [localhost] Start scanning
[May 13 00:11:58]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[May 13 00:11:58]  INFO [localhost] Validating config...
[May 13 00:11:58]  INFO [localhost] Detecting Server/Container OS... 
[May 13 00:11:58]  INFO [localhost] Detecting OS of servers... 
[May 13 00:11:58]  INFO [localhost] (1/1) Detected: vagrant: debian 12
[May 13 00:11:58]  INFO [localhost] Detecting OS of containers... 
[May 13 00:11:58]  INFO [localhost] Checking Scan Modes... 
[May 13 00:11:58]  INFO [localhost] Detecting Platforms... 
[May 13 00:12:00]  INFO [localhost] (1/1) vagrant is running on other
[May 13 00:12:00]  INFO [vagrant] Scanning OS pkg in fast mode

Scan Summary
================
vagrant	debian12	472 installed





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ vuls report
[May 13 00:12:07]  INFO [localhost] vuls-v0.23.2-build-20230513_005405_cf5e1bb
...
[May 13 00:12:07]  INFO [localhost] Skip OVAL and Scan with gost alone.
[May 13 00:12:07]  INFO [localhost] vagrant: 0 CVEs are detected with OVAL
[May 13 00:12:08]  INFO [localhost] vagrant: 194 CVEs are detected with gost
[May 13 00:12:08]  INFO [localhost] vagrant: 0 CVEs are detected with CPE
[May 13 00:12:09]  INFO [localhost] vagrant: 4 PoC are detected
[May 13 00:12:09]  INFO [localhost] vagrant: 0 exploits are detected
[May 13 00:12:09]  INFO [localhost] vagrant: Known Exploited Vulnerabilities are detected for 0 CVEs
[May 13 00:12:13]  INFO [localhost] vagrant: Cyber Threat Intelligences are detected for 59 CVEs
[May 13 00:12:13]  INFO [localhost] vagrant: total 194 CVEs detected
[May 13 00:12:13]  INFO [localhost] vagrant: 0 CVEs filtered by --confidence-over=80
vagrant (debian12)
==================
Total: 194 (Critical:8 High:39 Medium:67 Low:8 ?:72)
0/194 Fixed, 51 poc, 0 exploits, cisa: 0, uscert: 4, jpcert: 3 alerts
472 installed

+---------------------+------+--------+-----+-----------+---------+--------------------------------+
|       CVE-ID        | CVSS | ATTACK | POC |   ALERT   |  FIXED  |            PACKAGES            |
+---------------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2005-2541       | 10.0 |  AV:N  |     |           | unfixed | tar                            |
+---------------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2016-1585       |  9.8 |  AV:N  |     |           | unfixed | apparmor, libapparmor1         |
+---------------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2016-9085       |  9.8 |  AV:L  |     |           | unfixed | libwebp7                       |
+---------------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2017-9117       |  9.8 |  AV:N  | POC |           | unfixed | libtiff6                       |
+---------------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2018-13410      |  9.8 |  AV:N  |     |           | unfixed | zip                            |
+---------------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2019-1010022    |  9.8 |  AV:N  | POC |           | unfixed | libc-bin, libc-dev-bin,        |
|                     |      |        |     |           |         | libc-devtools, libc-l10n,      |
|                     |      |        |     |           |         | libc6, libc6-dev, locales      |
+---------------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2019-16089      |  9.8 |  AV:L  |     |           | unfixed | linux-image-6.1.0-7-amd64      |
+---------------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2022-28391      |  9.8 |  AV:N  | POC |           | unfixed | busybox                        |
+---------------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2017-17973      |  8.8 |  AV:N  | POC |           | unfixed | libtiff6                       |
+---------------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2017-5563       |  8.8 |  AV:N  |     |           | unfixed | libtiff6                       |
+---------------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2019-1010023    |  8.8 |  AV:N  | POC |           | unfixed | libc-bin, libc-dev-bin,        |
|                     |      |        |     |           |         | libc-devtools, libc-l10n,      |
|                     |      |        |     |           |         | libc6, libc6-dev, locales      |
...
```

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://github.com/vulsdoc/vuls/pull/232