### PR TITLE
refactor(report/s3): remove deprecated method for s3 endpoint

### DIFF
--- a/reporter/s3.go
+++ b/reporter/s3.go
@@ -33,11 +33,6 @@ type S3Writer struct {
 
 func (w S3Writer) getS3() (*s3.Client, error) {
 	var optFns []func(*awsConfig.LoadOptions) error
-	if w.S3Endpoint != "" {
-		optFns = append(optFns, awsConfig.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-			return aws.Endpoint{URL: w.S3Endpoint}, nil
-		})))
-	}
 	if w.Region != "" {
 		optFns = append(optFns, awsConfig.WithRegion(w.Region))
 	}
@@ -55,7 +50,14 @@ func (w S3Writer) getS3() (*s3.Client, error) {
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to load config. err: %w", err)
 	}
-	return s3.NewFromConfig(cfg, func(o *s3.Options) { o.UsePathStyle = w.S3UsePathStyle }), nil
+	return s3.NewFromConfig(cfg,
+		func(o *s3.Options) {
+			if w.S3Endpoint != "" {
+				o.BaseEndpoint = aws.String(w.S3Endpoint)
+			}
+		},
+		func(o *s3.Options) { o.UsePathStyle = w.S3UsePathStyle },
+	), nil
 }
 
 // Write results to S3


### PR DESCRIPTION
# What did you implement:

The method currently used to configure S3 endpoints is deprecated.
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/config#WithEndpointResolverWithOptions

Refer to the following to set up the S3 BaseEndpoint.
https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/endpoints/

## Type of change

# How Has This Been Tested?
## setup
```console
$ docker run --rm --name minio -p 9000:9000 -p 9001:9001 quay.io/minio/minio server /data --console-address ":9001"
$ docker exec -it minio bash
bash-5.1# mc config host add local http://localhost:9000 minioadmin minioadmin
bash-5.1# mc mb local/vuls
bash-5.1# mc anonymous set public local/vuls
```

## run
```console
$ cat config.toml
[aws]
s3Endpoint = "http://localhost:9000"
region = "us-east-1"
credentialProvider = "anonymous"
s3Bucket = "vuls"
s3UsePathStyle = true

$ vuls report --to-s3

$ docker exec -it minio bash
bash-5.1# mc ls local/vuls/2024-06-12T18:36:18+09:00/
[2024-06-17 09:25:32 UTC]   226B STANDARD pseudo_short.txt
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

