### PR TITLE
fix(scanner): yum makecache was not working when scanning redhat

### DIFF
--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -420,6 +420,10 @@ func (o *redhatBase) scanPackages() (err error) {
 		return xerrors.Errorf("Failed to scan installed packages: %w", err)
 	}
 
+	if err := o.yumMakeCache(); err != nil {
+		return xerrors.Errorf("Failed to execute `yum makecache`: %w", err)
+	}
+
 	if o.EnabledDnfModules, err = o.detectEnabledDnfModules(); err != nil {
 		return xerrors.Errorf("Failed to detect installed dnf modules: %w", err)
 	}
@@ -645,10 +649,6 @@ func (o *redhatBase) yumMakeCache() error {
 }
 
 func (o *redhatBase) scanUpdatablePackages() (models.Packages, error) {
-	if err := o.yumMakeCache(); err != nil {
-		return nil, xerrors.Errorf("Failed to `yum makecache`: %w", err)
-	}
-
 	isDnf := o.exec(util.PrependProxyEnv(`repoquery --version | grep dnf`), o.sudo.repoquery()).isSuccess()
 	cmd := `repoquery --all --pkgnarrow=updates --qf='%{NAME} %{EPOCH} %{VERSION} %{RELEASE} %{REPO}'`
 	if isDnf {


### PR DESCRIPTION
# What did you implement:

When scanning for redhat, there was an error in the execution part of the following command.
```
dnf --nogpgcheck --cacheonly --color=never --quiet module list --enabled
```

The cacheonly flag was specified for this command, so that module information was retrieved by referencing the cache.
The scan was failing because the `dnf --nogpgcheck --cacheonly --color=never --quiet module list --enabled` was executed before the `yum makecache` command to create the cache was executed.
This problem does not occur if the cache is created before the scan.
```
[root@ip-192-168-0-193 vuls-saas]# yum clean all
Updating Subscription Management repositories.
25 files removed
[root@ip-192-168-0-193 vuls-saas]# ./vuls scan
[Dec 14 06:00:47]  INFO [localhost] vuls-v0.24.4-build-b9db541
[Dec 14 06:00:47]  INFO [localhost] Start scanning
[Dec 14 06:00:47]  INFO [localhost] config: /opt/vuls-saas/config.toml
[Dec 14 06:00:47]  INFO [localhost] Validating config...
[Dec 14 06:00:47]  INFO [localhost] Detecting Server/Container OS...
[Dec 14 06:00:47]  INFO [localhost] Detecting OS of servers...
[Dec 14 06:00:47]  INFO [localhost] (1/1) Detected: ip-192-168-0-193_ap-northeast-1_compute_internal: redhat 9.3
[Dec 14 06:00:47]  INFO [localhost] Detecting OS of containers...
[Dec 14 06:00:47]  INFO [localhost] Checking Scan Modes...
[Dec 14 06:00:47]  INFO [localhost] Detecting Platforms...
[Dec 14 06:00:48]  INFO [localhost] (1/1) ip-192-168-0-193_ap-northeast-1_compute_internal is running on aws
[Dec 14 06:00:48]  INFO [ip-192-168-0-193_ap-northeast-1_compute_internal] Scanning OS pkg in fast-root mode
[Dec 14 06:00:49] ERROR [localhost] Error on ip-192-168-0-193_ap-northeast-1_compute_internal, err: [Failed to detect installed dnf modules:
    github.com/future-architect/vuls/scanner.(*redhatBase).scanPackages
        /home/runner/work/futurevuls-backend/futurevuls-backend/scanner-src/scanner/redhatbase.go:424
  - Failed to dnf module list: execResult: servername:
      cmd: dnf --nogpgcheck --cacheonly --color=never --quiet module list --enabled
      exitstatus: 1
      stdout:
      stderr: Error: Cache-only enabled but no cache for 'rhel-9-appstream-rhui-rpms'

      err: exit status 1:
    github.com/future-architect/vuls/scanner.(*redhatBase).detectEnabledDnfModules
        /home/runner/work/futurevuls-backend/futurevuls-backend/scanner-src/scanner/redhatbase.go:949]


Scan Summary
================
ip-192-168-0-193_ap-northeast-1_compute_internal        Error           Use configtest subcommand or scan with --debug to view the details


[Dec 14 06:00:49] ERROR [localhost] Failed to scan: Failed to scan. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/runner/work/futurevuls-backend/futurevuls-backend/scanner-src/scanner/scanner.go:110
  - An error occurred on [ip-192-168-0-193_ap-northeast-1_compute_internal]
```

So I changed the `dnf --nogpgcheck --cacheonly --color=never --quiet module list --enabled` to be executed after yum makecache.

_**Note that if you run the scan offline, yum makecache will fail, so the scan will also fail.**_

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
[root@ip-192-168-0-193 vuls-saas]# yum clean all
Updating Subscription Management repositories.
25 files removed
[root@ip-192-168-0-193 vuls-saas]# ./vuls_test scan
[Dec 14 06:20:19]  INFO [localhost] vuls-`make build` or `make install` will show the version-
[Dec 14 06:20:19]  INFO [localhost] Start scanning
[Dec 14 06:20:19]  INFO [localhost] config: /opt/vuls-saas/config.toml
[Dec 14 06:20:19]  INFO [localhost] Validating config...
[Dec 14 06:20:19]  INFO [localhost] Detecting Server/Container OS...
[Dec 14 06:20:19]  INFO [localhost] Detecting OS of servers...
[Dec 14 06:20:19]  INFO [localhost] (1/1) Detected: ip-192-168-0-193_ap-northeast-1_compute_internal: redhat 9.3
[Dec 14 06:20:19]  INFO [localhost] Detecting OS of containers...
[Dec 14 06:20:19]  INFO [localhost] Checking Scan Modes...
[Dec 14 06:20:19]  INFO [localhost] Detecting Platforms...
[Dec 14 06:20:19]  INFO [localhost] (1/1) ip-192-168-0-193_ap-northeast-1_compute_internal is running on aws
[Dec 14 06:20:19]  INFO [ip-192-168-0-193_ap-northeast-1_compute_internal] Scanning OS pkg in fast-root mode
[Dec 14 06:20:43]  INFO [ip-192-168-0-193_ap-northeast-1_compute_internal] Scanning listen port...
[Dec 14 06:20:43]  INFO [ip-192-168-0-193_ap-northeast-1_compute_internal] Using Port Scanner: Vuls built-in Scanner


Scan Summary
================
ip-192-168-0-193_ap-northeast-1_compute_internal        redhat9.3       430 installed, 21 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

