### PR TITLE
style(log) fix trivy docs link

### DIFF
--- a/contrib/trivy/parser/v2/parser.go
+++ b/contrib/trivy/parser/v2/parser.go
@@ -40,7 +40,7 @@ var dockerTagPattern = regexp.MustCompile(`^(.*):(.*)$`)
 
 func setScanResultMeta(scanResult *models.ScanResult, report *types.Report) error {
 	if len(report.Results) == 0 {
-		return xerrors.Errorf("scanned images or libraries are not supported by Trivy. see https://aquasecurity.github.io/trivy/dev/vulnerability/detection/os/, https://aquasecurity.github.io/trivy/dev/vulnerability/detection/language/")
+		return xerrors.Errorf("scanned images or libraries are not supported by Trivy. see https://aquasecurity.github.io/trivy/dev/docs/coverage/os/, https://aquasecurity.github.io/trivy/dev/docs/coverage/language/")
 	}
 
 	scanResult.ServerName = report.ArtifactName

--- a/contrib/trivy/parser/v2/parser_test.go
+++ b/contrib/trivy/parser/v2/parser_test.go
@@ -1075,7 +1075,7 @@ func TestParseError(t *testing.T) {
 	}{
 		"image hello-world": {
 			vulnJSON: helloWorldTrivy,
-			expected: xerrors.Errorf("scanned images or libraries are not supported by Trivy. see https://aquasecurity.github.io/trivy/dev/vulnerability/detection/os/, https://aquasecurity.github.io/trivy/dev/vulnerability/detection/language/"),
+			expected: xerrors.Errorf("scanned images or libraries are not supported by Trivy. see https://aquasecurity.github.io/trivy/dev/docs/coverage/os/, https://aquasecurity.github.io/trivy/dev/docs/coverage/language/"),
 		},
 	}
 


### PR DESCRIPTION
# What did you implement:

I have fixed the broken link to the following trivy docs page.

* https://aquasecurity.github.io/trivy/dev/docs/coverage/os/
* https://aquasecurity.github.io/trivy/dev/docs/coverage/language/

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have run tests related to the edited parts and confirmed that they have passed.

```sh
$ go test -v -run TestParse
=== RUN   TestParse
--- PASS: TestParse (0.00s)
=== RUN   TestParseError
--- PASS: TestParseError (0.00s)
PASS
ok      github.com/future-architect/vuls/contrib/trivy/parser/v2        0.005s
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** Yes  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/
