### PR TITLE
feat(PackageURL):add package URL for library scan result

### DIFF
--- a/contrib/trivy/parser/v2/parser_test.go
+++ b/contrib/trivy/parser/v2/parser_test.go
@@ -136,6 +136,9 @@ var redisTrivy = []byte(`
       "Packages": [
         {
           "Name": "adduser",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/adduser@3.118?arch=all\u0026distro=debian-10.10"
+          },
           "Version": "3.118",
           "SrcName": "adduser",
           "SrcVersion": "3.118",
@@ -145,6 +148,9 @@ var redisTrivy = []byte(`
         },
         {
           "Name": "apt",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/apt@1.8.2.3?arch=amd64\u0026distro=debian-10.10"
+          },
           "Version": "1.8.2.3",
           "SrcName": "apt",
           "SrcVersion": "1.8.2.3",
@@ -154,6 +160,9 @@ var redisTrivy = []byte(`
         },
         {
           "Name": "bsdutils",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/bsdutils@2.33.1-0.1?arch=amd64\u0026distro=debian-10.10\u0026epoch=1"
+          },
           "Version": "1:2.33.1-0.1",
           "SrcName": "util-linux",
           "SrcVersion": "2.33.1-0.1",
@@ -163,6 +172,9 @@ var redisTrivy = []byte(`
         },
         {
           "Name": "pkgA",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/pkgA@2.33.1-0.1?arch=amd64\u0026distro=debian-10.10\u0026epoch=1"
+          },
           "Version": "1:2.33.1-0.1",
           "SrcName": "util-linux",
           "SrcVersion": "2.33.1-0.1",
@@ -308,16 +320,25 @@ var strutsTrivy = []byte(`
       "Packages": [
         {
           "Name": "oro:oro",
+          "Identifier": {
+            "PURL": "pkg:maven/oro/oro@2.0.7"
+          },
           "Version": "2.0.7",
           "Layer": {}
         },
         {
           "Name": "struts:struts",
+          "Identifier": {
+            "PURL": "pkg:maven/struts/struts@1.2.7"
+          },
           "Version": "1.2.7",
           "Layer": {}
         },
         {
           "Name": "commons-beanutils:commons-beanutils",
+          "Identifier": {
+            "PURL": "pkg:maven/commons-beanutils/commons-beanutils@1.7.0"
+          },
           "Version": "1.7.0",
           "Layer": {}
         }
@@ -459,16 +480,19 @@ var strutsSR = &models.ScanResult{
 			LockfilePath: "Java",
 			Libs: []models.Library{
 				{
-					Name:    "commons-beanutils:commons-beanutils",
-					Version: "1.7.0",
+					Name:       "commons-beanutils:commons-beanutils",
+					PackageURL: "pkg:maven/commons-beanutils/commons-beanutils@1.7.0",
+					Version:    "1.7.0",
 				},
 				{
-					Name:    "oro:oro",
-					Version: "2.0.7",
+					Name:       "oro:oro",
+					PackageURL: "pkg:maven/oro/oro@2.0.7",
+					Version:    "2.0.7",
 				},
 				{
-					Name:    "struts:struts",
-					Version: "1.2.7",
+					Name:       "struts:struts",
+					PackageURL: "pkg:maven/struts/struts@1.2.7",
+					Version:    "1.2.7",
 				},
 			},
 		},
@@ -540,6 +564,9 @@ var osAndLibTrivy = []byte(`
       "Packages": [
         {
           "Name": "libgnutls30",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libgnutls30@3.6.7-4?arch=amd64\u0026distro=debian-10.2"
+          },
           "Version": "3.6.7-4",
           "SrcName": "gnutls28",
           "SrcVersion": "3.6.7-4",
@@ -594,6 +621,9 @@ var osAndLibTrivy = []byte(`
       "Packages": [
         {
           "Name": "activesupport",
+          "Identifier": {
+            "PURL": "pkg:gem/activesupport@6.0.2.1"
+          },
           "Version": "6.0.2.1",
           "License": "MIT",
           "Layer": {
@@ -715,9 +745,10 @@ var osAndLibSR = &models.ScanResult{
 			LockfilePath: "Ruby",
 			Libs: []models.Library{
 				{
-					Name:     "activesupport",
-					Version:  "6.0.2.1",
-					FilePath: "var/lib/gems/2.5.0/specifications/activesupport-6.0.2.1.gemspec",
+					Name:       "activesupport",
+					Version:    "6.0.2.1",
+					PackageURL: "pkg:gem/activesupport@6.0.2.1",
+					FilePath:   "var/lib/gems/2.5.0/specifications/activesupport-6.0.2.1.gemspec",
 				},
 			},
 		},
@@ -804,6 +835,9 @@ var osAndLib2Trivy = []byte(`
         {
           "ID": "libgnutls30@3.6.7-4",
           "Name": "libgnutls30",
+          "Identifier": {
+            "PURL": "pkg:deb/debian/libgnutls30@3.6.7-4?arch=amd64\u0026distro=debian-10.2"
+          },
           "Version": "3.6.7",
           "Release": "4",
           "Arch": "amd64",
@@ -889,6 +923,9 @@ var osAndLib2Trivy = []byte(`
       "Packages": [
         {
           "Name": "activesupport",
+          "Identifier": {
+            "PURL": "pkg:gem/activesupport@6.0.2.1"
+          },
           "Version": "6.0.2.1",
           "License": "MIT",
           "Layer": {
@@ -1010,9 +1047,10 @@ var osAndLib2SR = &models.ScanResult{
 			LockfilePath: "Ruby",
 			Libs: []models.Library{
 				{
-					Name:     "activesupport",
-					Version:  "6.0.2.1",
-					FilePath: "var/lib/gems/2.5.0/specifications/activesupport-6.0.2.1.gemspec",
+					Name:       "activesupport",
+					Version:    "6.0.2.1",
+					PackageURL: "pkg:gem/activesupport@6.0.2.1",
+					FilePath:   "var/lib/gems/2.5.0/specifications/activesupport-6.0.2.1.gemspec",
 				},
 			},
 		},

--- a/contrib/trivy/parser/v2/parser_test.go
+++ b/contrib/trivy/parser/v2/parser_test.go
@@ -37,7 +37,6 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s", err)
 		}
-
 		diff, equal := messagediff.PrettyDiff(
 			v.expected,
 			actual,
@@ -835,9 +834,6 @@ var osAndLib2Trivy = []byte(`
         {
           "ID": "libgnutls30@3.6.7-4",
           "Name": "libgnutls30",
-          "Identifier": {
-            "PURL": "pkg:deb/debian/libgnutls30@3.6.7-4?arch=amd64\u0026distro=debian-10.2"
-          },
           "Version": "3.6.7",
           "Release": "4",
           "Arch": "amd64",
@@ -923,9 +919,6 @@ var osAndLib2Trivy = []byte(`
       "Packages": [
         {
           "Name": "activesupport",
-          "Identifier": {
-            "PURL": "pkg:gem/activesupport@6.0.2.1"
-          },
           "Version": "6.0.2.1",
           "License": "MIT",
           "Layer": {
@@ -1049,7 +1042,7 @@ var osAndLib2SR = &models.ScanResult{
 				{
 					Name:       "activesupport",
 					Version:    "6.0.2.1",
-					PackageURL: "pkg:gem/activesupport@6.0.2.1",
+					PackageURL: "",
 					FilePath:   "var/lib/gems/2.5.0/specifications/activesupport-6.0.2.1.gemspec",
 				},
 			},

--- a/contrib/trivy/parser/v2/parser_test.go
+++ b/contrib/trivy/parser/v2/parser_test.go
@@ -37,6 +37,7 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s", err)
 		}
+
 		diff, equal := messagediff.PrettyDiff(
 			v.expected,
 			actual,

--- a/contrib/trivy/parser/v2/parser_test.go
+++ b/contrib/trivy/parser/v2/parser_test.go
@@ -1041,10 +1041,9 @@ var osAndLib2SR = &models.ScanResult{
 			LockfilePath: "Ruby",
 			Libs: []models.Library{
 				{
-					Name:       "activesupport",
-					Version:    "6.0.2.1",
-					PackageURL: "",
-					FilePath:   "var/lib/gems/2.5.0/specifications/activesupport-6.0.2.1.gemspec",
+					Name:     "activesupport",
+					Version:  "6.0.2.1",
+					FilePath: "var/lib/gems/2.5.0/specifications/activesupport-6.0.2.1.gemspec",
 				},
 			},
 		},

--- a/contrib/trivy/parser/v2/parser_test.go
+++ b/contrib/trivy/parser/v2/parser_test.go
@@ -480,19 +480,19 @@ var strutsSR = &models.ScanResult{
 			LockfilePath: "Java",
 			Libs: []models.Library{
 				{
-					Name:       "commons-beanutils:commons-beanutils",
-					PackageURL: "pkg:maven/commons-beanutils/commons-beanutils@1.7.0",
-					Version:    "1.7.0",
+					Name:    "commons-beanutils:commons-beanutils",
+					PURL:    "pkg:maven/commons-beanutils/commons-beanutils@1.7.0",
+					Version: "1.7.0",
 				},
 				{
-					Name:       "oro:oro",
-					PackageURL: "pkg:maven/oro/oro@2.0.7",
-					Version:    "2.0.7",
+					Name:    "oro:oro",
+					PURL:    "pkg:maven/oro/oro@2.0.7",
+					Version: "2.0.7",
 				},
 				{
-					Name:       "struts:struts",
-					PackageURL: "pkg:maven/struts/struts@1.2.7",
-					Version:    "1.2.7",
+					Name:    "struts:struts",
+					PURL:    "pkg:maven/struts/struts@1.2.7",
+					Version: "1.2.7",
 				},
 			},
 		},
@@ -745,10 +745,10 @@ var osAndLibSR = &models.ScanResult{
 			LockfilePath: "Ruby",
 			Libs: []models.Library{
 				{
-					Name:       "activesupport",
-					Version:    "6.0.2.1",
-					PackageURL: "pkg:gem/activesupport@6.0.2.1",
-					FilePath:   "var/lib/gems/2.5.0/specifications/activesupport-6.0.2.1.gemspec",
+					Name:     "activesupport",
+					Version:  "6.0.2.1",
+					PURL:     "pkg:gem/activesupport@6.0.2.1",
+					FilePath: "var/lib/gems/2.5.0/specifications/activesupport-6.0.2.1.gemspec",
 				},
 			},
 		},

--- a/contrib/trivy/pkg/converter.go
+++ b/contrib/trivy/pkg/converter.go
@@ -145,14 +145,12 @@ func Convert(results types.Results) (result *models.ScanResult, err error) {
 			libScanner := uniqueLibraryScannerPaths[trivyResult.Target]
 			libScanner.Type = trivyResult.Type
 			for _, p := range trivyResult.Packages {
-				// fmt.Printf("p: %#v", p)
 				libScanner.Libs = append(libScanner.Libs, models.Library{
 					Name:       p.Name,
 					Version:    p.Version,
 					PackageURL: getPURL(p),
 					FilePath:   p.FilePath,
 				})
-				fmt.Println("getPURL", getPURL(p))
 			}
 			uniqueLibraryScannerPaths[trivyResult.Target] = libScanner
 		}

--- a/contrib/trivy/pkg/converter.go
+++ b/contrib/trivy/pkg/converter.go
@@ -146,10 +146,10 @@ func Convert(results types.Results) (result *models.ScanResult, err error) {
 			libScanner.Type = trivyResult.Type
 			for _, p := range trivyResult.Packages {
 				libScanner.Libs = append(libScanner.Libs, models.Library{
-					Name:       p.Name,
-					Version:    p.Version,
-					PackageURL: getPURL(p),
-					FilePath:   p.FilePath,
+					Name:     p.Name,
+					Version:  p.Version,
+					PURL:     getPURL(p),
+					FilePath: p.FilePath,
 				})
 			}
 			uniqueLibraryScannerPaths[trivyResult.Target] = libScanner

--- a/contrib/trivy/pkg/converter.go
+++ b/contrib/trivy/pkg/converter.go
@@ -147,9 +147,10 @@ func Convert(results types.Results) (result *models.ScanResult, err error) {
 			libScanner.Type = trivyResult.Type
 			for _, p := range trivyResult.Packages {
 				libScanner.Libs = append(libScanner.Libs, models.Library{
-					Name:     p.Name,
-					Version:  p.Version,
-					FilePath: p.FilePath,
+					Name:       p.Name,
+					Version:    p.Version,
+					PackageURL: p.Identifier.PURL.String(),
+					FilePath:   p.FilePath,
 				})
 			}
 			uniqueLibraryScannerPaths[trivyResult.Target] = libScanner

--- a/contrib/trivy/pkg/converter.go
+++ b/contrib/trivy/pkg/converter.go
@@ -17,7 +17,6 @@ func Convert(results types.Results) (result *models.ScanResult, err error) {
 		JSONVersion: models.JSONVersion,
 		ScannedCves: models.VulnInfos{},
 	}
-
 	pkgs := models.Packages{}
 	srcPkgs := models.SrcPackages{}
 	vulnInfos := models.VulnInfos{}
@@ -146,12 +145,14 @@ func Convert(results types.Results) (result *models.ScanResult, err error) {
 			libScanner := uniqueLibraryScannerPaths[trivyResult.Target]
 			libScanner.Type = trivyResult.Type
 			for _, p := range trivyResult.Packages {
+				// fmt.Printf("p: %#v", p)
 				libScanner.Libs = append(libScanner.Libs, models.Library{
 					Name:       p.Name,
 					Version:    p.Version,
-					PackageURL: p.Identifier.PURL.String(),
+					PackageURL: getPURL(p),
 					FilePath:   p.FilePath,
 				})
+				fmt.Println("getPURL", getPURL(p))
 			}
 			uniqueLibraryScannerPaths[trivyResult.Target] = libScanner
 		}
@@ -214,4 +215,12 @@ func isTrivySupportedOS(family ftypes.TargetType) bool {
 	}
 	_, ok := supportedFamilies[family]
 	return ok
+}
+
+func getPURL(p ftypes.Package) string {
+	if p.Identifier.PURL == nil {
+		fmt.Println("EROOR")
+		return ""
+	}
+	return p.Identifier.PURL.String()
 }

--- a/contrib/trivy/pkg/converter.go
+++ b/contrib/trivy/pkg/converter.go
@@ -219,7 +219,6 @@ func isTrivySupportedOS(family ftypes.TargetType) bool {
 
 func getPURL(p ftypes.Package) string {
 	if p.Identifier.PURL == nil {
-		fmt.Println("EROOR")
 		return ""
 	}
 	return p.Identifier.PURL.String()

--- a/contrib/trivy/pkg/converter.go
+++ b/contrib/trivy/pkg/converter.go
@@ -17,6 +17,7 @@ func Convert(results types.Results) (result *models.ScanResult, err error) {
 		JSONVersion: models.JSONVersion,
 		ScannedCves: models.VulnInfos{},
 	}
+
 	pkgs := models.Packages{}
 	srcPkgs := models.SrcPackages{}
 	vulnInfos := models.VulnInfos{}

--- a/models/library.go
+++ b/models/library.go
@@ -56,9 +56,9 @@ type LibraryScanner struct {
 
 // Library holds the attribute of a package library
 type Library struct {
-	Name       string
-	Version    string
-	PackageURL string
+	Name    string
+	Version string
+	PURL    string
 
 	// The Path to the library in the container image. Empty string when Lockfile scan.
 	// This field is used to convert the result JSON of a `trivy image` using trivy-to-vuls.

--- a/models/library.go
+++ b/models/library.go
@@ -56,8 +56,9 @@ type LibraryScanner struct {
 
 // Library holds the attribute of a package library
 type Library struct {
-	Name    string
-	Version string
+	Name       string
+	Version    string
+	PackageURL string
 
 	// The Path to the library in the container image. Empty string when Lockfile scan.
 	// This field is used to convert the result JSON of a `trivy image` using trivy-to-vuls.

--- a/models/library_test.go
+++ b/models/library_test.go
@@ -23,9 +23,9 @@ func TestLibraryScanners_Find(t *testing.T) {
 					LockfilePath: "/pathA",
 					Libs: []Library{
 						{
-							Name:       "libA",
-							Version:    "1.0.0",
-							PackageURL: "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
+							Name:    "libA",
+							Version: "1.0.0",
+							PURL:    "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
 						},
 					},
 				},
@@ -33,9 +33,9 @@ func TestLibraryScanners_Find(t *testing.T) {
 			args: args{"/pathA", "libA"},
 			want: map[string]Library{
 				"/pathA": {
-					Name:       "libA",
-					Version:    "1.0.0",
-					PackageURL: "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
+					Name:    "libA",
+					Version: "1.0.0",
+					PURL:    "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
 				},
 			},
 		},
@@ -46,9 +46,9 @@ func TestLibraryScanners_Find(t *testing.T) {
 					LockfilePath: "/pathA",
 					Libs: []Library{
 						{
-							Name:       "libA",
-							Version:    "1.0.0",
-							PackageURL: "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
+							Name:    "libA",
+							Version: "1.0.0",
+							PURL:    "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
 						},
 					},
 				},
@@ -56,9 +56,9 @@ func TestLibraryScanners_Find(t *testing.T) {
 					LockfilePath: "/pathB",
 					Libs: []Library{
 						{
-							Name:       "libA",
-							Version:    "1.0.5",
-							PackageURL: "scheme/type/namespace/libA@1.0.5?qualifiers#subpath",
+							Name:    "libA",
+							Version: "1.0.5",
+							PURL:    "scheme/type/namespace/libA@1.0.5?qualifiers#subpath",
 						},
 					},
 				},
@@ -66,9 +66,9 @@ func TestLibraryScanners_Find(t *testing.T) {
 			args: args{"/pathA", "libA"},
 			want: map[string]Library{
 				"/pathA": {
-					Name:       "libA",
-					Version:    "1.0.0",
-					PackageURL: "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
+					Name:    "libA",
+					Version: "1.0.0",
+					PURL:    "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
 				},
 			},
 		},
@@ -79,9 +79,9 @@ func TestLibraryScanners_Find(t *testing.T) {
 					LockfilePath: "/pathA",
 					Libs: []Library{
 						{
-							Name:       "libA",
-							Version:    "1.0.0",
-							PackageURL: "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
+							Name:    "libA",
+							Version: "1.0.0",
+							PURL:    "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
 						},
 					},
 				},

--- a/models/library_test.go
+++ b/models/library_test.go
@@ -23,8 +23,9 @@ func TestLibraryScanners_Find(t *testing.T) {
 					LockfilePath: "/pathA",
 					Libs: []Library{
 						{
-							Name:    "libA",
-							Version: "1.0.0",
+							Name:       "libA",
+							Version:    "1.0.0",
+							PackageURL: "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
 						},
 					},
 				},
@@ -32,8 +33,9 @@ func TestLibraryScanners_Find(t *testing.T) {
 			args: args{"/pathA", "libA"},
 			want: map[string]Library{
 				"/pathA": {
-					Name:    "libA",
-					Version: "1.0.0",
+					Name:       "libA",
+					Version:    "1.0.0",
+					PackageURL: "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
 				},
 			},
 		},
@@ -44,8 +46,9 @@ func TestLibraryScanners_Find(t *testing.T) {
 					LockfilePath: "/pathA",
 					Libs: []Library{
 						{
-							Name:    "libA",
-							Version: "1.0.0",
+							Name:       "libA",
+							Version:    "1.0.0",
+							PackageURL: "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
 						},
 					},
 				},
@@ -53,8 +56,9 @@ func TestLibraryScanners_Find(t *testing.T) {
 					LockfilePath: "/pathB",
 					Libs: []Library{
 						{
-							Name:    "libA",
-							Version: "1.0.5",
+							Name:       "libA",
+							Version:    "1.0.5",
+							PackageURL: "scheme/type/namespace/libA@1.0.5?qualifiers#subpath",
 						},
 					},
 				},
@@ -62,8 +66,9 @@ func TestLibraryScanners_Find(t *testing.T) {
 			args: args{"/pathA", "libA"},
 			want: map[string]Library{
 				"/pathA": {
-					Name:    "libA",
-					Version: "1.0.0",
+					Name:       "libA",
+					Version:    "1.0.0",
+					PackageURL: "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
 				},
 			},
 		},
@@ -74,8 +79,9 @@ func TestLibraryScanners_Find(t *testing.T) {
 					LockfilePath: "/pathA",
 					Libs: []Library{
 						{
-							Name:    "libA",
-							Version: "1.0.0",
+							Name:       "libA",
+							Version:    "1.0.0",
+							PackageURL: "scheme/type/namespace/libA@1.0.0?qualifiers#subpath",
 						},
 					},
 				},

--- a/scanner/library.go
+++ b/scanner/library.go
@@ -4,6 +4,7 @@ import (
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/purl"
 	"github.com/aquasecurity/trivy/pkg/types"
+
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
 )

--- a/scanner/library.go
+++ b/scanner/library.go
@@ -15,11 +15,11 @@ func convertLibWithScanner(apps []ftypes.Application) ([]models.LibraryScanner, 
 		libs := make([]models.Library, 0, len(app.Libraries))
 		for _, lib := range app.Libraries {
 			libs = append(libs, models.Library{
-				Name:       lib.Name,
-				Version:    lib.Version,
-				PackageURL: newPURL(app.Type, types.Metadata{}, lib),
-				FilePath:   lib.FilePath,
-				Digest:     string(lib.Digest),
+				Name:     lib.Name,
+				Version:  lib.Version,
+				PURL:     newPURL(app.Type, types.Metadata{}, lib),
+				FilePath: lib.FilePath,
+				Digest:   string(lib.Digest),
 			})
 		}
 		scanners = append(scanners, models.LibraryScanner{

--- a/scanner/library.go
+++ b/scanner/library.go
@@ -1,20 +1,26 @@
 package scanner
 
 import (
-	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/aquasecurity/trivy/pkg/purl"
+	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
+	"github.com/package-url/packageurl-go"
 )
 
-func convertLibWithScanner(apps []types.Application) ([]models.LibraryScanner, error) {
+func convertLibWithScanner(apps []ftypes.Application) ([]models.LibraryScanner, error) {
 	scanners := []models.LibraryScanner{}
 	for _, app := range apps {
 		libs := []models.Library{}
 		for _, lib := range app.Libraries {
+			purl := newPURL(app.Type, types.Metadata{}, lib)
 			libs = append(libs, models.Library{
-				Name:     lib.Name,
-				Version:  lib.Version,
-				FilePath: lib.FilePath,
-				Digest:   string(lib.Digest),
+				Name:       lib.Name,
+				Version:    lib.Version,
+				PackageURL: purl.ToString(),
+				FilePath:   lib.FilePath,
+				Digest:     string(lib.Digest),
 			})
 		}
 		scanners = append(scanners, models.LibraryScanner{
@@ -24,4 +30,13 @@ func convertLibWithScanner(apps []types.Application) ([]models.LibraryScanner, e
 		})
 	}
 	return scanners, nil
+}
+
+func newPURL(pkgType ftypes.TargetType, metadata types.Metadata, pkg ftypes.Package) *packageurl.PackageURL {
+	p, err := purl.New(pkgType, metadata, pkg)
+	if err != nil {
+		logging.Log.Errorf("Failed to create PackageURL: %+v", err)
+		return nil
+	}
+	return p.Unwrap()
 }


### PR DESCRIPTION
# What did you implement:
We have [updated the version of Trivy used in Vuls to 0.49.1.](https://github.com/future-architect/vuls/pull/1806)
As a result, the results of filesystem scan and container image scan now include a Package URL.
Therefore, we will also include Package URL in the results of trivy-to-vuls and lockfile scan.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Manually.

## trivy-to-vuls
### Parse file system scan result
```bash
$ trivy -q fs -f json poetry.lock --list-all-pkgs | CGO_ENABLED=0 go run contrib/trivy/cmd/main.go parse --stdin
```

The PackageURL does not exist in the libraries.Libs.

<details close>
<summary>before</summary>

```json
"libraries": [
   {
      "Type": "poetry",
      "Libs": [
         {
            "Name": "anyio",
            "Version": "3.7.1",
            "FilePath": ""
         },
         {
            "Name": "appnope",
            "Version": "0.1.3",
            "FilePath": ""
         },
         {
            "Name": "argon2-cffi",
            "Version": "21.3.0",
            "FilePath": ""
         },
         etc...
      ]
   }
]
```
</details>

The PackageURL is added inside the libraries.Libs.
<details close>
<summary>after</summary>

```json
"libraries": [
   {
      "Type": "poetry",
      "Libs": [
         {
            "Name": "anyio",
            "Version": "3.7.1",
            "PackageURL": "pkg:pypi/anyio@3.7.1",
            "FilePath": "",
            "Digest": ""
         },
         {
            "Name": "appnope",
            "Version": "0.1.3",
            "PackageURL": "pkg:pypi/appnope@0.1.3",
            "FilePath": "",
            "Digest": ""
         },
         {
            "Name": "argon2-cffi",
            "Version": "21.3.0",
            "PackageURL": "pkg:pypi/argon2-cffi@21.3.0",
            "FilePath": "",
            "Digest": ""
         },
         etc...
      ]
   }
]
```
</details>

### Parse container image scan result
```bash
$ trivy -q image -f=json python:3.4-alpine --list-all-pkgs | CGO_ENABLED=0 go run contrib/trivy/cmd/main.go parse --stdin
```
The PackageURL does not exist in the libraries.Libs.
<details close>
<summary>before</summary>

```json
 "libraries": [
    {
       "Type": "python-pkg",
       "Libs": [
          {
             "Name": "pip",
             "Version": "19.0.3",
             "FilePath": "usr/local/lib/python3.4/site-packages/pip-19.0.3.dist-info/METADATA"
          },
          {
             "Name": "setuptools",
             "Version": "40.8.0",
             "FilePath": "usr/local/lib/python3.4/site-packages/setuptools-40.8.0.dist-info/METADATA"
          },
          {
             "Name": "wheel",
             "Version": "0.33.1",
             "FilePath": "usr/local/lib/python3.4/site-packages/wheel-0.33.1.dist-info/METADATA"
          }
       ],
       "path": "Python"
    }
 ],
```
</details>

The PackageURL has been added inside the libraries.Libs.
<details close>
<summary>after</summary>

```json
 "libraries": [
    {
       "Type": "python-pkg",
       "Libs": [
          {
             "Name": "pip",
             "Version": "19.0.3",
             "PackageURL": "pkg:pypi/pip@19.0.3",
             "FilePath": "usr/local/lib/python3.4/site-packages/pip-19.0.3.dist-info/METADATA",
             "Digest": ""
          },
          {
             "Name": "setuptools",
             "Version": "40.8.0",
             "PackageURL": "pkg:pypi/setuptools@40.8.0",
             "FilePath": "usr/local/lib/python3.4/site-packages/setuptools-40.8.0.dist-info/METADATA",
             "Digest": ""
          },
          {
             "Name": "wheel",
             "Version": "0.33.1",
             "PackageURL": "pkg:pypi/wheel@0.33.1",
             "FilePath": "usr/local/lib/python3.4/site-packages/wheel-0.33.1.dist-info/METADATA",
             "Digest": ""
          }
       ],
       "path": "Python"
    }
 ],
```
</details>

## Lockfile Scan
```bash
$ docker run --rm -it \
    -v ~/.ssh:/root/.ssh:ro \
    -v $PWD:/vuls \
    -v $PWD/vuls-log:/var/log/vuls \
    -v /etc/localtime:/etc/localtime:ro \
    -e "TZ=Asia/Tokyo" \
    vuls:latest scan \
    -config=./config.toml

[Mar  5 16:12:45]  INFO [localhost] vuls--build-20240305_160720_584a441
[Mar  5 16:12:45]  INFO [localhost] Start scanning
[Mar  5 16:12:45]  INFO [localhost] config: ./config.toml
[Mar  5 16:12:45]  INFO [localhost] Validating config...
[Mar  5 16:12:45]  INFO [localhost] Detecting Server/Container OS... 
[Mar  5 16:12:45]  INFO [localhost] Detecting OS of servers... 
[Mar  5 16:12:45]  INFO [localhost] (1/1) Detected: localhost: alpine 3.16.9
[Mar  5 16:12:45]  INFO [localhost] Detecting OS of containers... 
[Mar  5 16:12:45]  INFO [localhost] Checking Scan Modes... 
[Mar  5 16:12:45]  INFO [localhost] Detecting Platforms... 
[Mar  5 16:12:45]  INFO [localhost] (1/1) localhost is running on other
[Mar  5 16:12:45]  INFO [localhost] Scanning OS pkg in fast mode
[Mar  5 16:12:47]  INFO [localhost] Scanning listen port...
[Mar  5 16:12:47]  INFO [localhost] Using Port Scanner: Vuls built-in Scanner
[Mar  5 16:12:47]  INFO [localhost] Scanning Language-specific Packages...
[Mar  5 16:12:47]  INFO [localhost] It's recommended to specify FindLockDirs in config.toml. If FindLockDirs is not specified, all directories under / will be searched, which may increase CPU load
[Mar  5 16:12:47]  INFO [localhost] Finding files under /
[Mar  5 16:12:47]  WARN [localhost] Some warnings occurred during scanning on localhost. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Standard OS support will be end in 3 months. EOL date: 2024-05-23]


Scan Summary
================
localhost       alpine3.16.9    34 installed, 0 updatable       341 libs

Warning: [Standard OS support will be end in 3 months. EOL date: 2024-05-23]
```

<details close>
<summary>config.toml</summary>

```toml
[servers]

[servers.localhost]
host = "localhost"
port = "local"
findLock = true
```
</details>

The PackageURL does not exist in the libraries.Libs.
<details close>
<summary>before</summary>

```json
"libraries": [
    {
        "Type": "gomod",
        "Libs": [
            {
                "Name": "cloud.google.com/go",
                "Version": "0.110.10",
                "FilePath": "",
                "Digest": ""
            },
            {
                "Name": "cloud.google.com/go/compute",
                "Version": "1.23.3",
                "FilePath": "",
                "Digest": ""
            },
            {
                "Name": "cloud.google.com/go/compute/metadata",
                "Version": "0.2.3",
                "FilePath": "",
                "Digest": ""
            },
        etc...
        ],
    }
]
```
</details>

The PackageURL has been added inside the libraries.Libs.
<details close>
<summary>after</summary>

```json
"libraries": [
      {
          "Type": "gomod",
          "Libs": [
              {
                  "Name": "cloud.google.com/go",
                  "Version": "0.110.10",
                  "PackageURL": "pkg:golang/cloud.google.com/go@0.110.10",
                  "FilePath": "",
                  "Digest": ""
              },
              {
                  "Name": "cloud.google.com/go/compute",
                  "Version": "1.23.3",
                  "PackageURL": "pkg:golang/cloud.google.com/go/compute@1.23.3",
                  "FilePath": "",
                  "Digest": ""
              },
              {
                  "Name": "cloud.google.com/go/compute/metadata",
                  "Version": "0.2.3",
                  "PackageURL": "pkg:golang/cloud.google.com/go/compute/metadata@0.2.3",
                  "FilePath": "",
                  "Digest": ""
              },
              etc...
          ],
     }
]
```
</details>



# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
* https://github.com/future-architect/vuls/pull/1806
* generate package url
  * https://github.com/aquasecurity/trivy/blob/c1d26ec3342ec776346c308b30e3a64d90effef1/pkg/fanal/applier/docker.go#L253-L260
* https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst
* https://vuls.io/docs/ja/tutorial-docker.html#step6-scan
