### PR TITLE
fix(config/os): Fix EOL date of ubuntu 23.10

### DIFF
--- a/config/os.go
+++ b/config/os.go
@@ -197,7 +197,7 @@ func GetEOL(family, release string) (eol EOL, found bool) {
 				StandardSupportUntil: time.Date(2024, 1, 25, 23, 59, 59, 0, time.UTC),
 			},
 			"23.10": {
-				StandardSupportUntil: time.Date(2024, 7, 31, 23, 59, 59, 0, time.UTC),
+				StandardSupportUntil: time.Date(2024, 7, 11, 23, 59, 59, 0, time.UTC),
 			},
 			"24.04": {
 				StandardSupportUntil: time.Date(2029, 6, 30, 23, 59, 59, 0, time.UTC),

--- a/config/os_test.go
+++ b/config/os_test.go
@@ -366,7 +366,7 @@ func TestEOL_IsStandardSupportEnded(t *testing.T) {
 		{
 			name:     "Ubuntu 23.10 supported",
 			fields:   fields{family: Ubuntu, release: "23.10"},
-			now:      time.Date(2024, 7, 31, 23, 59, 59, 0, time.UTC),
+			now:      time.Date(2024, 7, 11, 23, 59, 59, 0, time.UTC),
 			found:    true,
 			stdEnded: false,
 			extEnded: false,


### PR DESCRIPTION
cf. https://lists.ubuntu.com/archives/ubuntu-announce/2024-June/000302.html

# What did you implement:

Fix EOL date of Ubuntu 23.10 according to official announce

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

 Unit test

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
