### PR TITLE
fix(scan): fix nil poiter in needs-restarting

### DIFF
--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -815,7 +815,7 @@ func (o *redhatBase) parseNeedsRestarting(stdout string) (procs []models.NeedRes
 		}
 
 		path := ss[1]
-		if !strings.HasPrefix(path, "/") {
+		if path != "" && !strings.HasPrefix(path, "/") {
 			path = strings.Fields(path)[0]
 			// [ec2-user@ip-172-31-11-139 ~]$ sudo needs-restarting
 			// 2024 : auditd

--- a/scanner/redhatbase_test.go
+++ b/scanner/redhatbase_test.go
@@ -500,8 +500,14 @@ func TestParseNeedsRestarting(t *testing.T) {
 	}{
 		{
 			`1 : /usr/lib/systemd/systemd --switched-root --system --deserialize 21kk
+30170 : 
 437 : /usr/sbin/NetworkManager --no-daemon`,
 			[]models.NeedRestartProcess{
+				{
+					PID:     "30170",
+					Path:    "",
+					HasInit: true,
+				},
 				{
 					PID:     "437",
 					Path:    "/usr/sbin/NetworkManager --no-daemon",


### PR DESCRIPTION
# What did you implement:

I fixed a bug where a nil pointer exception occurred in needs-restarting when the path is empty ("").

 ```
time="Oct 13 15:28:21" level=debug msg="Executing... LANGUAGE=en_US.UTF-8 needs-restarting" 
time="Oct 13 15:28:30" level=debug msg="execResult: servername: \n  cmd: sudo LANGUAGE=en_US.UTF-8 needs-restarting\n  exitstatus: 0\n  stdout: 30020 : /usr/sbin/httpd -DFOREGROUND \n30170 : \n30399 : /usr/sbin/httpd -DFOREGROUND \n\n  stderr: \n  err: %!s(<nil>)" 
time="Oct 13 15:28:30" level=debug msg="Panic: runtime error: index out of range [0] with length 0 on ***" 
time="Oct 13 17:28:02" level=error msg="Timed out: ***\n    github.com/future-architect/vuls/scanner.parallelExec\n        /home/runner/work/futurevuls-backend/futurevuls-backend/scanner-src/scanner/executil.go:130" 
 ```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run  the test case and all test pass

# Checklist:

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES