### PR TITLE
fix(ci): use go version of go.mod

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,6 +37,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: go.mod
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
# What did you implement:

install go version of go.mod

>    2024/02/28 05:28:21 Autobuilder was built with go1.21.7, environment has go1.20.14
  2024/02/28 05:28:21 LGTM_SRC is /home/runner/work/vuls/vuls
  2024/02/28 05:28:21 Found go.mod, enabling go modules
  2024/02/28 05:28:21 The go.mod file requires version v1.21 of Go, but version v1.20.14 is installed. Consider adding an actions/setup-go step to your workflow.
  go: go.mod file indicates go 1.21, but maximum version supported by tidy is 1.20

https://github.com/future-architect/vuls/actions/runs/8075744361/job/22063101584?pr=1856

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
>    2024/02/28 07:07:58 Autobuilder was built with go1.21.7, environment has go1.21.7

https://github.com/future-architect/vuls/actions/runs/8076575378/job/22065274478?pr=1858

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

