### PR TITLE
fix(subcmds/saas): Add env HTTPS_PROXY for aws sdk

### DIFF
--- a/saas/saas.go
+++ b/saas/saas.go
@@ -109,6 +109,10 @@ func (w Writer) Write(rs ...models.ScanResult) error {
 	if err != nil {
 		return xerrors.Errorf("Failed to new aws session. err: %w", err)
 	}
+	// For S3 upload of aws sdk
+	if err := os.Setenv("HTTPS_PROXY", config.Conf.HTTPProxy); err != nil {
+		return xerrors.Errorf("Failed to set HTTP proxy: %s", err)
+	}
 
 	svc := s3.New(sess)
 	for _, r := range rs {


### PR DESCRIPTION
# What did you implement:

Added definition of the HTTPS_PROXY environment variable to load proxy settings into the aws sdk used for uploading scan results to S3.

To correct the following error.
`Failed to upload ...  dial tcp 3.5.156.15:443: i/o timeout`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

