### PR TITLE
Do not bail if OVAL is empty

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -548,7 +548,7 @@ func detectPkgsCvesWithOval(cnf config.GovalDictConf, r *models.ScanResult, logO
 			return err
 		}
 		if !ok {
-			return xerrors.Errorf("OVAL entries of %s %s are not found. Fetch OVAL before reporting. For details, see `https://github.com/vulsio/goval-dictionary#usage`", r.Family, r.Release)
+			logging.Log.Warnf("OVAL entries of %s %s are not found. Fetch OVAL before reporting. For details, see `https://github.com/vulsio/goval-dictionary#usage`", r.Family, r.Release)
 		}
 	}
 


### PR DESCRIPTION
Despite RHEL 8.9 and 9.3 having been released for over a month, RedHat hasn't published OVAL for them. This meant that running `vul report` after scanning a host running these versions will fail with "OVAL entries of redhat 8.9 are not found.". But other CVE sources may still be available. This change makes empty OVAL a warning instead of a hard error, so a report can still be generated.