### PR TITLE
fix(scanner): output all results even if all fail

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -296,8 +296,8 @@ func ParseInstalledPkgs(distro config.Distro, kernel models.Kernel, pkgList stri
 // initServers detect the kind of OS distribution of target servers
 func (s Scanner) initServers() error {
 	hosts, errHosts := s.detectServerOSes()
-	if len(hosts) == 0 {
-		return xerrors.New("No scannable host OS")
+	if (len(hosts) + len(errHosts)) == 0 {
+		return xerrors.New("No host defined. Check the configuration")
 	}
 
 	for _, srv := range hosts {
@@ -318,8 +318,8 @@ func (s Scanner) initServers() error {
 	servers = append(servers, containers...)
 	errServers = append(errHosts, errContainers...)
 
-	if len(servers) == 0 {
-		return xerrors.New("No scannable servers")
+	if (len(servers) + len(errServers)) == 0 {
+		return xerrors.New("No server defined. Check the configuration")
 	}
 	return nil
 }
@@ -896,7 +896,7 @@ func (s Scanner) detectIPS() {
 
 // execScan scan
 func (s Scanner) execScan() error {
-	if len(servers) == 0 {
+	if (len(servers) + len(errServers)) == 0 {
 		return xerrors.New("No server defined. Check the configuration")
 	}
 


### PR DESCRIPTION
# What did you implement:

When running `vuls scan`, there was a difference in behavior between cases where all servers failed and cases where only some servers failed in terms of generating results. 
In this PR, we modify it to output results for all servers regardless of the situation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
In the display of the Scan Summary, you can confirm the generation of results.

## all servers failed
### before
```console
$ vuls scan
[Mar  6 18:53:41]  INFO [localhost] vuls-v0.24.9-build-20240306_185212_bf14b5f
[Mar  6 18:53:41]  INFO [localhost] Start scanning
[Mar  6 18:53:41]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Mar  6 18:53:41]  INFO [localhost] Validating config...
[Mar  6 18:53:41]  INFO [localhost] Detecting Server/Container OS... 
[Mar  6 18:53:41]  INFO [localhost] Detecting OS of servers... 
[Mar  6 18:53:41] ERROR [localhost] (1/1) Failed: docker, err: [Failed to ssh-keyscan. cmd: /usr/bin/ssh-keyscan -p 2222 127.0.0.1, err:
    github.com/future-architect/vuls/scanner.validateSSHConfig
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/scanner.go:447
  - exit status 1]
[Mar  6 18:53:41] ERROR [localhost] Failed to scan: Failed to init servers. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/scanner.go:93
  - No scannable host OS:
    github.com/future-architect/vuls/scanner.Scanner.initServers
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/scanner.go:300
```

### after
```console
$ vuls scan
[Mar  6 18:50:16]  INFO [localhost] vuls-v0.24.9-build-20240306_184913_bf14b5f
[Mar  6 18:50:16]  INFO [localhost] Start scanning
[Mar  6 18:50:16]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Mar  6 18:50:16]  INFO [localhost] Validating config...
[Mar  6 18:50:16]  INFO [localhost] Detecting Server/Container OS... 
[Mar  6 18:50:16]  INFO [localhost] Detecting OS of servers... 
[Mar  6 18:50:16] ERROR [localhost] (1/1) Failed: docker, err: [Failed to ssh-keyscan. cmd: /usr/bin/ssh-keyscan -p 2222 127.0.0.1, err:
    github.com/future-architect/vuls/scanner.validateSSHConfig
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/scanner.go:447
  - exit status 1]
[Mar  6 18:50:16]  INFO [localhost] Detecting OS of containers... 
[Mar  6 18:50:16]  INFO [localhost] Checking Scan Modes... 
[Mar  6 18:50:16]  INFO [localhost] Detecting Platforms... 
[Mar  6 18:50:16]  WARN [localhost] Some warnings occurred during scanning on docker. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family:  Release: `]


Scan Summary
================
docker	Error		Use configtest subcommand or scan with --debug to view the details

Warning: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family:  Release: `]
[Mar  6 18:50:16] ERROR [localhost] Failed to scan: Failed to scan. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/scanner.go:110
  - An error occurred on [docker]
```

## some servers failed
### before
```console
$ vuls scan
[Mar  6 18:54:43]  INFO [localhost] vuls-v0.24.9-build-20240306_185212_bf14b5f
[Mar  6 18:54:43]  INFO [localhost] Start scanning
[Mar  6 18:54:43]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Mar  6 18:54:43]  INFO [localhost] Validating config...
[Mar  6 18:54:43]  INFO [localhost] Detecting Server/Container OS... 
[Mar  6 18:54:43]  INFO [localhost] Detecting OS of servers... 
[Mar  6 18:54:43]  INFO [localhost] (1/2) Detected: pseudo: pseudo 
[Mar  6 18:54:43] ERROR [localhost] (2/2) Failed: docker, err: [Failed to ssh-keyscan. cmd: /usr/bin/ssh-keyscan -p 2222 127.0.0.1, err:
    github.com/future-architect/vuls/scanner.validateSSHConfig
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/scanner.go:447
  - exit status 1]
[Mar  6 18:54:43]  INFO [localhost] Detecting OS of containers... 
[Mar  6 18:54:43]  INFO [localhost] Checking Scan Modes... 
[Mar  6 18:54:43]  INFO [localhost] Detecting Platforms... 
[Mar  6 18:54:43]  INFO [localhost] (1/1) pseudo is running on other
[Mar  6 18:54:43]  INFO [pseudo] Scanning listen port...
[Mar  6 18:54:43]  INFO [pseudo] Using Port Scanner: Vuls built-in Scanner
[Mar  6 18:54:43]  WARN [localhost] Some warnings occurred during scanning on docker. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family:  Release: `]


Scan Summary
================
pseudo	pseudo	0 installed, 0 updatable
docker	Error 	                        	Use configtest subcommand or scan with --debug to view the details

Warning: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family:  Release: `]
[Mar  6 18:54:43] ERROR [localhost] Failed to scan: Failed to scan. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/scanner.go:110
  - An error occurred on [docker]
```

### after
```console
$ vuls scan
[Mar  6 18:57:37]  INFO [localhost] vuls-v0.24.9-build-20240306_185559_bf01495
[Mar  6 18:57:37]  INFO [localhost] Start scanning
[Mar  6 18:57:37]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Mar  6 18:57:37]  INFO [localhost] Validating config...
[Mar  6 18:57:37]  INFO [localhost] Detecting Server/Container OS... 
[Mar  6 18:57:37]  INFO [localhost] Detecting OS of servers... 
[Mar  6 18:57:37]  INFO [localhost] (1/2) Detected: pseudo: pseudo 
[Mar  6 18:57:37] ERROR [localhost] (2/2) Failed: docker, err: [Failed to ssh-keyscan. cmd: /usr/bin/ssh-keyscan -p 2222 127.0.0.1, err:
    github.com/future-architect/vuls/scanner.validateSSHConfig
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/scanner.go:447
  - exit status 1]
[Mar  6 18:57:37]  INFO [localhost] Detecting OS of containers... 
[Mar  6 18:57:37]  INFO [localhost] Checking Scan Modes... 
[Mar  6 18:57:37]  INFO [localhost] Detecting Platforms... 
[Mar  6 18:57:37]  INFO [localhost] (1/1) pseudo is running on other
[Mar  6 18:57:37]  INFO [pseudo] Scanning listen port...
[Mar  6 18:57:37]  INFO [pseudo] Using Port Scanner: Vuls built-in Scanner
[Mar  6 18:57:37]  WARN [localhost] Some warnings occurred during scanning on docker. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family:  Release: `]


Scan Summary
================
pseudo	pseudo	0 installed, 0 updatable
docker	Error 	                        	Use configtest subcommand or scan with --debug to view the details

Warning: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family:  Release: `]
[Mar  6 18:57:37] ERROR [localhost] Failed to scan: Failed to scan. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/scanner.go:110
  - An error occurred on [docker]
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

