### PR TITLE
chore(deps): bump github.com/vulsio/gost to v0.4.6-0.20231027050036-c…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/vulsio/go-exploitdb v0.4.7-0.20231017104626-201191637c48
 	github.com/vulsio/go-kev v0.1.4-0.20231017105707-8a9a218d280a
 	github.com/vulsio/go-msfdb v0.2.4-0.20231017104449-b705e6975831
-	github.com/vulsio/gost v0.4.6-0.20231018164544-c4d0a39db372
+	github.com/vulsio/gost v0.4.6-0.20231027050036-c963bd83e7e5
 	github.com/vulsio/goval-dictionary v0.9.5-0.20231017110023-3ae99de8d1c5
 	go.etcd.io/bbolt v1.3.7
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d

--- a/go.sum
+++ b/go.sum
@@ -789,8 +789,8 @@ github.com/vulsio/go-kev v0.1.4-0.20231017105707-8a9a218d280a h1:pdV8P4krLPt2xxb
 github.com/vulsio/go-kev v0.1.4-0.20231017105707-8a9a218d280a/go.mod h1:+Tl/94+ckHpnRgurzQMsuPr9rjZuzEv4kyVYouD3v1w=
 github.com/vulsio/go-msfdb v0.2.4-0.20231017104449-b705e6975831 h1:K0SiMnTEH+uxXFkv7QFhmCVy6/U2rdojsd99P5Kw+qM=
 github.com/vulsio/go-msfdb v0.2.4-0.20231017104449-b705e6975831/go.mod h1:yzjPeHw7Ba0HniSiRiFbxne5XSXmDu7PRrOBIsWa6mw=
-github.com/vulsio/gost v0.4.6-0.20231018164544-c4d0a39db372 h1:NisWi165rKBALMZdrZWDTPvLTYk/XGPYF6JHaLRObME=
-github.com/vulsio/gost v0.4.6-0.20231018164544-c4d0a39db372/go.mod h1:+YjZF2zcmi1UFkHspF8EyLbe06tXOjvDSjon3SJ1jBI=
+github.com/vulsio/gost v0.4.6-0.20231027050036-c963bd83e7e5 h1:/jqUpz+POu5JSoyHp2IOOwevluat5xfpPENe9aZ3wEE=
+github.com/vulsio/gost v0.4.6-0.20231027050036-c963bd83e7e5/go.mod h1:+YjZF2zcmi1UFkHspF8EyLbe06tXOjvDSjon3SJ1jBI=
 github.com/vulsio/goval-dictionary v0.9.5-0.20231017110023-3ae99de8d1c5 h1:kfqeMTa1Q3JRzulBv2zdA69khiYOnFkUhaSiwJ4X6TU=
 github.com/vulsio/goval-dictionary v0.9.5-0.20231017110023-3ae99de8d1c5/go.mod h1:+FaS9XJ0lq4zmQ8qFYFS3b65tKkvIANpebHl3U42hqg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=


### PR DESCRIPTION
…963bd83e7e5


# What did you implement:

update gost.
If the scan target is Ubuntu and gost is in a redis backend environment, the memory consumption will be smaller.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## before
```console
$ /usr/bin/time -f "real(s): %e, user(s): %U, sys(s): %S  memory(kb): %M" ./vuls.master report --refresh-cve
[Oct 27 12:51:04]  INFO [localhost] vuls-v0.24.4-build-20231027_123840_fed731b
...
[Oct 27 12:51:04]  INFO [localhost] gost.type=redis, gost.url=redis://127.0.0.1:6379/1, gost.SQLite3Path=
...
[Oct 27 12:51:04]  INFO [localhost] Skip OVAL and Scan with gost alone.
[Oct 27 12:51:04]  INFO [localhost] [Reboot Required] localhost: 0 CVEs are detected with OVAL
[Oct 27 12:51:08]  INFO [localhost] [Reboot Required] localhost: 426 CVEs are detected with gost
[Oct 27 12:51:08]  INFO [localhost] [Reboot Required] localhost: 0 CVEs are detected with CPE
[Oct 27 12:51:11]  INFO [localhost] [Reboot Required] localhost: 3 PoC are detected
[Oct 27 12:51:11]  INFO [localhost] [Reboot Required] localhost: 0 exploits are detected
[Oct 27 12:51:11]  INFO [localhost] [Reboot Required] localhost: Known Exploited Vulnerabilities are detected for 2 CVEs
[Oct 27 12:51:19]  INFO [localhost] [Reboot Required] localhost: Cyber Threat Intelligences are detected for 121 CVEs
[Oct 27 12:51:19]  INFO [localhost] [Reboot Required] localhost: total 426 CVEs detected
[Oct 27 12:51:19]  INFO [localhost] [Reboot Required] localhost: 0 CVEs filtered by --confidence-over=80
[Reboot Required] localhost (ubuntu22.04)
=========================================
Total: 426 (Critical:34 High:169 Medium:207 Low:16 ?:0)
49/426 Fixed, 172 poc, 0 exploits, cisa: 2, uscert: 0, jpcert: 0 alerts
2725 installed
...
real(s): 15.48, user(s): 14.68, sys(s): 1.47  memory(kb): 384568
```

## after
```console
$ /usr/bin/time -f "real(s): %e, user(s): %U, sys(s): %S  memory(kb): %M" ./vuls.patched report --refresh-cve
[Oct 27 14:13:20]  INFO [localhost] vuls-v0.24.4-build-20231027_140442_aaf9577
[Oct 27 14:13:20]  INFO [localhost] Validating config...
...
[Oct 27 14:13:20]  INFO [localhost] gost.type=redis, gost.url=redis://127.0.0.1:6379/1, gost.SQLite3Path=
...
[Oct 27 14:13:20]  INFO [localhost] Skip OVAL and Scan with gost alone.
[Oct 27 14:13:20]  INFO [localhost] [Reboot Required] localhost: 0 CVEs are detected with OVAL
[Oct 27 14:13:25]  INFO [localhost] [Reboot Required] localhost: 426 CVEs are detected with gost
[Oct 27 14:13:25]  INFO [localhost] [Reboot Required] localhost: 0 CVEs are detected with CPE
[Oct 27 14:13:28]  INFO [localhost] [Reboot Required] localhost: 3 PoC are detected
[Oct 27 14:13:28]  INFO [localhost] [Reboot Required] localhost: 0 exploits are detected
[Oct 27 14:13:28]  INFO [localhost] [Reboot Required] localhost: Known Exploited Vulnerabilities are detected for 2 CVEs
[Oct 27 14:13:36]  INFO [localhost] [Reboot Required] localhost: Cyber Threat Intelligences are detected for 121 CVEs
[Oct 27 14:13:36]  INFO [localhost] [Reboot Required] localhost: total 426 CVEs detected
[Oct 27 14:13:36]  INFO [localhost] [Reboot Required] localhost: 0 CVEs filtered by --confidence-over=80
[Reboot Required] localhost (ubuntu22.04)
=========================================
Total: 426 (Critical:34 High:169 Medium:207 Low:16 ?:0)
49/426 Fixed, 172 poc, 0 exploits, cisa: 2, uscert: 0, jpcert: 0 alerts
2725 installed
...
real(s): 15.93, user(s): 15.49, sys(s): 1.42  memory(kb): 113928
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

