### PR TITLE
fix(contrib/fvuls): Add flag to specify snmp community for future-vuls discover

### DIFF
--- a/contrib/future-vuls/README.md
+++ b/contrib/future-vuls/README.md
@@ -100,6 +100,7 @@ future-vuls discover --cidr 192.168.0.0/24 --output discover_list.toml
 
 Flags:
       --cidr string           cidr range
+      --community string      snmp community name. default: public
   -h, --help                  help for discover
       --output string         output file
       --snmp-version string   snmp version v1,v2c and v3. default: v2c

--- a/contrib/future-vuls/cmd/main.go
+++ b/contrib/future-vuls/cmd/main.go
@@ -31,6 +31,7 @@ var (
 	cidr        string
 	snmpVersion string
 	proxy       string
+	community   string
 )
 
 func main() {
@@ -105,7 +106,10 @@ func main() {
 			if snmpVersion != "v1" && snmpVersion != "v2c" && snmpVersion != "v3" {
 				return fmt.Errorf("Invalid snmpVersion")
 			}
-			if err := discover.ActiveHosts(cidr, outputFile, snmpVersion); err != nil {
+			if community == "" {
+				community = config.Community
+			}
+			if err := discover.ActiveHosts(cidr, outputFile, snmpVersion, community); err != nil {
 				fmt.Printf("%v", err)
 				// avoid to display help message
 				os.Exit(1)
@@ -146,6 +150,7 @@ func main() {
 	cmdDiscover.PersistentFlags().StringVar(&cidr, "cidr", "", "cidr range")
 	cmdDiscover.PersistentFlags().StringVar(&outputFile, "output", "", "output file")
 	cmdDiscover.PersistentFlags().StringVar(&snmpVersion, "snmp-version", "", "snmp version v1,v2c and v3. default: v2c ")
+	cmdDiscover.PersistentFlags().StringVar(&community, "community", "", "snmp community name")
 
 	cmdAddCpe.PersistentFlags().StringVarP(&token, "token", "t", "", "future vuls token ENV: VULS_TOKEN")
 	cmdAddCpe.PersistentFlags().StringVar(&outputFile, "output", "", "output file")

--- a/contrib/future-vuls/cmd/main.go
+++ b/contrib/future-vuls/cmd/main.go
@@ -149,8 +149,8 @@ func main() {
 
 	cmdDiscover.PersistentFlags().StringVar(&cidr, "cidr", "", "cidr range")
 	cmdDiscover.PersistentFlags().StringVar(&outputFile, "output", "", "output file")
-	cmdDiscover.PersistentFlags().StringVar(&snmpVersion, "snmp-version", "", "snmp version v1,v2c and v3. default: v2c ")
-	cmdDiscover.PersistentFlags().StringVar(&community, "community", "", "snmp community name")
+	cmdDiscover.PersistentFlags().StringVar(&snmpVersion, "snmp-version", "", "snmp version v1,v2c and v3. default: v2c")
+	cmdDiscover.PersistentFlags().StringVar(&community, "community", "", "snmp community name. default: public")
 
 	cmdAddCpe.PersistentFlags().StringVarP(&token, "token", "t", "", "future vuls token ENV: VULS_TOKEN")
 	cmdAddCpe.PersistentFlags().StringVar(&outputFile, "output", "", "output file")

--- a/contrib/future-vuls/pkg/config/config.go
+++ b/contrib/future-vuls/pkg/config/config.go
@@ -5,6 +5,7 @@ const (
 	DiscoverTomlFileName        = "discover_list.toml"
 	SnmpVersion                 = "v2c"
 	FvulsDomain                 = "vuls.biz"
+	Community                   = "public"
 	DiscoverTomlTimeStampFormat = "20060102150405"
 )
 

--- a/contrib/future-vuls/pkg/discover/discover.go
+++ b/contrib/future-vuls/pkg/discover/discover.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ActiveHosts ...
-func ActiveHosts(cidr string, outputFile string, snmpVersion string) error {
+func ActiveHosts(cidr string, outputFile string, snmpVersion string, community string) error {
 	scanner := pingscanner.PingScanner{
 		CIDR: cidr,
 		PingOptions: []string{
@@ -42,7 +42,7 @@ func ActiveHosts(cidr string, outputFile string, snmpVersion string) error {
 
 	servers := make(config.DiscoverToml)
 	for _, activeHost := range activeHosts {
-		cpes, err := executeSnmp2cpe(activeHost, snmpVersion)
+		cpes, err := executeSnmp2cpe(activeHost, snmpVersion, community)
 		if err != nil {
 			fmt.Printf("failed to execute snmp2cpe. err: %v\n", err)
 			continue
@@ -100,9 +100,9 @@ func ActiveHosts(cidr string, outputFile string, snmpVersion string) error {
 	return nil
 }
 
-func executeSnmp2cpe(addr string, snmpVersion string) (cpes map[string][]string, err error) {
+func executeSnmp2cpe(addr string, snmpVersion string, community string) (cpes map[string][]string, err error) {
 	fmt.Printf("%s: Execute snmp2cpe...\n", addr)
-	result, err := exec.Command("./snmp2cpe", snmpVersion, addr, "public").CombinedOutput()
+	result, err := exec.Command("./snmp2cpe", snmpVersion, addr, community).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute snmp2cpe. err: %v", err)
 	}


### PR DESCRIPTION
# What did you implement:

Changed `future-vuls discover` command to allow specifying community when running `snmp2cpe`.
Default is  `public`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
./future-vuls discover -h
discover hosts with CIDR range. Run snmp2cpe on active host to get CPE. Default outputFile is ./discover_list.toml

Usage:
  future-vuls discover --cidr <CIDR_RANGE> --output <OUTPUT_FILE> [flags]

Examples:
future-vuls discover --cidr 192.168.0.0/24 --output discover_list.toml

Flags:
      --cidr string           cidr range
      --community string      snmp community name. default: public
  -h, --help                  help for discover
      --output string         output file
      --snmp-version string   snmp version v1,v2c and v3. default: v2c
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

