### PR TITLE
Avoid to use sync.Once inside trivy javadb Updater

### DIFF
--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -21,6 +21,7 @@ import (
 	"github.com/future-architect/vuls/logging"
 )
 
+// UpdateJavaDB updates Trivy Java DB
 func UpdateJavaDB(trivyOpts config.TrivyOpts, noProgress bool) error {
 	repo := fmt.Sprintf("%s:%d", trivyOpts.TrivyJavaDBRepository, db.SchemaVersion)
 	dbDir := filepath.Join(trivyOpts.TrivyCacheDBDir, "java-db")

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -30,9 +30,10 @@ func UpdateJavaDB(trivyOpts config.TrivyOpts, noProgress bool) error {
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return xerrors.Errorf("Failed to get Java DB metadata. err: %w", err)
-		} else if trivyOpts.TrivySkipJavaDBUpdate {
+		}
+		if trivyOpts.TrivySkipJavaDBUpdate {
 			logging.Log.Error("Could not skip, the first run cannot skip downloading Java DB")
-			return xerrors.New("'--skip-java-db-update' cannot be specified on the first run")
+			return xerrors.New("'--trivy-skip-java-db-update' cannot be specified on the first run")
 		}
 	}
 

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -89,6 +89,7 @@ func (client *DBClient) Close() error {
 	return client.driver.Close()
 }
 
+// SearchBySHA1 searches Jar Property by SHA1
 func (client *DBClient) SearchBySHA1(sha1 string) (jar.Properties, error) {
 	index, err := client.driver.SelectIndexBySha1(sha1)
 	if err != nil {

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -80,6 +80,7 @@ func NewClient(cacheDBDir string) (*DBClient, error) {
 	return &DBClient{driver: driver}, nil
 }
 
+// Close closes Trivy Java DB Client
 func (client *DBClient) Close() error {
 	if client == nil {
 		return nil

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -94,8 +94,9 @@ func (client *DBClient) SearchBySHA1(sha1 string) (jar.Properties, error) {
 	index, err := client.driver.SelectIndexBySha1(sha1)
 	if err != nil {
 		return jar.Properties{}, xerrors.Errorf("Failed to select from Trivy Java DB. err: %w", err)
-	} else if index.ArtifactID == "" {
-		return jar.Properties{}, xerrors.Errorf("digest %s: %w", sha1, jar.ArtifactNotFoundErr)
+	}
+	if index.ArtifactID == "" {
+		return jar.Properties{}, xerrors.Errorf("Failed to search ArtifactID by digest %s. err: %w", sha1, jar.ArtifactNotFoundErr)
 	}
 	return jar.Properties{
 		GroupID:    index.GroupID,

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -38,6 +38,7 @@ func UpdateJavaDB(trivyOpts config.TrivyOpts, noProgress bool) error {
 
 	if (meta.Version != db.SchemaVersion || meta.NextUpdate.Before(time.Now().UTC())) && !trivyOpts.TrivySkipJavaDBUpdate {
 		// Download DB
+		repo := fmt.Sprintf("%s:%d", trivyOpts.TrivyJavaDBRepository, db.SchemaVersion)
 		logging.Log.Infof("Trivy Java DB Repository: %s", repo)
 		logging.Log.Info("Downloading Trivy Java DB...")
 

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -58,7 +58,7 @@ func UpdateJavaDB(trivyOpts config.TrivyOpts, noProgress bool) error {
 		// Update DownloadedAt
 		meta.DownloadedAt = time.Now().UTC()
 		if err = metac.Update(meta); err != nil {
-			return xerrors.Errorf("Failed to update Trivy Java DB metadata. erro: %w", err)
+			return xerrors.Errorf("Failed to update Trivy Java DB metadata. err: %w", err)
 		}
 	}
 

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -1,6 +1,7 @@
 //go:build !scanner
 // +build !scanner
 
+// Package javadb implements functions that wrap trivy-java-db module.
 package javadb
 
 import (

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -44,7 +44,7 @@ func UpdateJavaDB(trivyOpts config.TrivyOpts, noProgress bool) error {
 
 		var a *oci.Artifact
 		if a, err = oci.NewArtifact(repo, noProgress, types.RegistryOptions{}); err != nil {
-			return xerrors.Errorf("oci error: %w", err)
+			return xerrors.Errorf("Failed to new oci artifact. err: %w", err)
 		}
 		if err = a.Download(context.Background(), dbDir, oci.DownloadOption{MediaType: "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"}); err != nil {
 			return xerrors.Errorf("Failed to download Trivy Java DB. err: %w", err)

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -71,6 +71,7 @@ type DBClient struct {
 	driver db.DB
 }
 
+// NewClient returns Trivy Java DB Client
 func NewClient(cacheDBDir string) (*DBClient, error) {
 	driver, err := db.New(filepath.Join(cacheDBDir, "java-db"))
 	if err != nil {

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -67,6 +67,7 @@ func UpdateJavaDB(trivyOpts config.TrivyOpts, noProgress bool) error {
 	return nil
 }
 
+// DBClient is Trivy Java DB Client
 type DBClient struct {
 	driver db.DB
 }

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -1,0 +1,100 @@
+//go:build !scanner
+// +build !scanner
+
+package javadb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/aquasecurity/go-dep-parser/pkg/java/jar"
+	"github.com/aquasecurity/trivy-java-db/pkg/db"
+	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/oci"
+	"golang.org/x/xerrors"
+
+	"github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/logging"
+)
+
+func UpdateJavaDB(trivyOpts config.TrivyOpts, noProgress bool) error {
+	repo := fmt.Sprintf("%s:%d", trivyOpts.TrivyJavaDBRepository, db.SchemaVersion)
+	dbDir := filepath.Join(trivyOpts.TrivyCacheDBDir, "java-db")
+
+	metac := db.NewMetadata(dbDir)
+	meta, err := metac.Get()
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return xerrors.Errorf("Failed to get Java DB metadata. err: %w", err)
+		} else if trivyOpts.TrivySkipJavaDBUpdate {
+			logging.Log.Error("Could not skip, the first run cannot skip downloading Java DB")
+			return xerrors.New("'--skip-java-db-update' cannot be specified on the first run")
+		}
+	}
+
+	if (meta.Version != db.SchemaVersion || meta.NextUpdate.Before(time.Now().UTC())) && !trivyOpts.TrivySkipJavaDBUpdate {
+		// Download DB
+		logging.Log.Infof("Trivy Java DB Repository: %s", repo)
+		logging.Log.Info("Downloading Trivy Java DB...")
+
+		var a *oci.Artifact
+		if a, err = oci.NewArtifact(repo, noProgress, types.RegistryOptions{}); err != nil {
+			return xerrors.Errorf("oci error: %w", err)
+		}
+		if err = a.Download(context.Background(), dbDir, oci.DownloadOption{MediaType: "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"}); err != nil {
+			return xerrors.Errorf("Failed to download Trivy Java DB. err: %w", err)
+		}
+
+		// Parse the newly downloaded metadata.json
+		meta, err = metac.Get()
+		if err != nil {
+			return xerrors.Errorf("Failed to get Trivy Java DB metadata. err: %w", err)
+		}
+
+		// Update DownloadedAt
+		meta.DownloadedAt = time.Now().UTC()
+		if err = metac.Update(meta); err != nil {
+			return xerrors.Errorf("Failed to update Trivy Java DB metadata. erro: %w", err)
+		}
+	}
+
+	return nil
+}
+
+type DBClient struct {
+	driver db.DB
+}
+
+func NewClient(cacheDBDir string) (*DBClient, error) {
+	driver, err := db.New(filepath.Join(cacheDBDir, "java-db"))
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to open Trivy Java DB. err: %w", err)
+	}
+	return &DBClient{driver: driver}, nil
+}
+
+func (client *DBClient) Close() error {
+	if client == nil {
+		return nil
+	}
+
+	return client.driver.Close()
+}
+
+func (client *DBClient) SearchBySHA1(sha1 string) (jar.Properties, error) {
+	index, err := client.driver.SelectIndexBySha1(sha1)
+	if err != nil {
+		return jar.Properties{}, xerrors.Errorf("Failed to select from Trivy Java DB. err: %w", err)
+	} else if index.ArtifactID == "" {
+		return jar.Properties{}, xerrors.Errorf("digest %s: %w", sha1, jar.ArtifactNotFoundErr)
+	}
+	return jar.Properties{
+		GroupID:    index.GroupID,
+		ArtifactID: index.ArtifactID,
+		Version:    index.Version,
+	}, nil
+}

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -23,7 +23,6 @@ import (
 
 // UpdateJavaDB updates Trivy Java DB
 func UpdateJavaDB(trivyOpts config.TrivyOpts, noProgress bool) error {
-	repo := fmt.Sprintf("%s:%d", trivyOpts.TrivyJavaDBRepository, db.SchemaVersion)
 	dbDir := filepath.Join(trivyOpts.TrivyCacheDBDir, "java-db")
 
 	metac := db.NewMetadata(dbDir)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aquasecurity/go-dep-parser v0.0.0-20240202105001-4f19ab402b0b
 	github.com/aquasecurity/trivy v0.49.1
 	github.com/aquasecurity/trivy-db v0.0.0-20231005141211-4fc651f7ac8d
+	github.com/aquasecurity/trivy-java-db v0.0.0-20240109071736-184bd7481d48
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/aws/aws-sdk-go v1.49.21
 	github.com/c-robinson/iplib v1.0.8
@@ -107,7 +108,6 @@ require (
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46 // indirect
 	github.com/aquasecurity/go-version v0.0.0-20210121072130-637058cfe492 // indirect
 	github.com/aquasecurity/trivy-iac v0.8.0 // indirect
-	github.com/aquasecurity/trivy-java-db v0.0.0-20240109071736-184bd7481d48 // indirect
 	github.com/aquasecurity/trivy-policies v0.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.24.1 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.26.3 // indirect

--- a/models/library.go
+++ b/models/library.go
@@ -10,11 +10,11 @@ import (
 	trivyDBTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/detector/library"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
-	"github.com/aquasecurity/trivy/pkg/javadb"
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 
+	"github.com/future-architect/vuls/detector/javadb"
 	"github.com/future-architect/vuls/logging"
 )
 
@@ -51,7 +51,7 @@ type LibraryScanner struct {
 	// The path to the Lockfile is stored.
 	LockfilePath string `json:"path,omitempty"`
 
-	JavaDBClient *javadb.DB `json:"-"`
+	JavaDBClient *javadb.DBClient `json:"-"`
 }
 
 // Library holds the attribute of a package library


### PR DESCRIPTION
Because the `detector` package may be used as library-like way in some places.

# What did you implement:

Avoid to use sync.Once in trivy's java db Updator.
Instead, Use trivy-java-db's interface functions directly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually.

Preparation: Execute vuls scan with two servers with JAR libs.

```
% CGO_ENABLED=0 go run cmd/vuls/main.go scan -config ./integration/int-config.toml jar jar-wrong-name-log4j-core
[Mar  4 17:12:01]  INFO [localhost] vuls-`make build` or `make install` will show the version-
[Mar  4 17:12:01]  INFO [localhost] Start scanning
[Mar  4 17:12:01]  INFO [localhost] config: ./integration/int-config.toml
[Mar  4 17:12:01]  INFO [localhost] Validating config...
[Mar  4 17:12:01]  INFO [localhost] Detecting Server/Container OS...
[Mar  4 17:12:01]  INFO [localhost] Detecting OS of servers...
[Mar  4 17:12:01]  INFO [localhost] (1/2) Detected: jar-wrong-name-log4j-core: pseudo
[Mar  4 17:12:01]  INFO [localhost] (2/2) Detected: jar: pseudo
[Mar  4 17:12:01]  INFO [localhost] Detecting OS of containers...
[Mar  4 17:12:01]  INFO [localhost] Checking Scan Modes...
[Mar  4 17:12:01]  INFO [localhost] Detecting Platforms...
[Mar  4 17:12:01]  INFO [localhost] (1/2) jar is running on other
[Mar  4 17:12:01]  INFO [localhost] (2/2) jar-wrong-name-log4j-core is running on other
[Mar  4 17:12:01]  INFO [jar-wrong-name-log4j-core] Scanning listen port...
[Mar  4 17:12:01]  INFO [jar-wrong-name-log4j-core] Using Port Scanner: Vuls built-in Scanner
[Mar  4 17:12:01]  INFO [jar-wrong-name-log4j-core] Scanning Language-specific Packages...
[Mar  4 17:12:01]  INFO [jar] Scanning listen port...
[Mar  4 17:12:01]  INFO [jar] Using Port Scanner: Vuls built-in Scanner
[Mar  4 17:12:01]  INFO [jar] Scanning Language-specific Packages...


Scan Summary
================
jar-wrong-name-log4j-core       pseudo  0 installed, 0 updatable        2 libs
jar                             pseudo  0 installed, 0 updatable        1 libs
```

Three patterns of report testing against the above result are done.

(1) When there exists fresh Java DB cache, no download happen.

```
% CGO_ENABLED=0 go run cmd/vuls/main.go report -config ./integration/int-config.toml -refresh-cve
[Mar  4 17:12:27]  INFO [localhost] vuls-`make build` or `make install` will show the version-
[Mar  4 17:12:27]  INFO [localhost] Validating config...
[Mar  4 17:12:27]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/data/vulsctl/docker/cve.sqlite3
[Mar  4 17:12:27]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/data/vulsctl/docker/oval.sqlite3
[Mar  4 17:12:27]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/data/vulsctl/docker/gost.sqlite3
[Mar  4 17:12:27]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/data/vulsctl/docker/go-exploitdb.sqlite3
[Mar  4 17:12:27]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/data/vulsctl/docker/go-msfdb.sqlite3
[Mar  4 17:12:27]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/data/vulsctl/docker/go-kev.sqlite3
[Mar  4 17:12:27]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/data/vulsctl/docker/go-cti.sqlite3
[Mar  4 17:12:27]  INFO [localhost] Loaded: /home/shino/g/vuls/results/2024-03-04T17-12-01+0900
[Mar  4 17:12:27]  INFO [localhost] Updating library db...
[Mar  4 17:12:27]  INFO [localhost] jar-wrong-name-log4j-core: 5 CVEs are detected with Library
[Mar  4 17:12:27]  INFO [localhost] pseudo type. Skip OVAL and gost detection
[Mar  4 17:12:27]  INFO [localhost] jar-wrong-name-log4j-core: 0 CVEs are detected with CPE
[Mar  4 17:12:28]  INFO [localhost] jar-wrong-name-log4j-core: 0 PoC are detected
[Mar  4 17:12:28]  INFO [localhost] jar-wrong-name-log4j-core: 0 exploits are detected
[Mar  4 17:12:28]  INFO [localhost] jar-wrong-name-log4j-core: Known Exploited Vulnerabilities are detected for 0 CVEs
[Mar  4 17:12:28]  INFO [localhost] jar-wrong-name-log4j-core: Cyber Threat Intelligences are detected for 0 CVEs
[Mar  4 17:12:28]  INFO [localhost] Updating library db...
[Mar  4 17:12:28]  INFO [localhost] jar: 5 CVEs are detected with Library
[Mar  4 17:12:28]  INFO [localhost] pseudo type. Skip OVAL and gost detection
[Mar  4 17:12:28]  INFO [localhost] jar: 0 CVEs are detected with CPE
[Mar  4 17:12:28]  INFO [localhost] jar: 0 PoC are detected
[Mar  4 17:12:28]  INFO [localhost] jar: 0 exploits are detected
[Mar  4 17:12:28]  INFO [localhost] jar: Known Exploited Vulnerabilities are detected for 0 CVEs
[Mar  4 17:12:28]  INFO [localhost] jar: Cyber Threat Intelligences are detected for 0 CVEs
[Mar  4 17:12:28]  INFO [localhost] jar-wrong-name-log4j-core: total 5 CVEs detected
[Mar  4 17:12:28]  INFO [localhost] jar-wrong-name-log4j-core: 0 CVEs filtered by --confidence-over=80
[Mar  4 17:12:28]  INFO [localhost] jar: total 5 CVEs detected
[Mar  4 17:12:28]  INFO [localhost] jar: 0 CVEs filtered by --confidence-over=80
jar-wrong-name-log4j-core (pseudo)
==================================
Total: 5 (Critical:2 High:0 Medium:2 Low:1 ?:0)
5/5 Fixed, 1 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
0 installed, 2 libs

+----------------+------+--------+-----+-----------+---------+-------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |              PACKAGES               |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-44228 | 10.0 |  AV:N  | POC |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-45046 | 10.0 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-44832 |  6.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-45105 |  6.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2020-9488  |  3.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+

jar (pseudo)
============
Total: 5 (Critical:2 High:0 Medium:2 Low:1 ?:0)
5/5 Fixed, 1 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
0 installed, 1 libs

+----------------+------+--------+-----+-----------+---------+-------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |              PACKAGES               |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-44228 | 10.0 |  AV:N  | POC |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-45046 | 10.0 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-44832 |  6.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-45105 |  6.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2020-9488  |  3.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
```

(2) When there is no Java DB cache, only one download, before detecting the first server, hpappens.

```
% rm -rf ~/.cache/trivy/java-db/
% CGO_ENABLED=0 go run cmd/vuls/main.go report -config ./integration/int-config.toml -refresh-cve
[Mar  4 17:12:39]  INFO [localhost] vuls-`make build` or `make install` will show the version-
[Mar  4 17:12:39]  INFO [localhost] Validating config...
[Mar  4 17:12:39]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/data/vulsctl/docker/cve.sqlite3
[Mar  4 17:12:39]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/data/vulsctl/docker/oval.sqlite3
[Mar  4 17:12:39]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/data/vulsctl/docker/gost.sqlite3
[Mar  4 17:12:39]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/data/vulsctl/docker/go-exploitdb.sqlite3
[Mar  4 17:12:39]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/data/vulsctl/docker/go-msfdb.sqlite3
[Mar  4 17:12:39]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/data/vulsctl/docker/go-kev.sqlite3
[Mar  4 17:12:39]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/data/vulsctl/docker/go-cti.sqlite3
[Mar  4 17:12:39]  INFO [localhost] Loaded: /home/shino/g/vuls/results/2024-03-04T17-12-01+0900
[Mar  4 17:12:39]  INFO [localhost] Updating library db...
[Mar  4 17:12:39]  INFO [localhost] Trivy Java DB Repository: ghcr.io/aquasecurity/trivy-java-db:1
[Mar  4 17:12:39]  INFO [localhost] Downloading Trivy Java DB...
509.35 MiB / 509.35 MiB [---------------------------------------------------------------------------------] 100.00% 3.52 MiB p/s 2m25s
[Mar  4 17:15:16]  INFO [localhost] jar-wrong-name-log4j-core: 5 CVEs are detected with Library
[Mar  4 17:15:16]  INFO [localhost] pseudo type. Skip OVAL and gost detection
[Mar  4 17:15:16]  INFO [localhost] jar-wrong-name-log4j-core: 0 CVEs are detected with CPE
[Mar  4 17:15:16]  INFO [localhost] jar-wrong-name-log4j-core: 0 PoC are detected
[Mar  4 17:15:16]  INFO [localhost] jar-wrong-name-log4j-core: 0 exploits are detected
[Mar  4 17:15:16]  INFO [localhost] jar-wrong-name-log4j-core: Known Exploited Vulnerabilities are detected for 0 CVEs
[Mar  4 17:15:16]  INFO [localhost] jar-wrong-name-log4j-core: Cyber Threat Intelligences are detected for 0 CVEs
[Mar  4 17:15:16]  INFO [localhost] Updating library db...
[Mar  4 17:15:16]  INFO [localhost] jar: 5 CVEs are detected with Library
[Mar  4 17:15:16]  INFO [localhost] pseudo type. Skip OVAL and gost detection
[Mar  4 17:15:16]  INFO [localhost] jar: 0 CVEs are detected with CPE
[Mar  4 17:15:16]  INFO [localhost] jar: 0 PoC are detected
[Mar  4 17:15:16]  INFO [localhost] jar: 0 exploits are detected
[Mar  4 17:15:16]  INFO [localhost] jar: Known Exploited Vulnerabilities are detected for 0 CVEs
[Mar  4 17:15:16]  INFO [localhost] jar: Cyber Threat Intelligences are detected for 0 CVEs
[Mar  4 17:15:16]  INFO [localhost] jar-wrong-name-log4j-core: total 5 CVEs detected
[Mar  4 17:15:16]  INFO [localhost] jar-wrong-name-log4j-core: 0 CVEs filtered by --confidence-over=80
[Mar  4 17:15:16]  INFO [localhost] jar: total 5 CVEs detected
[Mar  4 17:15:16]  INFO [localhost] jar: 0 CVEs filtered by --confidence-over=80
jar-wrong-name-log4j-core (pseudo)
==================================
Total: 5 (Critical:2 High:0 Medium:2 Low:1 ?:0)
5/5 Fixed, 1 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
0 installed, 2 libs

+----------------+------+--------+-----+-----------+---------+-------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |              PACKAGES               |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-44228 | 10.0 |  AV:N  | POC |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-45046 | 10.0 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-44832 |  6.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-45105 |  6.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2020-9488  |  3.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+

jar (pseudo)
============
Total: 5 (Critical:2 High:0 Medium:2 Low:1 ?:0)
5/5 Fixed, 1 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
0 installed, 1 libs

+----------------+------+--------+-----+-----------+---------+-------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |              PACKAGES               |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-44228 | 10.0 |  AV:N  | POC |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-45046 | 10.0 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-44832 |  6.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-45105 |  6.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2020-9488  |  3.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
```

(3)  When there is no Java DB cache and 2nd detect is executed very loooong time after the first, TWO download happens.

To emulate "long time", NextUpdate field is faked as: 

```
diff --git a/detector/javadb/javadb.go b/detector/javadb/javadb.go
index 9f14b64..8bae40d 100644
--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -57,6 +57,7 @@ func UpdateJavaDB(trivyOpts config.TrivyOpts, noProgress bool) error {

                // Update DownloadedAt
                meta.DownloadedAt = time.Now().UTC()
+               meta.NextUpdate = time.Now().AddDate(0, 0, -7).UTC()
                if err = metac.Update(meta); err != nil {
                        return xerrors.Errorf("Failed to update Trivy Java DB metadata. erro: %w", err)
                }
```

```
% rm -rf ~/.cache/trivy/java-db/
% CGO_ENABLED=0 go run cmd/vuls/main.go report -config ./integration/int-config.toml -refresh-cve
[Mar  4 17:33:20]  INFO [localhost] vuls-`make build` or `make install` will show the version-
[Mar  4 17:33:20]  INFO [localhost] Validating config...
[Mar  4 17:33:20]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/data/vulsctl/docker/cve.sqlite3
[Mar  4 17:33:20]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/data/vulsctl/docker/oval.sqlite3
[Mar  4 17:33:20]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/data/vulsctl/docker/gost.sqlite3
[Mar  4 17:33:20]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/data/vulsctl/docker/go-exploitdb.sqlite3
[Mar  4 17:33:20]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/data/vulsctl/docker/go-msfdb.sqlite3
[Mar  4 17:33:20]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/data/vulsctl/docker/go-kev.sqlite3
[Mar  4 17:33:20]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/data/vulsctl/docker/go-cti.sqlite3
[Mar  4 17:33:20]  INFO [localhost] Loaded: /home/shino/g/vuls/results/2024-03-04T17-12-01+0900
[Mar  4 17:33:20]  INFO [localhost] Updating library db...
[Mar  4 17:33:20]  INFO [localhost] Trivy Java DB Repository: ghcr.io/aquasecurity/trivy-java-db:1
[Mar  4 17:33:20]  INFO [localhost] Downloading Trivy Java DB...
509.35 MiB / 509.35 MiB [----------------------------------------------------------------------------------] 100.00% 4.26 MiB p/s 2m0s
[Mar  4 17:35:32]  INFO [localhost] jar-wrong-name-log4j-core: 5 CVEs are detected with Library
[Mar  4 17:35:32]  INFO [localhost] pseudo type. Skip OVAL and gost detection
[Mar  4 17:35:32]  INFO [localhost] jar-wrong-name-log4j-core: 0 CVEs are detected with CPE
[Mar  4 17:35:32]  INFO [localhost] jar-wrong-name-log4j-core: 0 PoC are detected
[Mar  4 17:35:32]  INFO [localhost] jar-wrong-name-log4j-core: 0 exploits are detected
[Mar  4 17:35:32]  INFO [localhost] jar-wrong-name-log4j-core: Known Exploited Vulnerabilities are detected for 0 CVEs
[Mar  4 17:35:32]  INFO [localhost] jar-wrong-name-log4j-core: Cyber Threat Intelligences are detected for 0 CVEs
[Mar  4 17:35:32]  INFO [localhost] Updating library db...
[Mar  4 17:35:32]  INFO [localhost] Trivy Java DB Repository: ghcr.io/aquasecurity/trivy-java-db:1
[Mar  4 17:35:32]  INFO [localhost] Downloading Trivy Java DB...
509.35 MiB / 509.35 MiB [---------------------------------------------------------------------------------] 100.00% 4.86 MiB p/s 1m45s
[Mar  4 17:37:28]  INFO [localhost] jar: 5 CVEs are detected with Library
[Mar  4 17:37:28]  INFO [localhost] pseudo type. Skip OVAL and gost detection
[Mar  4 17:37:28]  INFO [localhost] jar: 0 CVEs are detected with CPE
[Mar  4 17:37:28]  INFO [localhost] jar: 0 PoC are detected
[Mar  4 17:37:28]  INFO [localhost] jar: 0 exploits are detected
[Mar  4 17:37:28]  INFO [localhost] jar: Known Exploited Vulnerabilities are detected for 0 CVEs
[Mar  4 17:37:28]  INFO [localhost] jar: Cyber Threat Intelligences are detected for 0 CVEs
[Mar  4 17:37:28]  INFO [localhost] jar-wrong-name-log4j-core: total 5 CVEs detected
[Mar  4 17:37:28]  INFO [localhost] jar-wrong-name-log4j-core: 0 CVEs filtered by --confidence-over=80
[Mar  4 17:37:28]  INFO [localhost] jar: total 5 CVEs detected
[Mar  4 17:37:28]  INFO [localhost] jar: 0 CVEs filtered by --confidence-over=80
jar-wrong-name-log4j-core (pseudo)
==================================
Total: 5 (Critical:2 High:0 Medium:2 Low:1 ?:0)
5/5 Fixed, 1 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
0 installed, 2 libs

+----------------+------+--------+-----+-----------+---------+-------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |              PACKAGES               |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-44228 | 10.0 |  AV:N  | POC |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-45046 | 10.0 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-44832 |  6.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-45105 |  6.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2020-9488  |  3.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+

jar (pseudo)
============
Total: 5 (Critical:2 High:0 Medium:2 Low:1 ?:0)
5/5 Fixed, 1 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
0 installed, 1 libs

+----------------+------+--------+-----+-----------+---------+-------------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |              PACKAGES               |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-44228 | 10.0 |  AV:N  | POC |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-45046 | 10.0 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-44832 |  6.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2021-45105 |  6.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
| CVE-2020-9488  |  3.9 |  AV:N  |     |           |   fixed | org.apache.logging.log4j:log4j-core |
+----------------+------+--------+-----+-----------+---------+-------------------------------------+
```


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

