### PR TITLE
fix(scanner/windows): support when default shell is powershell

### DIFF
--- a/scanner/executil.go
+++ b/scanner/executil.go
@@ -249,7 +249,7 @@ func sshExecExternal(c config.ServerInfo, cmdstr string, sudo bool) (result exec
 	var cmd *ex.Cmd
 	switch c.Distro.Family {
 	case constant.Windows:
-		cmd = ex.Command(sshBinaryPath, append(args, "powershell.exe", "-NoProfile", "-NonInteractive", fmt.Sprintf(`"%s`, cmdstr))...)
+		cmd = ex.Command(sshBinaryPath, append(args, cmdstr)...)
 	default:
 		cmd = ex.Command(sshBinaryPath, append(args, fmt.Sprintf("stty cols 1000; %s", cmdstr))...)
 	}

--- a/scanner/windows_test.go
+++ b/scanner/windows_test.go
@@ -306,20 +306,15 @@ SystemType : x64-based PC`,
 }
 
 func Test_parseRegistry(t *testing.T) {
-	type args struct {
-		stdout string
-		arch   string
-	}
 	tests := []struct {
 		name    string
-		args    args
+		args    string
 		want    osInfo
 		wantErr bool
 	}{
 		{
 			name: "happy",
-			args: args{
-				stdout: `
+			args: `
 ProductName               : Windows 10 Pro
 CurrentVersion            : 6.3
 CurrentMajorVersionNumber : 10
@@ -327,9 +322,10 @@ CurrentMinorVersionNumber : 0
 CurrentBuildNumber        : 19044
 UBR                       : 2364
 EditionID                 : Professional
-InstallationType          : Client`,
-				arch: "AMD64",
-			},
+InstallationType          : Client
+
+PROCESSOR_ARCHITECTURE : AMD64
+`,
 			want: osInfo{
 				productName:      "Windows 10 Pro",
 				version:          "10.0",
@@ -344,7 +340,7 @@ InstallationType          : Client`,
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseRegistry(tt.args.stdout, tt.args.arch)
+			got, err := parseRegistry(tt.args)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseRegistry() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
# What did you implement:

Fixes #1835 

The issue of failing to identify the OS when the default shell when connecting via SSH is powershell.exe will be fixed by identifying the shell that executes the command and reviewing the escaping of each command.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## remote (default shell: cmd.exe)
### before
```console
$ vuls scan
[Feb  2 12:10:40]  INFO [localhost] vuls-0.24.8-bbf53c7639b266e3a658e8f0a8b2ff7bf17e8e62-2023-12-17T20:41:46Z
[Feb  2 12:10:40]  INFO [localhost] Start scanning
[Feb  2 12:10:40]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Feb  2 12:10:40]  INFO [localhost] Validating config...
[Feb  2 12:10:40]  INFO [localhost] Detecting Server/Container OS... 
[Feb  2 12:10:40]  INFO [localhost] Detecting OS of servers... 
[Feb  2 12:10:44]  INFO [localhost] (1/1) Detected: vagrant: windows Windows Server 2022
[Feb  2 12:10:44]  INFO [localhost] Detecting OS of containers... 
[Feb  2 12:10:44]  INFO [localhost] Checking Scan Modes... 
[Feb  2 12:10:44]  INFO [localhost] Detecting Platforms... 
[Feb  2 12:10:55]  INFO [localhost] (1/1) vagrant is running on other


Scan Summary
================
vagrant	windowsWindows Server 2022	5 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### after
```console
$ vuls scan
[Feb  2 12:08:19]  INFO [localhost] vuls-v0.24.8-build-20240202_114014_a865324
[Feb  2 12:08:19]  INFO [localhost] Start scanning
[Feb  2 12:08:19]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Feb  2 12:08:19]  INFO [localhost] Validating config...
[Feb  2 12:08:19]  INFO [localhost] Detecting Server/Container OS... 
[Feb  2 12:08:19]  INFO [localhost] Detecting OS of servers... 
[Feb  2 12:08:22]  INFO [localhost] (1/1) Detected: vagrant: windows Windows Server 2022
[Feb  2 12:08:22]  INFO [localhost] Detecting OS of containers... 
[Feb  2 12:08:22]  INFO [localhost] Checking Scan Modes... 
[Feb  2 12:08:22]  INFO [localhost] Detecting Platforms... 
[Feb  2 12:08:24]  INFO [localhost] (1/1) vagrant is running on other


Scan Summary
================
vagrant	windowsWindows Server 2022	5 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

## remote (default shell: powershell)
### before
```console
$ vuls scan
[Feb  2 12:11:41]  INFO [localhost] vuls-0.24.8-bbf53c7639b266e3a658e8f0a8b2ff7bf17e8e62-2023-12-17T20:41:46Z
[Feb  2 12:11:41]  INFO [localhost] Start scanning
[Feb  2 12:11:41]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Feb  2 12:11:41]  INFO [localhost] Validating config...
[Feb  2 12:11:41]  INFO [localhost] Detecting Server/Container OS... 
[Feb  2 12:11:41]  INFO [localhost] Detecting OS of servers... 
[Feb  2 12:12:32] ERROR [localhost] (1/1) Failed: vagrant, err: [Unknown OS Type:
    github.com/future-architect/vuls/scanner.Scanner.detectOS
        /home/runner/work/vuls/vuls/scanner/scanner.go:800]
[Feb  2 12:12:32] ERROR [localhost] Failed to scan: Failed to init servers. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/runner/work/vuls/vuls/scanner/scanner.go:93
  - No scannable host OS:
    github.com/future-architect/vuls/scanner.Scanner.initServers
        /home/runner/work/vuls/vuls/scanner/scanner.go:300
```

### after
```console
$ vuls scan
[Feb  2 12:13:11]  INFO [localhost] vuls-v0.24.8-build-20240202_114014_a865324
[Feb  2 12:13:11]  INFO [localhost] Start scanning
[Feb  2 12:13:11]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Feb  2 12:13:11]  INFO [localhost] Validating config...
[Feb  2 12:13:11]  INFO [localhost] Detecting Server/Container OS... 
[Feb  2 12:13:11]  INFO [localhost] Detecting OS of servers... 
[Feb  2 12:13:17]  INFO [localhost] (1/1) Detected: vagrant: windows Windows Server 2022
[Feb  2 12:13:17]  INFO [localhost] Detecting OS of containers... 
[Feb  2 12:13:17]  INFO [localhost] Checking Scan Modes... 
[Feb  2 12:13:17]  INFO [localhost] Detecting Platforms... 
[Feb  2 12:13:34]  INFO [localhost] (1/1) vagrant is running on other


Scan Summary
================
vagrant	windowsWindows Server 2022	5 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

## local(default shell: cmd.exe)
### before
```console
vagrant@WIN-HL763J091HK C:\Users\vagrant>vuls.exe scan
time="Feb  2 03:03:13" level=info msg="vuls-0.24.8-bbf53c7639b266e3a658e8f0a8b2ff7bf17e8e62-2023-12-17T20:41:46Z" 
time="Feb  2 03:03:13" level=info msg="Start scanning" 
time="Feb  2 03:03:13" level=info msg="config: C:\\Users\\vagrant\\config.toml" 
time="Feb  2 03:03:13" level=info msg="Validating config..." 
time="Feb  2 03:03:13" level=info msg="Detecting Server/Container OS... " 
time="Feb  2 03:03:13" level=info msg="Detecting OS of servers... " 
time="Feb  2 03:03:17" level=info msg="(1/1) Detected: localhost: windows Windows Server 2022" 
time="Feb  2 03:03:17" level=info msg="Detecting OS of containers... " 
time="Feb  2 03:03:17" level=info msg="Checking Scan Modes... " 
time="Feb  2 03:03:17" level=info msg="Detecting Platforms... " 
time="Feb  2 03:03:27" level=info msg="(1/1) localhost is running on other" 


Scan Summary
================
localhost       windowsWindows Server 2022      5 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### after
```console
vagrant@WIN-HL763J091HK C:\Users\vagrant>vuls.exe scan
time="Feb  2 02:59:33" level=info msg="vuls-v0.24.8-build-20240202_114712_a865324" 
time="Feb  2 02:59:33" level=info msg="Start scanning" 
time="Feb  2 02:59:33" level=info msg="config: C:\\Users\\vagrant\\config.toml" 
time="Feb  2 02:59:33" level=info msg="Validating config..." 
time="Feb  2 02:59:33" level=info msg="Detecting Server/Container OS... " 
time="Feb  2 02:59:33" level=info msg="Detecting OS of servers... " 
time="Feb  2 02:59:42" level=info msg="(1/1) Detected: localhost: windows Windows Server 2022" 
time="Feb  2 02:59:42" level=info msg="Detecting OS of containers... " 
time="Feb  2 02:59:42" level=info msg="Checking Scan Modes... " 
time="Feb  2 02:59:42" level=info msg="Detecting Platforms... " 
time="Feb  2 02:59:59" level=info msg="(1/1) localhost is running on other" 


Scan Summary
================
localhost       windowsWindows Server 2022      5 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

## local (default shell: powershell)
### before
```console
PS C:\Users\vagrant> .\vuls.exe scan
time="Feb  2 03:06:34" level=info msg="vuls-0.24.8-bbf53c7639b266e3a658e8f0a8b2ff7bf17e8e62-2023-12-17T20:41:46Z" 
time="Feb  2 03:06:34" level=info msg="Start scanning" 
time="Feb  2 03:06:34" level=info msg="config: C:\\Users\\vagrant\\config.toml"
time="Feb  2 03:06:34" level=info msg="Validating config..."
time="Feb  2 03:06:34" level=info msg="Detecting Server/Container OS... "
time="Feb  2 03:06:34" level=info msg="Detecting OS of servers... "
time="Feb  2 03:06:38" level=info msg="(1/1) Detected: localhost: windows Windows Server 2022" 
time="Feb  2 03:06:38" level=info msg="Detecting OS of containers... " 
time="Feb  2 03:06:38" level=info msg="Checking Scan Modes... "
time="Feb  2 03:06:38" level=info msg="Detecting Platforms... "
time="Feb  2 03:06:50" level=info msg="(1/1) localhost is running on other" 


Scan Summary
================
localhost       windowsWindows Server 2022      5 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### after
```console
PS C:\Users\vagrant> .\vuls.exe scan
time="Feb  2 03:04:54" level=info msg="vuls-v0.24.8-build-20240202_114712_a865324" 
time="Feb  2 03:04:54" level=info msg="Start scanning" 
time="Feb  2 03:04:54" level=info msg="config: C:\\Users\\vagrant\\config.toml"
time="Feb  2 03:04:54" level=info msg="Validating config..."
time="Feb  2 03:04:54" level=info msg="Detecting Server/Container OS... "
time="Feb  2 03:04:54" level=info msg="Detecting OS of servers... "
time="Feb  2 03:04:58" level=info msg="(1/1) Detected: localhost: windows Windows Server 2022" 
time="Feb  2 03:04:58" level=info msg="Detecting OS of containers... " 
time="Feb  2 03:04:58" level=info msg="Checking Scan Modes... "
time="Feb  2 03:04:58" level=info msg="Detecting Platforms... "
time="Feb  2 03:05:11" level=info msg="(1/1) localhost is running on other" 


Scan Summary
================
localhost       windowsWindows Server 2022      5 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```
# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

