### PR TITLE
fix(scanner): fix socket file name length of SSH ControlPath

### DIFF
--- a/scanner/executil.go
+++ b/scanner/executil.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"bytes"
 	"fmt"
+	"hash/fnv"
 	"io"
 	ex "os/exec"
 	"path/filepath"
@@ -213,7 +214,12 @@ func sshExecExternal(c config.ServerInfo, cmdstr string, sudo bool) (result exec
 				return
 			}
 
-			controlPath := filepath.Join(home, ".vuls", `controlmaster-%r-`+c.ServerName+`.%p`)
+			controlPath := filepath.Join(home, ".vuls", "cm-%C")
+			h := fnv.New32()
+			if _, err := h.Write([]byte(c.ServerName)); err == nil {
+				controlPath = filepath.Join(home, ".vuls", fmt.Sprintf("cm-%x-%%C", h.Sum32()))
+			}
+
 			args = append(args,
 				"-o", "ControlMaster=auto",
 				"-o", fmt.Sprintf("ControlPath=%s", controlPath),


### PR DESCRIPTION
# What did you implement:

Fixes #1713 

In this implementation, the length of strings such as servername, user name, port number, etc. is not constant and the scan fails when the controlpath becomes long.

https://github.com/future-architect/vuls/blob/a23abf48fd52e0cffa0fd0053908152755b63c22/scanner/executil.go#L216

> [TOKENS](https://man.openbsd.org/ssh_config.5#TOKENS)
...
%C
    Hash of %l%h%p%r.
...
%p
    The remote port.
%r
    The remote username.
...
CertificateFile, ControlPath, IdentityAgent, IdentityFile, KnownHostsCommand, LocalForward, Match exec, RemoteCommand, RemoteForward, RevokedHostKeys, and UserKnownHostsFile accept the tokens %%, %C, %d, %h, %i, %k, %L, %l, %n, %p, %r, and %u.

Therefore, by using hash of `%C` and hash of servername, the length of the socket filename is fixed to make this problem less likely to occur.

`%C` is a new token from OpenSSH 6.7.

> Add a %C escape sequence for LocalCommand and ControlPath
   that expands to a unique identifer based on a hash of the tuple of
   (local host, remote user, hostname, port). Helps avoid exceeding
   miserly pathname limits for Unix domain sockets in multiplexing
   control paths; bz#2220

https://www.openssh.com/txt/release-6.7

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- config.toml
```toml
[servers.too-long-854c8eb54e5ac69305997509582ae74a4ff526308c15862e42a0a960f66e5ee4db548205298f77878cb03cd9e54bf7fa592]
host = "127.0.0.1"
port = "2222"
user = "root"
keyPath = "/home/xxxxxxxxx/.ssh/id_rsa"
scanMode           = ["fast"]
scanModules        = ["ospkg"]

[servers.too-long-854c8eb54e5ac69305997509582ae74a4ff526308c152]
host = "127.0.0.1"
port = "2222"
user = "root"
keyPath = "/home/xxxxxxxxx/.ssh/id_rsa"
scanMode           = ["fast"]
scanModules        = ["ospkg"]
```

## before
```console
$ vuls scan -vvv
[Jul 31 16:40:27]  INFO [localhost] vuls-v0.23.3-build-20230731_163841_a23abf4
[Jul 31 16:40:27]  INFO [localhost] Start scanning
[Jul 31 16:40:27]  INFO [localhost] config: /home/xxxxxxxxx/github/github.com/xxxxxxxxx/vuls/config.toml
[Jul 31 16:40:27]  INFO [localhost] Validating config...
[Jul 31 16:40:27]  INFO [localhost] Detecting Server/Container OS... 
[Jul 31 16:40:27]  INFO [localhost] Detecting OS of servers... 
[Jul 31 16:40:27] ERROR [localhost] (1/2) Failed: too-long-854c8eb54e5ac69305997509582ae74a4ff526308c15862e42a0a960f66e5ee4db548205298f77878cb03cd9e54bf7fa592, err: [Failed to test first SSH Connection. err:
    github.com/future-architect/vuls/scanner.Scanner.detectOS
        /home/xxxxxxxxx/github/github.com/xxxxxxxxx/vuls/scanner/scanner.go:742
  - Unable to connect via SSH. Scan with -vvv option to print SSH debugging messages and check SSH settings.
    execResult: servername: too-long-854c8eb54e5ac69305997509582ae74a4ff526308c15862e42a0a960f66e5ee4db548205298f77878cb03cd9e54bf7fa592
      cmd: /usr/bin/ssh -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/xxxxxxxxx/.vuls/controlmaster-%r-too-long-854c8eb54e5ac69305997509582ae74a4ff526308c15862e42a0a960f66e5ee4db548205298f77878cb03cd9e54bf7fa592.%p -o Controlpersist=10m -vvv -l root -p 2222 -i /home/xxxxxxxxx/.ssh/id_rsa -o PasswordAuthentication=no 127.0.0.1
      exitstatus: 255
      stdout: 
      stderr: OpenSSH_8.9p1 Ubuntu-3ubuntu0.3, OpenSSL 3.0.2 15 Mar 2022
    debug1: Reading configuration data /home/xxxxxxxxx/.ssh/config
    debug3: kex names ok: [diffie-hellman-group1-sha1]
    debug1: Reading configuration data /etc/ssh/ssh_config
    debug1: /etc/ssh/ssh_config line 19: include /etc/ssh/ssh_config.d/*.conf matched no files
    debug1: /etc/ssh/ssh_config line 21: Applying options for *
    debug2: resolve_canonicalize: hostname 127.0.0.1 is address
    debug3: expanded UserKnownHostsFile '~/.ssh/known_hosts' -> '/home/xxxxxxxxx/.ssh/known_hosts'
    debug3: expanded UserKnownHostsFile '~/.ssh/known_hosts2' -> '/home/xxxxxxxxx/.ssh/known_hosts2'
    debug1: auto-mux: Trying existing master
    ControlPath too long ('/home/xxxxxxxxx/.vuls/controlmaster-root-too-long-854c8eb54e5ac69305997509582ae74a4ff526308c15862e42a0a960f66e5ee4db548205298f77878cb03cd9e54bf7fa592.2222' >= 108 bytes)
    
      err: %!s(<nil>):
    github.com/future-architect/vuls/scanner.testFirstSSHConnection
        /home/xxxxxxxxx/github/github.com/xxxxxxxxx/vuls/scanner/scanner.go:791]
[Jul 31 16:40:27] ERROR [localhost] (2/2) Failed: too-long-854c8eb54e5ac69305997509582ae74a4ff526308c152, err: [Failed to test first SSH Connection. err:
    github.com/future-architect/vuls/scanner.Scanner.detectOS
        /home/xxxxxxxxx/github/github.com/xxxxxxxxx/vuls/scanner/scanner.go:742
  - Unable to connect via SSH. Scan with -vvv option to print SSH debugging messages and check SSH settings.
    execResult: servername: too-long-854c8eb54e5ac69305997509582ae74a4ff526308c152
      cmd: /usr/bin/ssh -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/xxxxxxxxx/.vuls/controlmaster-%r-too-long-854c8eb54e5ac69305997509582ae74a4ff526308c152.%p -o Controlpersist=10m -vvv -l root -p 2222 -i /home/xxxxxxxxx/.ssh/id_rsa -o PasswordAuthentication=no 127.0.0.1
      exitstatus: 255
      stdout: 
      stderr: OpenSSH_8.9p1 Ubuntu-3ubuntu0.3, OpenSSL 3.0.2 15 Mar 2022
    debug1: Reading configuration data /home/xxxxxxxxx/.ssh/config
    debug3: kex names ok: [diffie-hellman-group1-sha1]
    debug1: Reading configuration data /etc/ssh/ssh_config
    debug1: /etc/ssh/ssh_config line 19: include /etc/ssh/ssh_config.d/*.conf matched no files
    debug1: /etc/ssh/ssh_config line 21: Applying options for *
    debug2: resolve_canonicalize: hostname 127.0.0.1 is address
    debug3: expanded UserKnownHostsFile '~/.ssh/known_hosts' -> '/home/xxxxxxxxx/.ssh/known_hosts'
    debug3: expanded UserKnownHostsFile '~/.ssh/known_hosts2' -> '/home/xxxxxxxxx/.ssh/known_hosts2'
    debug1: auto-mux: Trying existing master
    debug1: Control socket "/home/xxxxxxxxx/.vuls/controlmaster-root-too-long-854c8eb54e5ac69305997509582ae74a4ff526308c152.2222" does not exist
    debug3: ssh_connect_direct: entering
    debug1: Connecting to 127.0.0.1 [127.0.0.1] port 2222.
    debug3: set_sock_tos: set socket 3 IP_TOS 0x10
    debug2: fd 3 setting O_NONBLOCK
    debug1: fd 3 clearing O_NONBLOCK
    debug1: Connection established.
    debug3: timeout: 10000 ms remain after connect
    debug1: identity file /home/xxxxxxxxx/.ssh/id_rsa type 0
    debug1: identity file /home/xxxxxxxxx/.ssh/id_rsa-cert type -1
    debug1: Local version string SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.3
    debug1: Remote protocol version 2.0, remote software version OpenSSH_8.2p1 Ubuntu-4ubuntu0.7
    debug1: compat_banner: match: OpenSSH_8.2p1 Ubuntu-4ubuntu0.7 pat OpenSSH* compat 0x04000000
    debug2: fd 3 setting O_NONBLOCK
    debug1: Authenticating to 127.0.0.1:2222 as 'root'
    debug3: put_host_port: [127.0.0.1]:2222
    debug3: record_hostkey: found key type ED25519 in file /home/xxxxxxxxx/.ssh/known_hosts:8
    debug3: record_hostkey: found key type ECDSA in file /home/xxxxxxxxx/.ssh/known_hosts:9
    debug3: load_hostkeys_file: loaded 2 keys from [127.0.0.1]:2222
    debug1: load_hostkeys: fopen /home/xxxxxxxxx/.ssh/known_hosts2: No such file or directory
    debug1: load_hostkeys: fopen /etc/ssh/ssh_known_hosts: No such file or directory
    debug1: load_hostkeys: fopen /etc/ssh/ssh_known_hosts2: No such file or directory
    debug3: order_hostkeyalgs: have matching best-preference key type ssh-ed25519-cert-v01@openssh.com, using HostkeyAlgorithms verbatim
    debug3: send packet: type 20
    debug1: SSH2_MSG_KEXINIT sent
    debug3: receive packet: type 20
    debug1: SSH2_MSG_KEXINIT received
    debug2: local client KEXINIT proposal
    debug2: KEX algorithms: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,sntrup761x25519-sha512@openssh.com,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256,ext-info-c
    debug2: host key algorithms: ssh-ed25519-cert-v01@openssh.com,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,sk-ssh-ed25519-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ssh-ed25519@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com,rsa-sha2-512,rsa-sha2-256
    debug2: ciphers ctos: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
    debug2: ciphers stoc: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
    debug2: MACs ctos: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
    debug2: MACs stoc: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
    debug2: compression ctos: none,zlib@openssh.com,zlib
    debug2: compression stoc: none,zlib@openssh.com,zlib
    debug2: languages ctos: 
    debug2: languages stoc: 
    debug2: first_kex_follows 0 
    debug2: reserved 0 
    debug2: peer server KEXINIT proposal
    debug2: KEX algorithms: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
    debug2: host key algorithms: rsa-sha2-512,rsa-sha2-256,ssh-rsa,ecdsa-sha2-nistp256,ssh-ed25519
    debug2: ciphers ctos: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
    debug2: ciphers stoc: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
    debug2: MACs ctos: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
    debug2: MACs stoc: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
    debug2: compression ctos: none,zlib@openssh.com
    debug2: compression stoc: none,zlib@openssh.com
    debug2: languages ctos: 
    debug2: languages stoc: 
    debug2: first_kex_follows 0 
    debug2: reserved 0 
    debug1: kex: algorithm: curve25519-sha256
    debug1: kex: host key algorithm: ssh-ed25519
    debug1: kex: server->client cipher: chacha20-poly1305@openssh.com MAC: <implicit> compression: none
    debug1: kex: client->server cipher: chacha20-poly1305@openssh.com MAC: <implicit> compression: none
    debug3: send packet: type 30
    debug1: expecting SSH2_MSG_KEX_ECDH_REPLY
    debug3: receive packet: type 31
    debug1: SSH2_MSG_KEX_ECDH_REPLY received
    debug1: Server host key: ssh-ed25519 SHA256:z3+FDtD1UUJ9nJ/kcpQpAMS+kEJ5zEAcsHHLFIoTwFo
    debug3: put_host_port: [127.0.0.1]:2222
    debug3: put_host_port: [127.0.0.1]:2222
    debug3: record_hostkey: found key type ED25519 in file /home/xxxxxxxxx/.ssh/known_hosts:8
    debug3: record_hostkey: found key type ECDSA in file /home/xxxxxxxxx/.ssh/known_hosts:9
    debug3: load_hostkeys_file: loaded 2 keys from [127.0.0.1]:2222
    debug1: load_hostkeys: fopen /home/xxxxxxxxx/.ssh/known_hosts2: No such file or directory
    debug1: load_hostkeys: fopen /etc/ssh/ssh_known_hosts: No such file or directory
    debug1: load_hostkeys: fopen /etc/ssh/ssh_known_hosts2: No such file or directory
    debug1: Host '[127.0.0.1]:2222' is known and matches the ED25519 host key.
    debug1: Found key in /home/xxxxxxxxx/.ssh/known_hosts:8
    debug3: send packet: type 21
    debug2: ssh_set_newkeys: mode 1
    debug1: rekey out after 134217728 blocks
    debug1: SSH2_MSG_NEWKEYS sent
    debug1: expecting SSH2_MSG_NEWKEYS
    debug3: receive packet: type 21
    debug1: SSH2_MSG_NEWKEYS received
    debug2: ssh_set_newkeys: mode 0
    debug1: rekey in after 134217728 blocks
    debug1: get_agent_identities: bound agent to hostkey
    debug1: get_agent_identities: agent returned 1 keys
    debug1: Will attempt key: xxxxxxxxx.1229@gmail.com ED25519 SHA256:4jIUskYCnYIXJxSeFGYp8X2KzL7/lyV5FgIeiU8P2i4 agent
    debug1: Will attempt key: /home/xxxxxxxxx/.ssh/id_rsa RSA SHA256:MULda7YxHsHDri6Bjobgt1ICzXGFWEu18kQDnpeVAt8 explicit
    debug2: pubkey_prepare: done
    debug3: send packet: type 5
    debug3: receive packet: type 7
    debug1: SSH2_MSG_EXT_INFO received
    debug1: kex_input_ext_info: server-sig-algs=<ssh-ed25519,sk-ssh-ed25519@openssh.com,ssh-rsa,rsa-sha2-256,rsa-sha2-512,ssh-dss,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,sk-ecdsa-sha2-nistp256@openssh.com>
    debug3: receive packet: type 6
    debug2: service_accept: ssh-userauth
    debug1: SSH2_MSG_SERVICE_ACCEPT received
    debug3: send packet: type 50
    debug3: receive packet: type 51
    debug1: Authentications that can continue: publickey,password
    debug3: start over, passed a different list publickey,password
    debug3: preferred gssapi-with-mic,publickey,keyboard-interactive
    debug3: authmethod_lookup publickey
    debug3: remaining preferred: keyboard-interactive
    debug3: authmethod_is_enabled publickey
    debug1: Next authentication method: publickey
    debug1: Offering public key: xxxxxxxxx.1229@gmail.com ED25519 SHA256:4jIUskYCnYIXJxSeFGYp8X2KzL7/lyV5FgIeiU8P2i4 agent
    debug3: send packet: type 50
    debug2: we sent a publickey packet, wait for reply
    debug3: receive packet: type 51
    debug1: Authentications that can continue: publickey,password
    debug1: Offering public key: /home/xxxxxxxxx/.ssh/id_rsa RSA SHA256:MULda7YxHsHDri6Bjobgt1ICzXGFWEu18kQDnpeVAt8 explicit
    debug3: send packet: type 50
    debug2: we sent a publickey packet, wait for reply
    debug3: receive packet: type 60
    debug1: Server accepts key: /home/xxxxxxxxx/.ssh/id_rsa RSA SHA256:MULda7YxHsHDri6Bjobgt1ICzXGFWEu18kQDnpeVAt8 explicit
    debug3: sign_and_send_pubkey: using publickey with RSA SHA256:MULda7YxHsHDri6Bjobgt1ICzXGFWEu18kQDnpeVAt8
    debug3: sign_and_send_pubkey: signing using rsa-sha2-512 SHA256:MULda7YxHsHDri6Bjobgt1ICzXGFWEu18kQDnpeVAt8
    debug3: send packet: type 50
    debug3: receive packet: type 52
    Authenticated to 127.0.0.1 ([127.0.0.1]:2222) using "publickey".
    debug1: setting up multiplex master socket
    debug3: muxserver_listen: temporary control path /home/xxxxxxxxx/.vuls/controlmaster-root-too-long-854c8eb54e5ac69305997509582ae74a4ff526308c152.2222.0BtgqwJufLjYxyUJ
    unix_listener: path "/home/xxxxxxxxx/.vuls/controlmaster-root-too-long-854c8eb54e5ac69305997509582ae74a4ff526308c152.2222.0BtgqwJufLjYxyUJ" too long for Unix domain socket
    
      err: %!s(<nil>):
    github.com/future-architect/vuls/scanner.testFirstSSHConnection
        /home/xxxxxxxxx/github/github.com/xxxxxxxxx/vuls/scanner/scanner.go:791]
[Jul 31 16:40:27] ERROR [localhost] Failed to scan: Failed to init servers. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/xxxxxxxxx/github/github.com/xxxxxxxxx/vuls/scanner/scanner.go:90
  - No scannable host OS:
    github.com/future-architect/vuls/scanner.Scanner.initServers
        /home/xxxxxxxxx/github/github.com/xxxxxxxxx/vuls/scanner/scanner.go:293
```


## after
```console
$ vuls scan -vvv
[Jul 31 16:43:23]  INFO [localhost] vuls-v0.23.3-build-20230731_164058_5ab0211
[Jul 31 16:43:23]  INFO [localhost] Start scanning
[Jul 31 16:43:23]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Jul 31 16:43:23]  INFO [localhost] Validating config...
[Jul 31 16:43:23]  INFO [localhost] Detecting Server/Container OS... 
[Jul 31 16:43:23]  INFO [localhost] Detecting OS of servers... 
[Jul 31 16:43:26]  INFO [localhost] (1/2) Detected: too-long-854c8eb54e5ac69305997509582ae74a4ff526308c152: ubuntu 20.04
[Jul 31 16:43:26]  INFO [localhost] (2/2) Detected: too-long-854c8eb54e5ac69305997509582ae74a4ff526308c15862e42a0a960f66e5ee4db548205298f77878cb03cd9e54bf7fa592: ubuntu 20.04
[Jul 31 16:43:26]  INFO [localhost] Detecting OS of containers... 
[Jul 31 16:43:26]  INFO [localhost] Checking Scan Modes... 
[Jul 31 16:43:26]  INFO [localhost] Detecting Platforms... 
[Jul 31 16:43:28]  INFO [localhost] (1/2) too-long-854c8eb54e5ac69305997509582ae74a4ff526308c15862e42a0a960f66e5ee4db548205298f77878cb03cd9e54bf7fa592 is running on other
[Jul 31 16:43:28]  INFO [localhost] (2/2) too-long-854c8eb54e5ac69305997509582ae74a4ff526308c152 is running on other
[Jul 31 16:43:28]  INFO [too-long-854c8eb54e5ac69305997509582ae74a4ff526308c15862e42a0a960f66e5ee4db548205298f77878cb03cd9e54bf7fa592] Scanning OS pkg in fast mode
[Jul 31 16:43:28]  INFO [too-long-854c8eb54e5ac69305997509582ae74a4ff526308c152] Scanning OS pkg in fast mode


Scan Summary
================
too-long-854c8eb54e5ac69305997509582ae74a4ff526308c15862e42a0a960f66e5ee4db548205298f77878cb03cd9...	ubuntu20.04	231 installed
too-long-854c8eb54e5ac69305997509582ae74a4ff526308c152                                              	ubuntu20.04	231 installed





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

