### PR TITLE
feat(models/nvd): group by source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/vulsio/go-cti v0.0.5-0.20231017103759-59e022ddcd0e
-	github.com/vulsio/go-cve-dictionary v0.10.0
+	github.com/vulsio/go-cve-dictionary v0.10.1-0.20231208101928-9dd0d2707ae5
 	github.com/vulsio/go-exploitdb v0.4.7-0.20231017104626-201191637c48
 	github.com/vulsio/go-kev v0.1.4-0.20231017105707-8a9a218d280a
 	github.com/vulsio/go-msfdb v0.2.4-0.20231017104449-b705e6975831

--- a/go.sum
+++ b/go.sum
@@ -776,8 +776,8 @@ github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/X
 github.com/vbatts/tar-split v0.11.2 h1:Via6XqJr0hceW4wff3QRzD5gAk/tatMw/4ZA7cTlIME=
 github.com/vulsio/go-cti v0.0.5-0.20231017103759-59e022ddcd0e h1:UicE8zdH+TSTFeULX4jwYJgspK9ptMQX5zqdBsYsaPI=
 github.com/vulsio/go-cti v0.0.5-0.20231017103759-59e022ddcd0e/go.mod h1:A7G6SEdN1vChE56Auq8bw/XilEcumqxx2lb3cH8lCdQ=
-github.com/vulsio/go-cve-dictionary v0.10.0 h1:1lE1qoVy7UmFInftMfLWL/hQoWIcs9rnx+zILN5AvR4=
-github.com/vulsio/go-cve-dictionary v0.10.0/go.mod h1:ZY5Q+7ADz1RU0Wu7Q491+70+ZBuc4VN64xkvZFNPYuc=
+github.com/vulsio/go-cve-dictionary v0.10.1-0.20231208101928-9dd0d2707ae5 h1:8iIJwVDVUTzkXW+7cVTjeLmtgQETYYIA4w4qsKS8WTs=
+github.com/vulsio/go-cve-dictionary v0.10.1-0.20231208101928-9dd0d2707ae5/go.mod h1:ZY5Q+7ADz1RU0Wu7Q491+70+ZBuc4VN64xkvZFNPYuc=
 github.com/vulsio/go-exploitdb v0.4.7-0.20231017104626-201191637c48 h1:iT6/EfbOF0lEkCxKZEV9b0yAz1XIELTY1Y50gXyLVJ4=
 github.com/vulsio/go-exploitdb v0.4.7-0.20231017104626-201191637c48/go.mod h1:a8XVcfjrkHcbVCGxL6fo1KsgpShXNA5fxxjfpv+zGt8=
 github.com/vulsio/go-kev v0.1.4-0.20231017105707-8a9a218d280a h1:pdV8P4krLPt2xxbeDoUBDYjhA2OrPceNY1WVmc9Yz0E=

--- a/models/utils.go
+++ b/models/utils.go
@@ -93,46 +93,50 @@ func ConvertNvdToModel(cveID string, nvds []cvedict.Nvd) ([]CveContent, []Exploi
 			}
 		}
 
-		cweIDs := []string{}
-		for _, cid := range nvd.Cwes {
-			cweIDs = append(cweIDs, cid.CweID)
-		}
-
 		desc := []string{}
 		for _, d := range nvd.Descriptions {
 			desc = append(desc, d.Value)
 		}
 
+		m := map[string]CveContent{}
+		for _, cwe := range nvd.Cwes {
+			c := m[cwe.Source]
+			c.CweIDs = append(c.CweIDs, cwe.CweID)
+			m[cwe.Source] = c
+		}
 		for _, cvss2 := range nvd.Cvss2 {
-			cves = append(cves, CveContent{
-				Type:          Nvd,
-				CveID:         cveID,
-				Summary:       strings.Join(desc, "\n"),
-				Cvss2Score:    cvss2.BaseScore,
-				Cvss2Vector:   cvss2.VectorString,
-				Cvss2Severity: cvss2.Severity,
-				SourceLink:    fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", cveID),
-				// Cpes:          cpes,
-				CweIDs:       cweIDs,
-				References:   refs,
-				Published:    nvd.PublishedDate,
-				LastModified: nvd.LastModifiedDate,
-			})
+			c := m[cvss2.Source]
+			c.Cvss2Score = cvss2.BaseScore
+			c.Cvss2Vector = cvss2.VectorString
+			c.Cvss2Severity = cvss2.Severity
+			m[cvss2.Source] = c
 		}
 		for _, cvss3 := range nvd.Cvss3 {
+			c := m[cvss3.Source]
+			c.Cvss3Score = cvss3.BaseScore
+			c.Cvss3Vector = cvss3.VectorString
+			c.Cvss3Severity = cvss3.BaseSeverity
+			m[cvss3.Source] = c
+		}
+
+		for source, cont := range m {
 			cves = append(cves, CveContent{
 				Type:          Nvd,
 				CveID:         cveID,
 				Summary:       strings.Join(desc, "\n"),
-				Cvss3Score:    cvss3.BaseScore,
-				Cvss3Vector:   cvss3.VectorString,
-				Cvss3Severity: cvss3.BaseSeverity,
+				Cvss2Score:    cont.Cvss2Score,
+				Cvss2Vector:   cont.Cvss2Vector,
+				Cvss2Severity: cont.Cvss2Severity,
+				Cvss3Score:    cont.Cvss3Score,
+				Cvss3Vector:   cont.Cvss3Vector,
+				Cvss3Severity: cont.Cvss3Severity,
 				SourceLink:    fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", cveID),
 				// Cpes:          cpes,
-				CweIDs:       cweIDs,
+				CweIDs:       cont.CweIDs,
 				References:   refs,
 				Published:    nvd.PublishedDate,
 				LastModified: nvd.LastModifiedDate,
+				Optional:     map[string]string{"source": source},
 			})
 		}
 	}


### PR DESCRIPTION
# What did you implement:
Group CVSS and CWE in the NVD section in CveContent by source.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## before
```console
"cveContents": {
                "nvd": [
                    {
                        "type": "nvd",
                        "cveID": "CVE-2023-1194",
                        "title": "",
                        "summary": "An out-of-bounds (OOB) memory read flaw was found in parse_lease_state in the KSMBD implementation of the in-kernel samba server and CIFS in the Linux kernel. When an attacker sends the CREATE command with a malformed payload to KSMBD, due to a missing check of `NameOffset` in the `parse_lease_state()` function, the `create_context` object can access invalid memory.\nSe encontró una falla de lectura de memoria Out-Of-Bounds (OOB) en parse_lease_state en la implementación KSMBD del servidor samba en el kernel y CIFS en el kernel de Linux. Cuando un atacante envía el comando CREATE con un payload mal formada a KSMBD, debido a una verificación faltante de `NameOffset` en la función `parse_lease_state()`, el objeto `create_context` puede acceder a memoria no válida.",
                        "cvss2Score": 0,
                        "cvss2Vector": "",
                        "cvss2Severity": "",
                        "cvss3Score": 8.1,
                        "cvss3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H",
                        "cvss3Severity": "HIGH",
                        "sourceLink": "https://nvd.nist.gov/vuln/detail/CVE-2023-1194",
                        "references": [
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2023-1194",
                                "source": "secalert@redhat.com",
                                "tags": [
                                    "Third Party Advisory"
                                ]
                            },
                            {
                                "link": "https://bugzilla.redhat.com/show_bug.cgi?id=2154176",
                                "source": "secalert@redhat.com",
                                "tags": [
                                    "Issue Tracking",
                                    "Third Party Advisory"
                                ]
                            },
                            {
                                "link": "https://www.spinics.net/lists/stable-commits/msg303065.html",
                                "source": "secalert@redhat.com",
                                "tags": [
                                    "Mailing List",
                                    "Patch"
                                ]
                            }
                        ],
                        "cweIDs": [
                            "CWE-125",
                            "CWE-416"
                        ],
                        "published": "2023-11-03T08:15:07.49Z",
                        "lastModified": "2023-11-13T20:01:15.78Z"
                    },
                    {
                        "type": "nvd",
                        "cveID": "CVE-2023-1194",
                        "title": "",
                        "summary": "An out-of-bounds (OOB) memory read flaw was found in parse_lease_state in the KSMBD implementation of the in-kernel samba server and CIFS in the Linux kernel. When an attacker sends the CREATE command with a malformed payload to KSMBD, due to a missing check of `NameOffset` in the `parse_lease_state()` function, the `create_context` object can access invalid memory.\nSe encontró una falla de lectura de memoria Out-Of-Bounds (OOB) en parse_lease_state en la implementación KSMBD del servidor samba en el kernel y CIFS en el kernel de Linux. Cuando un atacante envía el comando CREATE con un payload mal formada a KSMBD, debido a una verificación faltante de `NameOffset` en la función `parse_lease_state()`, el objeto `create_context` puede acceder a memoria no válida.",
                        "cvss2Score": 0,
                        "cvss2Vector": "",
                        "cvss2Severity": "",
                        "cvss3Score": 7.1,
                        "cvss3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H",
                        "cvss3Severity": "HIGH",
                        "sourceLink": "https://nvd.nist.gov/vuln/detail/CVE-2023-1194",
                        "references": [
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2023-1194",
                                "source": "secalert@redhat.com",
                                "tags": [
                                    "Third Party Advisory"
                                ]
                            },
                            {
                                "link": "https://bugzilla.redhat.com/show_bug.cgi?id=2154176",
                                "source": "secalert@redhat.com",
                                "tags": [
                                    "Issue Tracking",
                                    "Third Party Advisory"
                                ]
                            },
                            {
                                "link": "https://www.spinics.net/lists/stable-commits/msg303065.html",
                                "source": "secalert@redhat.com",
                                "tags": [
                                    "Mailing List",
                                    "Patch"
                                ]
                            }
                        ],
                        "cweIDs": [
                            "CWE-125",
                            "CWE-416"
                        ],
                        "published": "2023-11-03T08:15:07.49Z",
                        "lastModified": "2023-11-13T20:01:15.78Z"
                    }
                ],
```

## after
```console
"cveContents": {
                "nvd": [
                    {
                        "type": "nvd",
                        "cveID": "CVE-2023-1194",
                        "title": "",
                        "summary": "An out-of-bounds (OOB) memory read flaw was found in parse_lease_state in the KSMBD implementation of the in-kernel samba server and CIFS in the Linux kernel. When an attacker sends the CREATE command with a malformed payload to KSMBD, due to a missing check of `NameOffset` in the `parse_lease_state()` function, the `create_context` object can access invalid memory.\nSe encontró una falla de lectura de memoria Out-Of-Bounds (OOB) en parse_lease_state en la implementación KSMBD del servidor samba en el kernel y CIFS en el kernel de Linux. Cuando un atacante envía el comando CREATE con un payload mal formada a KSMBD, debido a una verificación faltante de `NameOffset` en la función `parse_lease_state()`, el objeto `create_context` puede acceder a memoria no válida.",
                        "cvss2Score": 0,
                        "cvss2Vector": "",
                        "cvss2Severity": "",
                        "cvss3Score": 8.1,
                        "cvss3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H",
                        "cvss3Severity": "HIGH",
                        "sourceLink": "https://nvd.nist.gov/vuln/detail/CVE-2023-1194",
                        "references": [
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2023-1194",
                                "source": "secalert@redhat.com",
                                "tags": [
                                    "Third Party Advisory"
                                ]
                            },
                            {
                                "link": "https://bugzilla.redhat.com/show_bug.cgi?id=2154176",
                                "source": "secalert@redhat.com",
                                "tags": [
                                    "Issue Tracking",
                                    "Third Party Advisory"
                                ]
                            },
                            {
                                "link": "https://www.spinics.net/lists/stable-commits/msg303065.html",
                                "source": "secalert@redhat.com",
                                "tags": [
                                    "Mailing List",
                                    "Patch"
                                ]
                            }
                        ],
                        "cweIDs": [
                            "CWE-125"
                        ],
                        "published": "2023-11-03T08:15:07.49Z",
                        "lastModified": "2023-11-13T20:01:15.78Z",
                        "optional": {
                            "source": "nvd@nist.gov"
                        }
                    },
                    {
                        "type": "nvd",
                        "cveID": "CVE-2023-1194",
                        "title": "",
                        "summary": "An out-of-bounds (OOB) memory read flaw was found in parse_lease_state in the KSMBD implementation of the in-kernel samba server and CIFS in the Linux kernel. When an attacker sends the CREATE command with a malformed payload to KSMBD, due to a missing check of `NameOffset` in the `parse_lease_state()` function, the `create_context` object can access invalid memory.\nSe encontró una falla de lectura de memoria Out-Of-Bounds (OOB) en parse_lease_state en la implementación KSMBD del servidor samba en el kernel y CIFS en el kernel de Linux. Cuando un atacante envía el comando CREATE con un payload mal formada a KSMBD, debido a una verificación faltante de `NameOffset` en la función `parse_lease_state()`, el objeto `create_context` puede acceder a memoria no válida.",
                        "cvss2Score": 0,
                        "cvss2Vector": "",
                        "cvss2Severity": "",
                        "cvss3Score": 7.1,
                        "cvss3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:H",
                        "cvss3Severity": "HIGH",
                        "sourceLink": "https://nvd.nist.gov/vuln/detail/CVE-2023-1194",
                        "references": [
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2023-1194",
                                "source": "secalert@redhat.com",
                                "tags": [
                                    "Third Party Advisory"
                                ]
                            },
                            {
                                "link": "https://bugzilla.redhat.com/show_bug.cgi?id=2154176",
                                "source": "secalert@redhat.com",
                                "tags": [
                                    "Issue Tracking",
                                    "Third Party Advisory"
                                ]
                            },
                            {
                                "link": "https://www.spinics.net/lists/stable-commits/msg303065.html",
                                "source": "secalert@redhat.com",
                                "tags": [
                                    "Mailing List",
                                    "Patch"
                                ]
                            }
                        ],
                        "cweIDs": [
                            "CWE-416"
                        ],
                        "published": "2023-11-03T08:15:07.49Z",
                        "lastModified": "2023-11-13T20:01:15.78Z",
                        "optional": {
                            "source": "secalert@redhat.com"
                        }
                    }
                ],
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://github.com/vulsio/go-cve-dictionary/pull/349

