### PR TITLE
feat(ubuntu): add ubuntu 23.10(mantic)

### DIFF
--- a/config/os.go
+++ b/config/os.go
@@ -196,6 +196,9 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 			"23.04": {
 				StandardSupportUntil: time.Date(2024, 1, 31, 23, 59, 59, 0, time.UTC),
 			},
+			"23.10": {
+				StandardSupportUntil: time.Date(2024, 7, 31, 23, 59, 59, 0, time.UTC),
+			},
 		}[release]
 	case constant.OpenSUSE:
 		// https://en.opensuse.org/Lifetime

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -363,6 +363,14 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			stdEnded: false,
 			extEnded: false,
 		},
+		{
+			name:     "Ubuntu 23.10 supported",
+			fields:   fields{family: Ubuntu, release: "23.10"},
+			now:      time.Date(2024, 7, 31, 23, 59, 59, 0, time.UTC),
+			found:    true,
+			stdEnded: false,
+			extEnded: false,
+		},
 		//Debian
 		{
 			name:     "Debian 8 supported",

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/vulsio/go-exploitdb v0.4.7-0.20231017104626-201191637c48
 	github.com/vulsio/go-kev v0.1.4-0.20231017105707-8a9a218d280a
 	github.com/vulsio/go-msfdb v0.2.4-0.20231017104449-b705e6975831
-	github.com/vulsio/gost v0.4.6-0.20231017094944-b2272b3bc9e7
+	github.com/vulsio/gost v0.4.6-0.20231018164544-c4d0a39db372
 	github.com/vulsio/goval-dictionary v0.9.5-0.20231017110023-3ae99de8d1c5
 	go.etcd.io/bbolt v1.3.7
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d

--- a/go.sum
+++ b/go.sum
@@ -789,8 +789,8 @@ github.com/vulsio/go-kev v0.1.4-0.20231017105707-8a9a218d280a h1:pdV8P4krLPt2xxb
 github.com/vulsio/go-kev v0.1.4-0.20231017105707-8a9a218d280a/go.mod h1:+Tl/94+ckHpnRgurzQMsuPr9rjZuzEv4kyVYouD3v1w=
 github.com/vulsio/go-msfdb v0.2.4-0.20231017104449-b705e6975831 h1:K0SiMnTEH+uxXFkv7QFhmCVy6/U2rdojsd99P5Kw+qM=
 github.com/vulsio/go-msfdb v0.2.4-0.20231017104449-b705e6975831/go.mod h1:yzjPeHw7Ba0HniSiRiFbxne5XSXmDu7PRrOBIsWa6mw=
-github.com/vulsio/gost v0.4.6-0.20231017094944-b2272b3bc9e7 h1:gwWcGjkvtcogSlVvD7/9abYJHx0BmVjudrnKXwoo5k0=
-github.com/vulsio/gost v0.4.6-0.20231017094944-b2272b3bc9e7/go.mod h1:+YjZF2zcmi1UFkHspF8EyLbe06tXOjvDSjon3SJ1jBI=
+github.com/vulsio/gost v0.4.6-0.20231018164544-c4d0a39db372 h1:NisWi165rKBALMZdrZWDTPvLTYk/XGPYF6JHaLRObME=
+github.com/vulsio/gost v0.4.6-0.20231018164544-c4d0a39db372/go.mod h1:+YjZF2zcmi1UFkHspF8EyLbe06tXOjvDSjon3SJ1jBI=
 github.com/vulsio/goval-dictionary v0.9.5-0.20231017110023-3ae99de8d1c5 h1:kfqeMTa1Q3JRzulBv2zdA69khiYOnFkUhaSiwJ4X6TU=
 github.com/vulsio/goval-dictionary v0.9.5-0.20231017110023-3ae99de8d1c5/go.mod h1:+FaS9XJ0lq4zmQ8qFYFS3b65tKkvIANpebHl3U42hqg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/gost/ubuntu.go
+++ b/gost/ubuntu.go
@@ -61,6 +61,7 @@ func (ubu Ubuntu) supported(version string) bool {
 		"2204": "jammy",
 		"2210": "kinetic",
 		"2304": "lunar",
+		"2310": "mantic",
 	}[version]
 	return ok
 }


### PR DESCRIPTION
# What did you implement:

add ubuntu 23.10

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?
```console
$ vuls scan
[Oct  3 00:40:42]  INFO [localhost] vuls-v0.24.3-build-20231019_014948_c02e9ab
[Oct  3 00:40:42]  INFO [localhost] Start scanning
[Oct  3 00:40:42]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Oct  3 00:40:42]  INFO [localhost] Validating config...
[Oct  3 00:40:42]  INFO [localhost] Detecting Server/Container OS... 
[Oct  3 00:40:42]  INFO [localhost] Detecting OS of servers... 
[Oct  3 00:40:43]  INFO [localhost] (1/1) Detected: docker: ubuntu 23.10
[Oct  3 00:40:43]  INFO [localhost] Detecting OS of containers... 
[Oct  3 00:40:43]  INFO [localhost] Checking Scan Modes... 
[Oct  3 00:40:43]  INFO [localhost] Detecting Platforms... 
[Oct  3 00:40:45]  INFO [localhost] (1/1) docker is running on other
[Oct  3 00:40:45]  INFO [docker] Scanning OS pkg in fast mode


Scan Summary
================
docker	ubuntu23.10	332 installed





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ vuls report
vuls report
[Oct 19 01:50:59]  INFO [localhost] vuls-v0.24.3-build-20231019_014948_c02e9ab
...
[Oct 19 01:50:59]  INFO [localhost] Skip OVAL and Scan with gost alone.
[Oct 19 01:50:59]  INFO [localhost] docker: 0 CVEs are detected with OVAL
[Oct 19 01:51:00]  INFO [localhost] docker: 37 CVEs are detected with gost
[Oct 19 01:51:00]  INFO [localhost] docker: 0 CVEs are detected with CPE
[Oct 19 01:51:01]  INFO [localhost] docker: 0 PoC are detected
[Oct 19 01:51:01]  INFO [localhost] docker: 0 exploits are detected
[Oct 19 01:51:01]  INFO [localhost] docker: Known Exploited Vulnerabilities are detected for 0 CVEs
[Oct 19 01:51:01]  INFO [localhost] docker: Cyber Threat Intelligences are detected for 6 CVEs
[Oct 19 01:51:01]  INFO [localhost] docker: total 37 CVEs detected
[Oct 19 01:51:01]  INFO [localhost] docker: 0 CVEs filtered by --confidence-over=80
docker (ubuntu23.10)
====================
Total: 37 (Critical:1 High:8 Medium:23 Low:5 ?:0)
7/37 Fixed, 10 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
332 installed

+----------------+------+--------+-----+-----------+---------+--------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |            PACKAGES            |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2022-28321 |  9.8 |  AV:N  |     |           | unfixed | libpam-modules,                |
|                |      |        |     |           |         | libpam-modules-bin,            |
|                |      |        |     |           |         | libpam-runtime, libpam0g       |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2023-38545 |  8.9 |        |     |           |   fixed | curl, libcurl4                 |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
...
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference
- https://github.com/vulsio/gost/pull/211
- https://github.com/vulsdoc/vuls/pull/235
