### PR TITLE
refactor: remove redundant `len` check

### DIFF
--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -138,14 +138,12 @@ func (c TOMLLoader) Load(pathToToml string) error {
 		if len(server.Enablerepo) == 0 {
 			server.Enablerepo = Conf.Default.Enablerepo
 		}
-		if len(server.Enablerepo) != 0 {
-			for _, repo := range server.Enablerepo {
-				switch repo {
-				case "base", "updates":
-					// nop
-				default:
-					return xerrors.Errorf("For now, enablerepo have to be base or updates: %s", server.Enablerepo)
-				}
+		for _, repo := range server.Enablerepo {
+			switch repo {
+			case "base", "updates":
+				// nop
+			default:
+				return xerrors.Errorf("For now, enablerepo have to be base or updates: %s", server.Enablerepo)
 			}
 		}
 

--- a/reporter/util.go
+++ b/reporter/util.go
@@ -378,25 +378,23 @@ No CVE-IDs are found in updatable packages.
 				}
 				data = append(data, []string{"Affected Pkg", line})
 
-				if len(pack.AffectedProcs) != 0 {
-					for _, p := range pack.AffectedProcs {
-						if len(p.ListenPortStats) == 0 {
-							data = append(data, []string{"", fmt.Sprintf("  - PID: %s %s", p.PID, p.Name)})
-							continue
-						}
-
-						var ports []string
-						for _, pp := range p.ListenPortStats {
-							if len(pp.PortReachableTo) == 0 {
-								ports = append(ports, fmt.Sprintf("%s:%s", pp.BindAddress, pp.Port))
-							} else {
-								ports = append(ports, fmt.Sprintf("%s:%s(◉ Scannable: %s)", pp.BindAddress, pp.Port, pp.PortReachableTo))
-							}
-						}
-
-						data = append(data, []string{"",
-							fmt.Sprintf("  - PID: %s %s, Port: %s", p.PID, p.Name, ports)})
+				for _, p := range pack.AffectedProcs {
+					if len(p.ListenPortStats) == 0 {
+						data = append(data, []string{"", fmt.Sprintf("  - PID: %s %s", p.PID, p.Name)})
+						continue
 					}
+
+					var ports []string
+					for _, pp := range p.ListenPortStats {
+						if len(pp.PortReachableTo) == 0 {
+							ports = append(ports, fmt.Sprintf("%s:%s", pp.BindAddress, pp.Port))
+						} else {
+							ports = append(ports, fmt.Sprintf("%s:%s(◉ Scannable: %s)", pp.BindAddress, pp.Port, pp.PortReachableTo))
+						}
+					}
+
+					data = append(data, []string{"",
+						fmt.Sprintf("  - PID: %s %s, Port: %s", p.PID, p.Name, ports)})
 				}
 			}
 		}

--- a/scanner/base.go
+++ b/scanner/base.go
@@ -1183,10 +1183,8 @@ func (l *base) execExternalPortScan(scanDestIPPorts map[string][]string) ([]stri
 
 func formatNmapOptionsToString(conf *config.PortScanConf) string {
 	cmd := []string{conf.ScannerBinPath}
-	if len(conf.ScanTechniques) != 0 {
-		for _, technique := range conf.ScanTechniques {
-			cmd = append(cmd, "-"+technique)
-		}
+	for _, technique := range conf.ScanTechniques {
+		cmd = append(cmd, "-"+technique)
 	}
 
 	if conf.SourcePort != "" {

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -719,24 +719,22 @@ func setChangelogLayout(g *gocui.Gui) error {
 				}
 				lines = append(lines, line)
 
-				if len(pack.AffectedProcs) != 0 {
-					for _, p := range pack.AffectedProcs {
-						if len(p.ListenPortStats) == 0 {
-							lines = append(lines, fmt.Sprintf("  * PID: %s %s", p.PID, p.Name))
-							continue
-						}
-
-						var ports []string
-						for _, pp := range p.ListenPortStats {
-							if len(pp.PortReachableTo) == 0 {
-								ports = append(ports, fmt.Sprintf("%s:%s", pp.BindAddress, pp.Port))
-							} else {
-								ports = append(ports, fmt.Sprintf("%s:%s(◉ Scannable: %s)", pp.BindAddress, pp.Port, pp.PortReachableTo))
-							}
-						}
-
-						lines = append(lines, fmt.Sprintf("  * PID: %s %s Port: %s", p.PID, p.Name, ports))
+				for _, p := range pack.AffectedProcs {
+					if len(p.ListenPortStats) == 0 {
+						lines = append(lines, fmt.Sprintf("  * PID: %s %s", p.PID, p.Name))
+						continue
 					}
+
+					var ports []string
+					for _, pp := range p.ListenPortStats {
+						if len(pp.PortReachableTo) == 0 {
+							ports = append(ports, fmt.Sprintf("%s:%s", pp.BindAddress, pp.Port))
+						} else {
+							ports = append(ports, fmt.Sprintf("%s:%s(◉ Scannable: %s)", pp.BindAddress, pp.Port, pp.PortReachableTo))
+						}
+					}
+
+					lines = append(lines, fmt.Sprintf("  * PID: %s %s Port: %s", p.PID, p.Name, ports))
 				}
 			}
 		}


### PR DESCRIPTION
# What did you implement:

`len` returns 0 if the slice is nil. From the Go specification [^1]:

> "1. For a nil slice, the number of iterations is 0."

Therefore, an additional `len(v) != 0` check for before the loop is unnecessary.

[^1]: https://go.dev/ref/spec#For_range

## Type of change

# How Has This Been Tested?

`make test`

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

