### PR TITLE
feat(config/windows): remove unnecessary os.Stat() to cabPath

### DIFF
--- a/config/windows.go
+++ b/config/windows.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"os"
-
 	"golang.org/x/xerrors"
 )
 
@@ -15,11 +13,7 @@ type WindowsConf struct {
 // Validate validates configuration
 func (c *WindowsConf) Validate() []error {
 	switch c.ServerSelection {
-	case 0, 1, 2:
-	case 3:
-		if _, err := os.Stat(c.CabPath); err != nil {
-			return []error{xerrors.Errorf("%s does not exist. err: %w", c.CabPath, err)}
-		}
+	case 0, 1, 2, 3:
 	default:
 		return []error{xerrors.Errorf("ServerSelection: %d does not support . Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-uamg/07e2bfa4-6795-4189-b007-cc50b476181a", c.ServerSelection)}
 	}


### PR DESCRIPTION
# What did you implement:

Removed cabPath validation for remote scanning using cab files

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

