### PR TITLE
fix(scanner): change lsof cmd that  should succeed without password

### DIFF
--- a/scanner/alma.go
+++ b/scanner/alma.go
@@ -90,7 +90,7 @@ func (o *alma) sudoNoPasswdCmdsFastRoot() []cmd {
 			{"stat /proc/1/exe", exitStatusZero},
 			{"ls -l /proc/1/exe", exitStatusZero},
 			{"cat /proc/1/maps", exitStatusZero},
-			{"lsof -i -P -n", exitStatusZero},
+			{"lsof -i -P -n -V", exitStatusZero},
 		}
 	}
 	return []cmd{

--- a/scanner/amazon.go
+++ b/scanner/amazon.go
@@ -102,7 +102,7 @@ func (o *amazon) sudoNoPasswdCmdsFastRoot() []cmd {
 		{"stat /proc/1/exe", exitStatusZero},
 		{"ls -l /proc/1/exe", exitStatusZero},
 		{"cat /proc/1/maps", exitStatusZero},
-		{"lsof -i -P -n", exitStatusZero},
+		{"lsof -i -P -n -V", exitStatusZero},
 	}
 }
 

--- a/scanner/centos.go
+++ b/scanner/centos.go
@@ -89,7 +89,7 @@ func (o *centos) sudoNoPasswdCmdsFastRoot() []cmd {
 			{"stat /proc/1/exe", exitStatusZero},
 			{"ls -l /proc/1/exe", exitStatusZero},
 			{"cat /proc/1/maps", exitStatusZero},
-			{"lsof -i -P -n", exitStatusZero},
+			{"lsof -i -P -n -V", exitStatusZero},
 		}
 	}
 	return []cmd{

--- a/scanner/debian.go
+++ b/scanner/debian.go
@@ -132,7 +132,7 @@ func (o *debian) checkIfSudoNoPasswd() error {
 		"stat /proc/1/exe",
 		"ls -l /proc/1/exe",
 		"cat /proc/1/maps",
-		"lsof -i -P -n",
+		"lsof -i -P -n -V",
 	}
 
 	if !o.getServerInfo().Mode.IsOffline() {

--- a/scanner/fedora.go
+++ b/scanner/fedora.go
@@ -88,7 +88,7 @@ func (o *fedora) sudoNoPasswdCmdsFastRoot() []cmd {
 			{"stat /proc/1/exe", exitStatusZero},
 			{"ls -l /proc/1/exe", exitStatusZero},
 			{"cat /proc/1/maps", exitStatusZero},
-			{"lsof -i -P -n", exitStatusZero},
+			{"lsof -i -P -n -V", exitStatusZero},
 		}
 	}
 	return []cmd{

--- a/scanner/rhel.go
+++ b/scanner/rhel.go
@@ -86,7 +86,7 @@ func (o *rhel) sudoNoPasswdCmdsFastRoot() []cmd {
 			{"stat /proc/1/exe", exitStatusZero},
 			{"ls -l /proc/1/exe", exitStatusZero},
 			{"cat /proc/1/maps", exitStatusZero},
-			{"lsof -i -P -n", exitStatusZero},
+			{"lsof -i -P -n -V", exitStatusZero},
 		}
 	}
 	return []cmd{

--- a/scanner/rocky.go
+++ b/scanner/rocky.go
@@ -90,7 +90,7 @@ func (o *rocky) sudoNoPasswdCmdsFastRoot() []cmd {
 			{"stat /proc/1/exe", exitStatusZero},
 			{"ls -l /proc/1/exe", exitStatusZero},
 			{"cat /proc/1/maps", exitStatusZero},
-			{"lsof -i -P -n", exitStatusZero},
+			{"lsof -i -P -n -V", exitStatusZero},
 		}
 	}
 	return []cmd{

--- a/scanner/suse.go
+++ b/scanner/suse.go
@@ -158,7 +158,7 @@ func (o *suse) sudoNoPasswdCmdsFastRoot() []cmd {
 			{"stat /proc/1/exe", exitStatusZero},
 			{"ls -l /proc/1/exe", exitStatusZero},
 			{"cat /proc/1/maps", exitStatusZero},
-			{"lsof -i -P -n", exitStatusZero},
+			{"lsof -i -P -n -V", exitStatusZero},
 		}
 	}
 	return []cmd{


### PR DESCRIPTION
# What did you implement:

Change the lsof cmd that should be executed successfully without a password.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?
## before
```console
$ cat /etc/sudoers.d/vagrant
vagrant ALL=(ALL) NOPASSWD:SETENV: /usr/bin/apt-get update, /usr/bin/stat *, /usr/sbin/checkrestart, /bin/ls -l /proc/*/exe, /bin/cat /proc/*/maps, /usr/bin/lsof -i -P -n

$ vuls configtest
[Oct 18 18:08:57]  INFO [localhost] vuls-v0.24.3-build-20231019_024423_75e9883
[Oct 18 18:08:57]  INFO [localhost] Validating config...
[Oct 18 18:08:57]  INFO [localhost] Detecting Server/Container OS... 
[Oct 18 18:08:57]  INFO [localhost] Detecting OS of servers... 
[Oct 18 18:08:57]  INFO [localhost] (1/1) Detected: localhost: ubuntu 22.04
[Oct 18 18:08:57]  INFO [localhost] Detecting OS of containers... 
[Oct 18 18:08:57]  INFO [localhost] Checking Scan Modes...
[Oct 18 18:08:57]  INFO [localhost] Checking dependencies...
[Oct 18 18:08:57]  INFO [localhost] Dependencies... Pass
[Oct 18 18:08:57]  INFO [localhost] Checking sudo settings...
[Oct 18 18:08:57]  INFO [localhost] Checking... sudo checkrestart
[Oct 18 18:08:57]  INFO [localhost] Checking... sudo stat /proc/1/exe
[Oct 18 18:08:57]  INFO [localhost] Checking... sudo ls -l /proc/1/exe
[Oct 18 18:08:57]  INFO [localhost] Checking... sudo cat /proc/1/maps
[Oct 18 18:08:57]  INFO [localhost] Checking... sudo lsof -i -P -n
[Oct 18 18:08:57]  INFO [localhost] Checking... sudo apt-get update
[Oct 18 18:08:59]  INFO [localhost] Sudo... Pass
[Oct 18 18:08:59]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Oct 18 18:08:59]  INFO [localhost] Scannable servers are below...
localhost

$ vuls scan -debug
[Oct 18 18:10:18]  INFO [localhost] vuls-v0.24.3-build-20231019_024423_75e9883
...
[Oct 18 18:10:24] DEBUG [localhost] Executing... lsof -i -P -n -V
[sudo] password for vagrant:
```

## after
```console
$ cat /etc/sudoers.d/vagrant
vagrant ALL=(ALL) NOPASSWD:SETENV: /usr/bin/apt-get update, /usr/bin/stat *, /usr/sbin/checkrestart, /bin/ls -l /proc/*/exe, /bin/cat /proc/*/maps, /usr/bin/lsof -i -P -n -V

$ vuls configtest
[Oct 18 18:17:38]  INFO [localhost] vuls-v0.24.3-build-20231019_024143_697118a
[Oct 18 18:17:38]  INFO [localhost] Validating config...
[Oct 18 18:17:38]  INFO [localhost] Detecting Server/Container OS... 
[Oct 18 18:17:38]  INFO [localhost] Detecting OS of servers... 
[Oct 18 18:17:38]  INFO [localhost] (1/1) Detected: localhost: ubuntu 22.04
[Oct 18 18:17:38]  INFO [localhost] Detecting OS of containers... 
[Oct 18 18:17:38]  INFO [localhost] Checking Scan Modes...
[Oct 18 18:17:38]  INFO [localhost] Checking dependencies...
[Oct 18 18:17:38]  INFO [localhost] Dependencies... Pass
[Oct 18 18:17:38]  INFO [localhost] Checking sudo settings...
[Oct 18 18:17:38]  INFO [localhost] Checking... sudo checkrestart
[Oct 18 18:17:38]  INFO [localhost] Checking... sudo stat /proc/1/exe
[Oct 18 18:17:38]  INFO [localhost] Checking... sudo ls -l /proc/1/exe
[Oct 18 18:17:38]  INFO [localhost] Checking... sudo cat /proc/1/maps
[Oct 18 18:17:38]  INFO [localhost] Checking... sudo lsof -i -P -n -V
[Oct 18 18:17:38]  INFO [localhost] Checking... sudo apt-get update
[Oct 18 18:17:43]  INFO [localhost] Sudo... Pass
[Oct 18 18:17:43]  INFO [localhost] It can be scanned with fast scan mode even if warn or err messages are displayed due to lack of dependent packages or sudo settings in fast-root or deep scan mode
[Oct 18 18:17:43]  INFO [localhost] Scannable servers are below...
localhost

$ vuls scan -debug
[Oct 18 18:18:05]  INFO [localhost] vuls-v0.24.3-build-20231019_024143_697118a
...
[Oct 18 18:19:32] DEBUG [localhost] Executing... lsof -i -P -n -V
[Oct 18 18:19:33] DEBUG [localhost] execResult: servername: 
  cmd: sudo lsof -i -P -n -V
  exitstatus: 0
  stdout: COMMAND    PID            USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
systemd-n  578 systemd-network   18u  IPv4  17037      0t0  UDP 10.0.2.15:68 
systemd-r  581 systemd-resolve   13u  IPv4  17424      0t0  UDP 127.0.0.53:53 
systemd-r  581 systemd-resolve   14u  IPv4  17425      0t0  TCP 127.0.0.53:53 (LISTEN)
sshd      2668            root    3u  IPv4  27113      0t0  TCP *:22 (LISTEN)
sshd      2668            root    4u  IPv6  27115      0t0  TCP *:22 (LISTEN)
sshd      4269            root    4u  IPv4  34208      0t0  TCP 10.0.2.15:22->10.0.2.2:37784 (ESTABLISHED)
sshd      4316         vagrant    4u  IPv4  34208      0t0  TCP 10.0.2.15:22->10.0.2.2:37784 (ESTABLISHED)

  stderr: 
  err: %!s(<nil>)
...

Scan Summary
================
[Reboot Required] localhost	ubuntu22.04	671 installed, 129 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://github.com/future-architect/vuls/pull/1688
* https://github.com/vulsdoc/vuls/pull/236
