### PR TITLE
fix(amazon): use major version for checking eol, security advisories

### DIFF
--- a/config/os.go
+++ b/config/os.go
@@ -459,7 +459,7 @@ func majorDotMinor(osVer string) (majorDotMinor string) {
 }
 
 func getAmazonLinuxVersion(osRelease string) string {
-	switch s := strings.Fields(osRelease)[0]; s {
+	switch s := strings.Fields(osRelease)[0]; major(s) {
 	case "1":
 		return "1"
 	case "2":

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -815,6 +815,10 @@ func Test_getAmazonLinuxVersion(t *testing.T) {
 			want:    "2023",
 		},
 		{
+			release: "2023.3.20240312",
+			want:    "2023",
+		},
+		{
 			release: "2025",
 			want:    "2025",
 		},

--- a/oval/oval.go
+++ b/oval/oval.go
@@ -52,8 +52,30 @@ func (b Base) CheckIfOvalFetched(osFamily, release string) (bool, error) {
 		return false, nil
 	}
 	ovalRelease := release
-	if osFamily == constant.CentOS {
+	switch osFamily {
+	case constant.CentOS:
 		ovalRelease = strings.TrimPrefix(release, "stream")
+	case constant.Amazon:
+		switch s := strings.Fields(release)[0]; util.Major(s) {
+		case "1":
+			ovalRelease = "1"
+		case "2":
+			ovalRelease = "2"
+		case "2022":
+			ovalRelease = "2022"
+		case "2023":
+			ovalRelease = "2023"
+		case "2025":
+			ovalRelease = "2025"
+		case "2027":
+			ovalRelease = "2027"
+		case "2029":
+			ovalRelease = "2029"
+		default:
+			if _, err := time.Parse("2006.01", s); err == nil {
+				ovalRelease = "1"
+			}
+		}
 	}
 
 	var count int
@@ -89,8 +111,30 @@ func (b Base) CheckIfOvalFresh(osFamily, release string) (ok bool, err error) {
 		return false, nil
 	}
 	ovalRelease := release
-	if osFamily == constant.CentOS {
+	switch osFamily {
+	case constant.CentOS:
 		ovalRelease = strings.TrimPrefix(release, "stream")
+	case constant.Amazon:
+		switch s := strings.Fields(release)[0]; util.Major(s) {
+		case "1":
+			ovalRelease = "1"
+		case "2":
+			ovalRelease = "2"
+		case "2022":
+			ovalRelease = "2022"
+		case "2023":
+			ovalRelease = "2023"
+		case "2025":
+			ovalRelease = "2025"
+		case "2027":
+			ovalRelease = "2027"
+		case "2029":
+			ovalRelease = "2029"
+		default:
+			if _, err := time.Parse("2006.01", s); err == nil {
+				ovalRelease = "1"
+			}
+		}
 	}
 
 	var lastModified time.Time

--- a/oval/util.go
+++ b/oval/util.go
@@ -112,7 +112,7 @@ func getDefsByPackNameViaHTTP(r *models.ScanResult, url string) (relatedDefs ova
 	case constant.CentOS:
 		ovalRelease = strings.TrimPrefix(r.Release, "stream")
 	case constant.Amazon:
-		switch s := strings.Fields(r.Release)[0]; s {
+		switch s := strings.Fields(r.Release)[0]; util.Major(s) {
 		case "1":
 			ovalRelease = "1"
 		case "2":
@@ -286,7 +286,7 @@ func getDefsByPackNameFromOvalDB(r *models.ScanResult, driver ovaldb.DB) (relate
 	case constant.CentOS:
 		ovalRelease = strings.TrimPrefix(r.Release, "stream")
 	case constant.Amazon:
-		switch s := strings.Fields(r.Release)[0]; s {
+		switch s := strings.Fields(r.Release)[0]; util.Major(s) {
 		case "1":
 			ovalRelease = "1"
 		case "2":

--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -192,6 +192,7 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 		// $ cat /etc/amazon-linux-release
 		// Amazon Linux release 2022 (Amazon Linux)
 		// Amazon Linux release 2023 (Amazon Linux)
+		// Amazon Linux release 2023.3.20240312 (Amazon Linux)
 		if r := exec(c, "cat /etc/amazon-linux-release", noSudo); r.isSuccess() {
 			amazon := newAmazon(c)
 			result := releasePattern.FindStringSubmatch(strings.TrimSpace(r.Stdout))
@@ -311,6 +312,7 @@ func detectRedhat(c config.ServerInfo) (bool, osTypeInterface) {
 			case strings.HasPrefix(r.Stdout, "Amazon Linux 2023"), strings.HasPrefix(r.Stdout, "Amazon Linux release 2023"):
 				// Amazon Linux 2023 (Amazon Linux)
 				// Amazon Linux release 2023 (Amazon Linux)
+				// Amazon Linux release 2023.3.20240312 (Amazon Linux)
 				release = "2023"
 			case strings.HasPrefix(r.Stdout, "Amazon Linux 2"), strings.HasPrefix(r.Stdout, "Amazon Linux release 2"):
 				// Amazon Linux 2 (Karoo)


### PR DESCRIPTION
# What did you implement:

It seems that the latest Amazon Linux version has been changed to major.minor.patch version instead of major version.

![image](https://github.com/future-architect/vuls/assets/16035056/603954c3-9749-4c92-91c2-84f8daf18794)
ref: https://github.com/aquasecurity/trivy-db/issues/390

Security advisories and EOL are in major version units, so the major version is always used for detection and EOL checks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ vuls scan
[Mar 15 17:27:06]  INFO [localhost] vuls-v0.25.1-build-20240315_172553_426eb53
[Mar 15 17:27:06]  INFO [localhost] Start scanning
[Mar 15 17:27:06]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Mar 15 17:27:06]  INFO [localhost] Validating config...
[Mar 15 17:27:06]  INFO [localhost] Detecting Server/Container OS... 
[Mar 15 17:27:06]  INFO [localhost] Detecting OS of servers... 
[Mar 15 17:27:07]  INFO [localhost] (1/1) Detected: docker: amazon 2023.3.20240312
[Mar 15 17:27:07]  INFO [localhost] Detecting OS of containers... 
[Mar 15 17:27:07]  INFO [localhost] Checking Scan Modes... 
[Mar 15 17:27:07]  INFO [localhost] Detecting Platforms... 
[Mar 15 17:27:07]  INFO [localhost] (1/1) docker is running on unknown
[Mar 15 17:27:07]  INFO [docker] Scanning OS pkg in fast offline mode
[Mar 15 17:27:07]  WARN [localhost] Some warnings occurred during scanning on docker. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family: amazon Release: 2023.3.20240312`]


Scan Summary
================
docker	amazon2023.3.20240312	160 installed

Warning: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family: amazon Release: 2023.3.20240312`]



To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ vuls report
[Mar 15 17:28:52]  INFO [localhost] vuls-v0.25.1-build-20240315_172553_426eb53
[Mar 15 17:28:52]  INFO [localhost] Validating config...
[Mar 15 17:28:52]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Mar 15 17:28:52]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/usr/share/vuls-data/oval.sqlite3
[Mar 15 17:28:52]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/usr/share/vuls-data/gost.sqlite3
[Mar 15 17:28:52]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Mar 15 17:28:52]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Mar 15 17:28:52]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/usr/share/vuls-data/go-kev.sqlite3
[Mar 15 17:28:52]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/usr/share/vuls-data/go-cti.sqlite3
[Mar 15 17:28:52]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2024-03-15T17-27-07+0900
[Mar 15 17:28:52]  INFO [localhost] OVAL amazon 2023.3.20240312 found. defs: 0
[Mar 15 17:28:52] ERROR [localhost] Failed to detect Pkg CVE:
    github.com/future-architect/vuls/detector.Detect
        /home/mainek00n/github/github.com/MaineK00n/vuls/detector/detector.go:54
  - Failed to detect CVE with OVAL:
    github.com/future-architect/vuls/detector.DetectPkgCves
        /home/mainek00n/github/github.com/MaineK00n/vuls/detector/detector.go:331
  - OVAL entries of amazon 2023.3.20240312 are not found. Fetch OVAL before reporting. For details, see `https://github.com/vulsio/goval-dictionary#usage`:
    github.com/future-architect/vuls/detector.detectPkgsCvesWithOval
        /home/mainek00n/github/github.com/MaineK00n/vuls/detector/detector.go:551
```

## after
```console
$ vuls scan
[Mar 15 18:00:37]  INFO [localhost] vuls-v0.25.1-build-20240315_175831_8a63d5f
[Mar 15 18:00:37]  INFO [localhost] Start scanning
[Mar 15 18:00:37]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Mar 15 18:00:37]  INFO [localhost] Validating config...
[Mar 15 18:00:37]  INFO [localhost] Detecting Server/Container OS... 
[Mar 15 18:00:37]  INFO [localhost] Detecting OS of servers... 
[Mar 15 18:00:37]  INFO [localhost] (1/1) Detected: docker: amazon 2023.3.20240312
[Mar 15 18:00:37]  INFO [localhost] Detecting OS of containers... 
[Mar 15 18:00:37]  INFO [localhost] Checking Scan Modes... 
[Mar 15 18:00:37]  INFO [localhost] Detecting Platforms... 
[Mar 15 18:00:37]  INFO [localhost] (1/1) docker is running on unknown
[Mar 15 18:00:37]  INFO [docker] Scanning OS pkg in fast offline mode


Scan Summary
================
docker	amazon2023.3.20240312	160 installed





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ vuls report
[Mar 15 18:17:45]  INFO [localhost] vuls-v0.25.1-build-20240315_175831_8a63d5f
[Mar 15 18:17:45]  INFO [localhost] Validating config...
[Mar 15 18:17:45]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Mar 15 18:17:45]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/goval-dictionary/oval.sqlite3
[Mar 15 18:17:45]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/usr/share/vuls-data/gost.sqlite3
[Mar 15 18:17:45]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Mar 15 18:17:45]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Mar 15 18:17:45]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/usr/share/vuls-data/go-kev.sqlite3
[Mar 15 18:17:45]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/usr/share/vuls-data/go-cti.sqlite3
[Mar 15 18:17:45]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2024-03-15T18-00-37+0900
[Mar 15 18:17:45]  INFO [localhost] OVAL amazon 2023 found. defs: 578
[Mar 15 18:17:45]  INFO [localhost] OVAL amazon 2023 is fresh. lastModified: 2024-03-15T17:32:50+09:00
[Mar 15 18:17:45]  INFO [localhost] docker: 0 CVEs are detected with OVAL
[Mar 15 18:17:45]  INFO [localhost] docker: 0 unfixed CVEs are detected with gost
[Mar 15 18:17:45]  INFO [localhost] docker: 0 CVEs are detected with CPE
[Mar 15 18:17:45]  INFO [localhost] docker: 0 PoC are detected
[Mar 15 18:17:45]  INFO [localhost] docker: 0 exploits are detected
[Mar 15 18:17:45]  INFO [localhost] docker: Known Exploited Vulnerabilities are detected for 0 CVEs
[Mar 15 18:17:45]  INFO [localhost] docker: Cyber Threat Intelligences are detected for 0 CVEs
[Mar 15 18:17:45]  INFO [localhost] docker: total 0 CVEs detected
[Mar 15 18:17:45]  INFO [localhost] docker: 0 CVEs filtered by --confidence-over=80

docker (amazon2023.3.20240312)
==============================
Total: 0 (Critical:0 High:0 Medium:0 Low:0 ?:0)
0/0 Fixed, 0 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
160 installed

No CVE-IDs are found in updatable packages.
160 installed
```

## before scan, after report
The EOL check fails, but the security advisory check succeeds.
```console
$ vuls.master scan
[Mar 15 18:24:53]  INFO [localhost] vuls-v0.25.1-build-20240315_174833_426eb53
[Mar 15 18:24:53]  INFO [localhost] Start scanning
[Mar 15 18:24:53]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[Mar 15 18:24:53]  INFO [localhost] Validating config...
[Mar 15 18:24:53]  INFO [localhost] Detecting Server/Container OS... 
[Mar 15 18:24:53]  INFO [localhost] Detecting OS of servers... 
[Mar 15 18:24:53]  INFO [localhost] (1/1) Detected: docker: amazon 2023.3.20240312
[Mar 15 18:24:53]  INFO [localhost] Detecting OS of containers... 
[Mar 15 18:24:53]  INFO [localhost] Checking Scan Modes... 
[Mar 15 18:24:53]  INFO [localhost] Detecting Platforms... 
[Mar 15 18:24:53]  INFO [localhost] (1/1) docker is running on unknown
[Mar 15 18:24:53]  INFO [docker] Scanning OS pkg in fast offline mode
[Mar 15 18:24:53]  WARN [localhost] Some warnings occurred during scanning on docker. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family: amazon Release: 2023.3.20240312`]


Scan Summary
================
docker	amazon2023.3.20240312	160 installed

Warning: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family: amazon Release: 2023.3.20240312`]



To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ vuls report
[Mar 15 18:25:07]  INFO [localhost] vuls-v0.25.1-build-20240315_175831_8a63d5f
[Mar 15 18:25:07]  INFO [localhost] Validating config...
[Mar 15 18:25:07]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/usr/share/vuls-data/cve.sqlite3
[Mar 15 18:25:07]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/goval-dictionary/oval.sqlite3
[Mar 15 18:25:07]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/usr/share/vuls-data/gost.sqlite3
[Mar 15 18:25:07]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/usr/share/vuls-data/go-exploitdb.sqlite3
[Mar 15 18:25:07]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/usr/share/vuls-data/go-msfdb.sqlite3
[Mar 15 18:25:07]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/usr/share/vuls-data/go-kev.sqlite3
[Mar 15 18:25:07]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/usr/share/vuls-data/go-cti.sqlite3
[Mar 15 18:25:07]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2024-03-15T18-24-53+0900
[Mar 15 18:25:07]  INFO [localhost] OVAL amazon 2023 found. defs: 578
[Mar 15 18:25:07]  INFO [localhost] OVAL amazon 2023 is fresh. lastModified: 2024-03-15T17:32:50+09:00
[Mar 15 18:25:07]  INFO [localhost] docker: 0 CVEs are detected with OVAL
[Mar 15 18:25:07]  INFO [localhost] docker: 0 unfixed CVEs are detected with gost
[Mar 15 18:25:07]  INFO [localhost] docker: 0 CVEs are detected with CPE
[Mar 15 18:25:07]  INFO [localhost] docker: 0 PoC are detected
[Mar 15 18:25:07]  INFO [localhost] docker: 0 exploits are detected
[Mar 15 18:25:07]  INFO [localhost] docker: Known Exploited Vulnerabilities are detected for 0 CVEs
[Mar 15 18:25:07]  INFO [localhost] docker: Cyber Threat Intelligences are detected for 0 CVEs
[Mar 15 18:25:07]  INFO [localhost] docker: total 0 CVEs detected
[Mar 15 18:25:07]  INFO [localhost] docker: 0 CVEs filtered by --confidence-over=80

docker (amazon2023.3.20240312)
==============================
Total: 0 (Critical:0 High:0 Medium:0 Low:0 ?:0)
0/0 Fixed, 0 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
160 installed

Warning: Some warnings occurred.
[Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family: amazon Release: 2023.3.20240312`]


No CVE-IDs are found in updatable packages.
160 installed
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

