### PR TITLE
feat(wpscan): support enterprise feature

### DIFF
--- a/detector/wordpress.go
+++ b/detector/wordpress.go
@@ -57,6 +57,7 @@ type References struct {
 	URL     []string `json:"url"`
 	Cve     []string `json:"cve"`
 	YouTube []string `json:"youtube,omitempty"`
+	ExploitDB []string `json:"exploitdb,omitempty"`
 }
 
 // CVSS is for wpscan json

--- a/detector/wordpress.go
+++ b/detector/wordpress.go
@@ -54,9 +54,9 @@ type WpCveInfo struct {
 
 // References is for wpscan json
 type References struct {
-	URL     []string `json:"url"`
-	Cve     []string `json:"cve"`
-	YouTube []string `json:"youtube,omitempty"`
+	URL       []string `json:"url"`
+	Cve       []string `json:"cve"`
+	YouTube   []string `json:"youtube,omitempty"`
 	ExploitDB []string `json:"exploitdb,omitempty"`
 }
 
@@ -221,9 +221,14 @@ func extractToVulnInfos(pkgName string, cves []WpCveInfo) (vinfos []models.VulnI
 				Link: url,
 			})
 		}
-		for _, key := range vulnerability.References.YouTube {
+		for _, id := range vulnerability.References.YouTube {
 			refs = append(refs, models.Reference{
-				Link: fmt.Sprintf("https://www.youtube.com/watch?v=%s", key),
+				Link: fmt.Sprintf("https://www.youtube.com/watch?v=%s", id),
+			})
+		}
+		for _, id := range vulnerability.References.ExploitDB {
+			refs = append(refs, models.Reference{
+				Link: fmt.Sprintf("https://www.exploit-db.com/exploits/%s", id),
 			})
 		}
 

--- a/detector/wordpress.go
+++ b/detector/wordpress.go
@@ -226,7 +226,7 @@ func extractToVulnInfos(pkgName string, cves []wpCveInfo) (vinfos []models.VulnI
 		for _, id := range vulnerability.References.ExploitDB {
 			exploits = append(exploits, models.Exploit{
 				ExploitType: "wpscan",
-				ID:          id,
+				ID:          fmt.Sprintf("Exploit-DB: %s", id),
 				URL:         fmt.Sprintf("https://www.exploit-db.com/exploits/%s", id),
 			})
 		}

--- a/detector/wordpress.go
+++ b/detector/wordpress.go
@@ -22,20 +22,20 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// WpCveInfos is for wpscan json
-type WpCveInfos struct {
+// wpCveInfos is for wpscan json
+type wpCveInfos struct {
 	ReleaseDate  string `json:"release_date"`
 	ChangelogURL string `json:"changelog_url"`
 	// Status        string `json:"status"`
 	LatestVersion string `json:"latest_version"`
 	LastUpdated   string `json:"last_updated"`
 	// Popular         bool        `json:"popular"`
-	Vulnerabilities []WpCveInfo `json:"vulnerabilities"`
+	Vulnerabilities []wpCveInfo `json:"vulnerabilities"`
 	Error           string      `json:"error"`
 }
 
-// WpCveInfo is for wpscan json
-type WpCveInfo struct {
+// wpCveInfo is for wpscan json
+type wpCveInfo struct {
 	ID            string     `json:"id"`
 	Title         string     `json:"title"`
 	CreatedAt     time.Time  `json:"created_at"`
@@ -44,7 +44,7 @@ type WpCveInfo struct {
 	Description   *string    `json:"description"` // Enterprise only
 	Poc           *string    `json:"poc"`         // Enterprise only
 	VulnType      string     `json:"vuln_type"`
-	References    References `json:"references"`
+	References    references `json:"references"`
 	Cvss          *Cvss      `json:"cvss"` // Enterprise only
 	Verified      bool       `json:"verified"`
 	FixedIn       *string    `json:"fixed_in"`
@@ -52,8 +52,8 @@ type WpCveInfo struct {
 	Closed        *Closed    `json:"closed"`
 }
 
-// References is for wpscan json
-type References struct {
+// references is for wpscan json
+type references struct {
 	URL       []string `json:"url"`
 	Cve       []string `json:"cve"`
 	YouTube   []string `json:"youtube,omitempty"`
@@ -187,7 +187,7 @@ func convertToVinfos(pkgName, body string) (vinfos []models.VulnInfo, err error)
 		return
 	}
 	// "pkgName" : CVE Detailed data
-	pkgnameCves := map[string]WpCveInfos{}
+	pkgnameCves := map[string]wpCveInfos{}
 	if err = json.Unmarshal([]byte(body), &pkgnameCves); err != nil {
 		return nil, xerrors.Errorf("Failed to unmarshal %s. err: %w", body, err)
 	}
@@ -199,7 +199,7 @@ func convertToVinfos(pkgName, body string) (vinfos []models.VulnInfo, err error)
 	return vinfos, nil
 }
 
-func extractToVulnInfos(pkgName string, cves []WpCveInfo) (vinfos []models.VulnInfo) {
+func extractToVulnInfos(pkgName string, cves []wpCveInfo) (vinfos []models.VulnInfo) {
 	for _, vulnerability := range cves {
 		var cveIDs []string
 

--- a/detector/wordpress.go
+++ b/detector/wordpress.go
@@ -19,7 +19,6 @@ import (
 	"github.com/future-architect/vuls/models"
 	"github.com/future-architect/vuls/util"
 	version "github.com/hashicorp/go-version"
-	exploitmodels "github.com/vulsio/go-exploitdb/models"
 	"golang.org/x/xerrors"
 )
 
@@ -226,7 +225,7 @@ func extractToVulnInfos(pkgName string, cves []wpCveInfo) (vinfos []models.VulnI
 		var exploits []models.Exploit
 		for _, id := range vulnerability.References.ExploitDB {
 			exploits = append(exploits, models.Exploit{
-				ExploitType: exploitmodels.OffensiveSecurityType,
+				ExploitType: "wpscan",
 				ID:          id,
 				URL:         fmt.Sprintf("https://www.exploit-db.com/exploits/%s", id),
 			})

--- a/detector/wordpress_test.go
+++ b/detector/wordpress_test.go
@@ -6,6 +6,7 @@ package detector
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/future-architect/vuls/models"
 )
@@ -80,5 +81,163 @@ func TestRemoveInactive(t *testing.T) {
 		if !reflect.DeepEqual(actual, tt.expected) {
 			t.Errorf("[%d] WordPressPackages error ", i)
 		}
+	}
+}
+
+// ref: https://wpscan.com/docs/api/v3/v3.yml/
+func Test_convertToVinfos(t *testing.T) {
+	type args struct {
+		pkgName string
+		body    string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantVinfos []models.VulnInfo
+		wantErr    bool
+	}{
+		{
+			name: "WordPress vulnerabilities Enterprise",
+			args: args{
+				pkgName: "4.9.4",
+				body: `
+{
+	"4.9.4": {
+		"release_date": "2018-02-06",
+		"changelog_url": "https://codex.wordpress.org/Version_4.9.4",
+		"status": "insecure",
+		"vulnerabilities": [
+			{
+				"id": "5e0c1ddd-fdd0-421b-bdbe-3eee6b75c919",
+				"title": "WordPress <= 4.9.4 - Application Denial of Service (DoS) (unpatched)",
+				"created_at": "2018-02-05T16:50:40.000Z",
+				"updated_at": "2020-09-22T07:24:12.000Z",
+				"published_date": "2018-02-05T00:00:00.000Z",
+				"description": "An application Denial of Service (DoS) was found to affect WordPress versions 4.9.4 and below. We are not aware of a patch for this issue.",
+				"poc": "string",
+				"vuln_type": "DOS",
+				"references": {
+					"url": [
+						"https://baraktawily.blogspot.fr/2018/02/how-to-dos-29-of-world-wide-websites.html"
+					]
+				},
+				"cvss": {
+					"score": "7.5",
+					"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+					"severity": "high"
+				},
+				"verified": false,
+				"fixed_in": "4.9.5",
+				"introduced_in": "1.0"
+			}
+		]
+	}
+}`,
+			},
+			wantVinfos: []models.VulnInfo{
+				{
+					CveID: "WPVDBID-5e0c1ddd-fdd0-421b-bdbe-3eee6b75c919",
+					CveContents: models.NewCveContents(
+						models.CveContent{
+							Type:          "wpscan",
+							CveID:         "WPVDBID-5e0c1ddd-fdd0-421b-bdbe-3eee6b75c919",
+							Title:         "WordPress <= 4.9.4 - Application Denial of Service (DoS) (unpatched)",
+							Cvss3Score:    7.5,
+							Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+							Cvss3Severity: "high",
+							References: []models.Reference{
+								{Link: "https://baraktawily.blogspot.fr/2018/02/how-to-dos-29-of-world-wide-websites.html"},
+							},
+							Published:    time.Date(2018, 2, 5, 16, 50, 40, 0, time.UTC),
+							LastModified: time.Date(2020, 9, 22, 7, 24, 12, 0, time.UTC),
+						},
+					),
+					VulnType: "DOS",
+					Confidences: []models.Confidence{
+						models.WpScanMatch,
+					},
+					WpPackageFixStats: []models.WpPackageFixStatus{
+						{
+							Name:    "4.9.4",
+							FixedIn: "4.9.5",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "WordPress vulnerabilities Researcher",
+			args: args{
+				pkgName: "4.9.4",
+				body: `
+{
+	"4.9.4": {
+		"release_date": "2018-02-06",
+		"changelog_url": "https://codex.wordpress.org/Version_4.9.4",
+		"status": "insecure",
+		"vulnerabilities": [
+			{
+				"id": "5e0c1ddd-fdd0-421b-bdbe-3eee6b75c919",
+				"title": "WordPress <= 4.9.4 - Application Denial of Service (DoS) (unpatched)",
+				"created_at": "2018-02-05T16:50:40.000Z",
+				"updated_at": "2020-09-22T07:24:12.000Z",
+				"published_date": "2018-02-05T00:00:00.000Z",
+				"description": null,
+				"poc": null,
+				"vuln_type": "DOS",
+				"references": {
+					"url": [
+						"https://baraktawily.blogspot.fr/2018/02/how-to-dos-29-of-world-wide-websites.html"
+					]
+				},
+				"cvss": null,
+				"verified": false,
+				"fixed_in": "4.9.5",
+				"introduced_in": null
+			}
+		]
+	}
+}`,
+			},
+			wantVinfos: []models.VulnInfo{
+				{
+					CveID: "WPVDBID-5e0c1ddd-fdd0-421b-bdbe-3eee6b75c919",
+					CveContents: models.NewCveContents(
+						models.CveContent{
+							Type:  "wpscan",
+							CveID: "WPVDBID-5e0c1ddd-fdd0-421b-bdbe-3eee6b75c919",
+							Title: "WordPress <= 4.9.4 - Application Denial of Service (DoS) (unpatched)",
+							References: []models.Reference{
+								{Link: "https://baraktawily.blogspot.fr/2018/02/how-to-dos-29-of-world-wide-websites.html"},
+							},
+							Published:    time.Date(2018, 2, 5, 16, 50, 40, 0, time.UTC),
+							LastModified: time.Date(2020, 9, 22, 7, 24, 12, 0, time.UTC),
+						},
+					),
+					VulnType: "DOS",
+					Confidences: []models.Confidence{
+						models.WpScanMatch,
+					},
+					WpPackageFixStats: []models.WpPackageFixStatus{
+						{
+							Name:    "4.9.4",
+							FixedIn: "4.9.5",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVinfos, err := convertToVinfos(tt.args.pkgName, tt.args.body)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("convertToVinfos() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotVinfos, tt.wantVinfos) {
+				t.Errorf("convertToVinfos() = %v, want %v", gotVinfos, tt.wantVinfos)
+			}
+		})
 	}
 }

--- a/detector/wordpress_test.go
+++ b/detector/wordpress_test.go
@@ -84,7 +84,7 @@ func TestRemoveInactive(t *testing.T) {
 	}
 }
 
-// ref: https://wpscan.com/docs/api/v3/v3.yml/
+// https://wpscan.com/docs/api/v3/v3.yml/
 func Test_convertToVinfos(t *testing.T) {
 	type args struct {
 		pkgName string

--- a/detector/wordpress_test.go
+++ b/detector/wordpress_test.go
@@ -91,10 +91,10 @@ func Test_convertToVinfos(t *testing.T) {
 		body    string
 	}
 	tests := []struct {
-		name       string
-		args       args
-		wantVinfos []models.VulnInfo
-		wantErr    bool
+		name        string
+		args        args
+		expected    []models.VulnInfo
+		expectedErr bool
 	}{
 		{
 			name: "WordPress vulnerabilities Enterprise",
@@ -114,11 +114,14 @@ func Test_convertToVinfos(t *testing.T) {
 				"updated_at": "2020-09-22T07:24:12.000Z",
 				"published_date": "2018-02-05T00:00:00.000Z",
 				"description": "An application Denial of Service (DoS) was found to affect WordPress versions 4.9.4 and below. We are not aware of a patch for this issue.",
-				"poc": "string",
+				"poc": "poc source url",
 				"vuln_type": "DOS",
 				"references": {
 					"url": [
 						"https://baraktawily.blogspot.fr/2018/02/how-to-dos-29-of-world-wide-websites.html"
+					],
+					"cve": [
+						"2018-6389"
 					]
 				},
 				"cvss": {
@@ -134,22 +137,27 @@ func Test_convertToVinfos(t *testing.T) {
 	}
 }`,
 			},
-			wantVinfos: []models.VulnInfo{
+			expected: []models.VulnInfo{
 				{
-					CveID: "WPVDBID-5e0c1ddd-fdd0-421b-bdbe-3eee6b75c919",
+					CveID: "CVE-2018-6389",
 					CveContents: models.NewCveContents(
 						models.CveContent{
 							Type:          "wpscan",
-							CveID:         "WPVDBID-5e0c1ddd-fdd0-421b-bdbe-3eee6b75c919",
+							CveID:         "CVE-2018-6389",
 							Title:         "WordPress <= 4.9.4 - Application Denial of Service (DoS) (unpatched)",
+							Summary:       "An application Denial of Service (DoS) was found to affect WordPress versions 4.9.4 and below. We are not aware of a patch for this issue.",
 							Cvss3Score:    7.5,
 							Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
 							Cvss3Severity: "high",
 							References: []models.Reference{
+								{Source: "poc source url"},
 								{Link: "https://baraktawily.blogspot.fr/2018/02/how-to-dos-29-of-world-wide-websites.html"},
 							},
 							Published:    time.Date(2018, 2, 5, 16, 50, 40, 0, time.UTC),
 							LastModified: time.Date(2020, 9, 22, 7, 24, 12, 0, time.UTC),
+							Optional: map[string]string{
+								"introduced_in": "1.0",
+							},
 						},
 					),
 					VulnType: "DOS",
@@ -188,6 +196,9 @@ func Test_convertToVinfos(t *testing.T) {
 				"references": {
 					"url": [
 						"https://baraktawily.blogspot.fr/2018/02/how-to-dos-29-of-world-wide-websites.html"
+					],
+					"cve": [
+						"2018-6389"
 					]
 				},
 				"cvss": null,
@@ -199,19 +210,20 @@ func Test_convertToVinfos(t *testing.T) {
 	}
 }`,
 			},
-			wantVinfos: []models.VulnInfo{
+			expected: []models.VulnInfo{
 				{
-					CveID: "WPVDBID-5e0c1ddd-fdd0-421b-bdbe-3eee6b75c919",
+					CveID: "CVE-2018-6389",
 					CveContents: models.NewCveContents(
 						models.CveContent{
 							Type:  "wpscan",
-							CveID: "WPVDBID-5e0c1ddd-fdd0-421b-bdbe-3eee6b75c919",
+							CveID: "CVE-2018-6389",
 							Title: "WordPress <= 4.9.4 - Application Denial of Service (DoS) (unpatched)",
 							References: []models.Reference{
 								{Link: "https://baraktawily.blogspot.fr/2018/02/how-to-dos-29-of-world-wide-websites.html"},
 							},
 							Published:    time.Date(2018, 2, 5, 16, 50, 40, 0, time.UTC),
 							LastModified: time.Date(2020, 9, 22, 7, 24, 12, 0, time.UTC),
+							Optional:     map[string]string{},
 						},
 					),
 					VulnType: "DOS",
@@ -230,13 +242,13 @@ func Test_convertToVinfos(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotVinfos, err := convertToVinfos(tt.args.pkgName, tt.args.body)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("convertToVinfos() error = %v, wantErr %v", err, tt.wantErr)
+			got, err := convertToVinfos(tt.args.pkgName, tt.args.body)
+			if (err != nil) != tt.expectedErr {
+				t.Errorf("convertToVinfos() error = %v, wantErr %v", err, tt.expectedErr)
 				return
 			}
-			if !reflect.DeepEqual(gotVinfos, tt.wantVinfos) {
-				t.Errorf("convertToVinfos() = %v, want %v", gotVinfos, tt.wantVinfos)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("convertToVinfos() = %+v, want %+v", got, tt.expected)
 			}
 		})
 	}

--- a/detector/wordpress_test.go
+++ b/detector/wordpress_test.go
@@ -114,7 +114,7 @@ func Test_convertToVinfos(t *testing.T) {
 				"updated_at": "2020-09-22T07:24:12.000Z",
 				"published_date": "2018-02-05T00:00:00.000Z",
 				"description": "An application Denial of Service (DoS) was found to affect WordPress versions 4.9.4 and below. We are not aware of a patch for this issue.",
-				"poc": "poc source url",
+				"poc": "poc url or description",
 				"vuln_type": "DOS",
 				"references": {
 					"url": [
@@ -150,13 +150,13 @@ func Test_convertToVinfos(t *testing.T) {
 							Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
 							Cvss3Severity: "high",
 							References: []models.Reference{
-								{Source: "poc source url"},
 								{Link: "https://baraktawily.blogspot.fr/2018/02/how-to-dos-29-of-world-wide-websites.html"},
 							},
 							Published:    time.Date(2018, 2, 5, 16, 50, 40, 0, time.UTC),
 							LastModified: time.Date(2020, 9, 22, 7, 24, 12, 0, time.UTC),
 							Optional: map[string]string{
 								"introduced_in": "1.0",
+								"poc":           "poc url or description",
 							},
 						},
 					),

--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -274,9 +274,9 @@ type CveContent struct {
 	Cvss2Score    float64           `json:"cvss2Score"`
 	Cvss2Vector   string            `json:"cvss2Vector"`
 	Cvss2Severity string            `json:"cvss2Severity"`
-	Cvss3Score    float64           `json:"cvss3Score"`
-	Cvss3Vector   string            `json:"cvss3Vector"`
-	Cvss3Severity string            `json:"cvss3Severity"`
+	Cvss3Score    float64           `json:"cvss3Score,omitempty"`
+	Cvss3Vector   string            `json:"cvss3Vector,omitempty"`
+	Cvss3Severity string            `json:"cvss3Severity,omitempty"`
 	SourceLink    string            `json:"sourceLink"`
 	Cpes          []Cpe             `json:"cpes,omitempty"`
 	References    References        `json:"references,omitempty"`

--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -274,9 +274,9 @@ type CveContent struct {
 	Cvss2Score    float64           `json:"cvss2Score"`
 	Cvss2Vector   string            `json:"cvss2Vector"`
 	Cvss2Severity string            `json:"cvss2Severity"`
-	Cvss3Score    float64           `json:"cvss3Score,omitempty"`
-	Cvss3Vector   string            `json:"cvss3Vector,omitempty"`
-	Cvss3Severity string            `json:"cvss3Severity,omitempty"`
+	Cvss3Score    float64           `json:"cvss3Score"`
+	Cvss3Vector   string            `json:"cvss3Vector"`
+	Cvss3Severity string            `json:"cvss3Severity"`
 	SourceLink    string            `json:"sourceLink"`
 	Cpes          []Cpe             `json:"cpes,omitempty"`
 	References    References        `json:"references,omitempty"`


### PR DESCRIPTION
# What did you implement:

There are two versions of wpscan:
・Free researcher version
・Paid enterprise version

This PR have accommodated the values obtained in the enterprise version.
And changed the structure that is only used for unmarshal of json in wpscan to unexported.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I ran `make test` in the local environment.
And I have also confirmed the passing of the following tests added this time.

```sh
$ go test -v -run Test_convertToVinfos
=== RUN   Test_convertToVinfos
=== RUN   Test_convertToVinfos/WordPress_vulnerabilities_Enterprise
=== RUN   Test_convertToVinfos/WordPress_vulnerabilities_Researcher
--- PASS: Test_convertToVinfos (0.00s)
    --- PASS: Test_convertToVinfos/WordPress_vulnerabilities_Enterprise (0.00s)
    --- PASS: Test_convertToVinfos/WordPress_vulnerabilities_Researcher (0.00s)
PASS
ok      github.com/future-architect/vuls/detector       0.016s
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes  

# Reference

* Enterprise Features
  * https://wpscan.com/enterprise-customers-features/
  * https://wpscan.com/blog/new-description-and-poc-fields-in-api/
* WPScan WordPress Vulnerability Database API
  * https://wpscan.com/docs/api/v3/v3.yml/
  * https://wpscan.com/docs/api/v3/
