### PR TITLE
refactor(contrib): Fix error log when trivy scan failed

### DIFF
--- a/contrib/future-vuls/pkg/fvuls/fvuls.go
+++ b/contrib/future-vuls/pkg/fvuls/fvuls.go
@@ -42,7 +42,7 @@ func NewClient(token string, proxy string) *Client {
 func (f Client) UploadToFvuls(serverUUID string, groupID int64, tags []string, scanResultJSON []byte) error {
 	var scanResult models.ScanResult
 	if err := json.Unmarshal(scanResultJSON, &scanResult); err != nil {
-		fmt.Printf("failed to parse json. err: %v\nPerhaps scan has failed. Please check following scan results.\nResult: %s", err, fmt.Sprintf("%s", scanResultJSON))
+		fmt.Printf("failed to parse json. err: %v\nPerhaps scan has failed. Please check the scan results above or run trivy without pipes.\n", err)
 		return err
 	}
 	scanResult.ServerUUID = serverUUID

--- a/contrib/trivy/parser/parser.go
+++ b/contrib/trivy/parser/parser.go
@@ -1,8 +1,8 @@
+// Package parser ...
 package parser
 
 import (
 	"encoding/json"
-	"fmt"
 
 	v2 "github.com/future-architect/vuls/contrib/trivy/parser/v2"
 	"github.com/future-architect/vuls/models"
@@ -23,7 +23,6 @@ type Report struct {
 func NewParser(vulnJSON []byte) (Parser, error) {
 	r := Report{}
 	if err := json.Unmarshal(vulnJSON, &r); err != nil {
-		fmt.Printf("%s", fmt.Sprintf("%s", vulnJSON))
 		return nil, xerrors.Errorf("Failed to parse JSON. Please use the latest version of trivy, trivy-to-vuls and future-vuls")
 	}
 	switch r.SchemaVersion {


### PR DESCRIPTION
# What did you implement:

Fix error log when uploading results of trivy runs using trivy-to-vuls and future-vuls

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
previous errorlog
```
trivy image python:3.4-alpin -f json |./trivy-to-vuls parse --stdin | ./future-vuls upload --stdin --group-id 2603 --token fvgr-528ec289-2516-11ee-b1e6-0a58a9feac02 --uuid 506b2ede-ebf8-82da-f25f-43932a5d290
2023-09-22T16:05:28.733+0900	INFO	Vulnerability scanning is enabled
2023-09-22T16:05:28.733+0900	INFO	Secret scanning is enabled
2023-09-22T16:05:28.733+0900	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-09-22T16:05:28.733+0900	INFO	Please see also https://aquasecurity.github.io/trivy/v0.44/docs/scanner/secret/#recommendatio
n for faster secret detection
2023-09-22T16:05:30.510+0900	FATAL	image scan error: scan error: unable to initialize a scanner: unable to initialize a docker scanner: 4 errors occurred:
	* unable to inspect the image (python:3.4-alpin): Error response from daemon: no such image: python:3.4-alpin: No such image: python:3.4-alpin
	* containerd socket not found: /run/containerd/containerd.sock
	* unable to initialize Podman client: no podman socket found: stat podman/podman.sock: no such file or directory
	* GET https://index.docker.io/v2/library/python/manifests/3.4-alpin: MANIFEST_UNKNOWN: manifest unknown; unknown tag=3.4-alpin


failed to parse json. err: invalid character 'F' looking for beginning of value
Perhaps scan has failed. Please check following scan results.
Result: Failed to new parser. err: Failed to parse JSON. Please use the latest version of trivy, trivy-to-vuls and future-vuls:
    github.com/future-architect/vuls/contrib/trivy/parser.NewParser
        /Users/wadahiroka/go/vuls/contrib/trivy/parser/parser.go:27
```
new errorlog
```
trivy image python:3.4-alpin -f json |./trivy-to-vuls parse --stdin | ./future-vuls upload --stdin --group-id 2603 --token fvgr-528ec289-2516-11ee-b1e6-0a58a9feac02 --uuid 506b2ede-ebf8-82da-f25f-43932a5d290
2023-09-22T16:35:30.177+0900	INFO	Vulnerability scanning is enabled
2023-09-22T16:35:30.177+0900	INFO	Secret scanning is enabled
2023-09-22T16:35:30.177+0900	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-09-22T16:35:30.177+0900	INFO	Please see also https://aquasecurity.github.io/trivy/v0.44/docs/scanner/secret/#recommendation for faster secret detection
2023-09-22T16:35:33.000+0900	FATAL	image scan error: scan error: unable to initialize a scanner: unable to initialize a docker scanner: 4 errors occurred:
	* unable to inspect the image (python:3.4-alpin): Error response from daemon: no such image: python:3.4-alpin: No such image: python:3.4-alpin
	* containerd socket not found: /run/containerd/containerd.sock
	* unable to initialize Podman client: no podman socket found: stat podman/podman.sock: no such file or directory
	* GET https://index.docker.io/v2/library/python/manifests/3.4-alpin: MANIFEST_UNKNOWN: manifest unknown; unknown tag=3.4-alpin


failed to parse json. err: invalid character 'F' looking for beginning of value
Perhaps scan has failed. Please check the scan results above or run trivy without pipes.
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

