### PR TITLE
feat(os): add FreeBSD 14 EOL

### DIFF
--- a/config/os.go
+++ b/config/os.go
@@ -317,6 +317,7 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 			"11": {StandardSupportUntil: time.Date(2021, 9, 30, 23, 59, 59, 0, time.UTC)},
 			"12": {StandardSupportUntil: time.Date(2023, 12, 31, 23, 59, 59, 0, time.UTC)},
 			"13": {StandardSupportUntil: time.Date(2026, 1, 31, 23, 59, 59, 0, time.UTC)},
+			"14": {StandardSupportUntil: time.Date(2028, 11, 21, 23, 59, 59, 0, time.UTC)},
 		}[major(release)]
 	case constant.Fedora:
 		// https://docs.fedoraproject.org/en-US/releases/eol/

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -542,6 +542,14 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 			extEnded: false,
 			found:    true,
 		},
+		{
+			name:     "freebsd 14 supported",
+			fields:   fields{family: FreeBSD, release: "14"},
+			now:      time.Date(2028, 11, 21, 23, 59, 59, 0, time.UTC),
+			stdEnded: false,
+			extEnded: false,
+			found:    true,
+		},
 		// Fedora
 		{
 			name:     "Fedora 32 supported",


### PR DESCRIPTION
# What did you implement:

Fixes #1796 

There are currently no errata for FreeBSD 14, so the number of detected cases is 0.
https://www.freebsd.org/releases/14.0R/errata/

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ vuls scan
[Nov 25 08:21:06]  INFO [localhost] vuls-v0.24.6-build-20231125_081606_32a9cfa
[Nov 25 08:21:06]  INFO [localhost] Start scanning
[Nov 25 08:21:06]  INFO [localhost] config: /home/user/vuls/config.toml
[Nov 25 08:21:06]  INFO [localhost] Validating config...
[Nov 25 08:21:06]  INFO [localhost] Detecting Server/Container OS... 
[Nov 25 08:21:06]  INFO [localhost] Detecting OS of servers... 
[Nov 25 08:21:06]  INFO [localhost] (1/1) Detected: vagrant: freebsd 14.0-RELEASE
[Nov 25 08:21:06]  INFO [localhost] Detecting OS of containers... 
[Nov 25 08:21:06]  INFO [localhost] Checking Scan Modes... 
[Nov 25 08:21:06]  INFO [localhost] Detecting Platforms... 
[Nov 25 08:21:06]  INFO [localhost] (1/1) vagrant is running on other
[Nov 25 08:21:06]  INFO [vagrant] Scanning OS pkg in fast-root mode


Scan Summary
================
vagrant	freebsd14.0-RELEASE	14 installed





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ vuls report
[Nov 25 08:21:51]  INFO [localhost] vuls-v0.24.6-build-20231125_081606_32a9cfa
[Nov 25 08:21:51]  INFO [localhost] Validating config...
[Nov 25 08:21:51]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/home/user/vuls/cve.sqlite3
[Nov 25 08:21:51]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/user/vuls/oval.sqlite3
[Nov 25 08:21:51]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/home/user/vuls/gost.sqlite3
[Nov 25 08:21:51]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/home/user/vuls/go-exploitdb.sqlite3
[Nov 25 08:21:51]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/home/user/vuls/go-msfdb.sqlite3
[Nov 25 08:21:51]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/home/user/vuls/go-kev.sqlite3
[Nov 25 08:21:51]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/home/user/vuls/go-cti.sqlite3
[Nov 25 08:21:51]  INFO [localhost] Loaded: /home/user/vuls/results/2023-11-25T08-21-06+0900
[Nov 25 08:21:51]  INFO [localhost] freebsd type. Skip OVAL and gost detection
[Nov 25 08:21:51]  INFO [localhost] vagrant: 0 CVEs are detected with CPE
[Nov 25 08:21:51]  INFO [localhost] vagrant: 0 PoC are detected
[Nov 25 08:21:51]  INFO [localhost] vagrant: 0 exploits are detected
[Nov 25 08:21:51]  INFO [localhost] vagrant: Known Exploited Vulnerabilities are detected for 0 CVEs
[Nov 25 08:21:51]  INFO [localhost] vagrant: Cyber Threat Intelligences are detected for 0 CVEs
[Nov 25 08:21:51]  INFO [localhost] vagrant: total 0 CVEs detected
[Nov 25 08:21:51]  INFO [localhost] vagrant: 0 CVEs filtered by --confidence-over=80

vagrant (freebsd14.0-RELEASE)
=============================
Total: 0 (Critical:0 High:0 Medium:0 Low:0 ?:0)
0/0 Fixed, 0 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
14 installed

No CVE-IDs are found in updatable packages.
14 installed
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

