### PR TITLE
(fix) Exclude dev dependencies from npm's package-lock.json and Fix Java DB download endpoint

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -90,7 +90,7 @@ NOW=$(shell date '+%Y-%m-%dT%H-%M-%S%z')
 NOW_JSON_DIR := '${BASE_DIR}/$(NOW)'
 ONE_SEC_AFTER=$(shell date -d '+1 second' '+%Y-%m-%dT%H-%M-%S%z')
 ONE_SEC_AFTER_JSON_DIR := '${BASE_DIR}/$(ONE_SEC_AFTER)'
-LIBS := 'bundler' 'dart' 'elixir' 'pip' 'pipenv' 'poetry' 'composer' 'npm' 'yarn' 'pnpm' 'cargo' 'gomod' 'gosum' 'gobinary' 'jar' 'jar-wrong-name-log4j-core' 'war' 'pom' 'gradle' 'nuget-lock' 'nuget-config' 'dotnet-deps' 'dotnet-package-props' 'conan' 'swift-cocoapods' 'swift-swift' 'rust-binary'
+LIBS := 'bundler' 'dart' 'elixir' 'pip' 'pipenv' 'poetry' 'composer' 'npm-v1' 'npm-v2' 'npm-v3' 'yarn' 'pnpm' 'cargo' 'gomod' 'gosum' 'gobinary' 'jar' 'jar-wrong-name-log4j-core' 'war' 'pom' 'gradle' 'nuget-lock' 'nuget-config' 'dotnet-deps' 'dotnet-package-props' 'conan' 'swift-cocoapods' 'swift-swift' 'rust-binary'
 
 diff:
 	# git clone git@github.com:vulsio/vulsctl.git

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -7,7 +7,6 @@ package javadb
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -40,12 +39,11 @@ func UpdateJavaDB(trivyOpts config.TrivyOpts, noProgress bool) error {
 
 	if (meta.Version != db.SchemaVersion || meta.NextUpdate.Before(time.Now().UTC())) && !trivyOpts.TrivySkipJavaDBUpdate {
 		// Download DB
-		repo := fmt.Sprintf("%s:%d", trivyOpts.TrivyJavaDBRepository, db.SchemaVersion)
-		logging.Log.Infof("Trivy Java DB Repository: %s", repo)
+		logging.Log.Infof("Trivy Java DB Repository: %s", trivyOpts.TrivyJavaDBRepository)
 		logging.Log.Info("Downloading Trivy Java DB...")
 
 		var a *oci.Artifact
-		if a, err = oci.NewArtifact(repo, noProgress, types.RegistryOptions{}); err != nil {
+		if a, err = oci.NewArtifact(trivyOpts.TrivyJavaDBRepository, noProgress, types.RegistryOptions{}); err != nil {
 			return xerrors.Errorf("Failed to new oci artifact. err: %w", err)
 		}
 		if err = a.Download(context.Background(), dbDir, oci.DownloadOption{MediaType: "application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"}); err != nil {

--- a/scanner/library.go
+++ b/scanner/library.go
@@ -4,12 +4,19 @@ import (
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/purl"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/samber/lo"
 
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
 )
 
 func convertLibWithScanner(apps []ftypes.Application) ([]models.LibraryScanner, error) {
+	for i := range apps {
+		apps[i].Libraries = lo.Filter(apps[i].Libraries, func(lib ftypes.Package, index int) bool {
+			return !lib.Dev
+		})
+	}
+
 	scanners := make([]models.LibraryScanner, 0, len(apps))
 	for _, app := range apps {
 		libs := make([]models.Library, 0, len(app.Libraries))


### PR DESCRIPTION
# What did you implement:

At 0.25.1, there is regression of npm's package-lock.json scan where dev dependencies are included in library list.
This PR fixes it.
Trivy of 0.50 has dev dependencies excluding feature of three types;
1. npm (package-lock.json), the main point of this fix PR
2. yarn, dev deps exclusion is triggered only when package.json is there alongside of yarn.lock, not the case for vuls (as a consequence, yarn lock file scans *include* dev dependencies)
3. maven (pom.xml) only for integration test cases, it has very specific path pattern "**/[src|target]/it/*/pom.xml" 

Realistically, only effect is npm.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually.

Results will be added as comments.

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

# Reference


