### PR TITLE
chore(deps): bump github.com/CycloneDX/cyclonedx-go from 0.7.2 to 0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/3th1nk/cidr v0.2.0
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/BurntSushi/toml v1.3.2
-	github.com/CycloneDX/cyclonedx-go v0.7.2
+	github.com/CycloneDX/cyclonedx-go v0.8.0
 	github.com/Ullaakut/nmap/v2 v2.2.2
 	github.com/aquasecurity/go-dep-parser v0.0.0-20221114145626-35ef808901e8
 	github.com/aquasecurity/trivy v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CycloneDX/cyclonedx-go v0.7.2 h1:kKQ0t1dPOlugSIYVOMiMtFqeXI2wp/f5DBIdfux8gnQ=
-github.com/CycloneDX/cyclonedx-go v0.7.2/go.mod h1:K2bA+324+Og0X84fA8HhN2X066K7Bxz4rpMQ4ZhjtSk=
+github.com/CycloneDX/cyclonedx-go v0.8.0 h1:FyWVj6x6hoJrui5uRQdYZcSievw3Z32Z88uYzG/0D6M=
+github.com/CycloneDX/cyclonedx-go v0.8.0/go.mod h1:K2bA+324+Og0X84fA8HhN2X066K7Bxz4rpMQ4ZhjtSk=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=

--- a/reporter/sbom/cyclonedx.go
+++ b/reporter/sbom/cyclonedx.go
@@ -36,11 +36,14 @@ func GenerateCycloneDX(format cdx.BOMFileFormat, r models.ScanResult) ([]byte, e
 func cdxMetadata(result models.ScanResult) *cdx.Metadata {
 	metadata := cdx.Metadata{
 		Timestamp: result.ReportedAt.Format(time.RFC3339),
-		Tools: &[]cdx.Tool{
-			{
-				Vendor:  "future-architect",
-				Name:    "vuls",
-				Version: fmt.Sprintf("%s-%s", result.ReportedVersion, result.ReportedRevision),
+		Tools: &cdx.ToolsChoice{
+			Components: &[]cdx.Component{
+				{
+					Type:    cdx.ComponentTypeApplication,
+					Author:  "future-architect",
+					Name:    "vuls",
+					Version: fmt.Sprintf("%s-%s", result.ReportedVersion, result.ReportedRevision),
+				},
 			},
 		},
 		Component: &cdx.Component{


### PR DESCRIPTION
# What did you implement:

- This PR replaces #1809 for compatibility
- Array of `metadata.tools` is deprecated in CycloneDX spec v1.5

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
$ vuls report -to-localfile -format-cyclonedx-json
or 
$ vuls report -to-localfile -format-cyclonedx-xml
```

check cyclondx

## before

```
...
  "metadata": {
    "timestamp": "2023-05-30T13:02:36+09:00",
    "tools": [
      {
        "vendor": "future-architect",
        "name": "vuls",
        "version": "-"
      }
    ],
...
```

## after

```
...
  "metadata": {
    "timestamp": "2024-01-12T13:44:56+09:00",
    "tools": {
      "components": [
        {
          "type": "application",
          "author": "future-architect",
          "name": "vuls",
          "version": "-"
        }
      ]
    },
...
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

https://cyclonedx.org/docs/1.5/json/#metadata_tools