### PR TITLE
feat(cve/mitre): support go-cve-dictionary:mitre

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -204,7 +204,7 @@ func Detect(rs []models.ScanResult, dir string) ([]models.ScanResult, error) {
 			return nil, xerrors.Errorf("Failed to fill with gost: %w", err)
 		}
 
-		if err := FillCvesWithNvdJvnFortinet(&r, config.Conf.CveDict, config.Conf.LogOpts); err != nil {
+		if err := FillCvesWithGoCVEDictionary(&r, config.Conf.CveDict, config.Conf.LogOpts); err != nil {
 			return nil, xerrors.Errorf("Failed to fill with CVE: %w", err)
 		}
 
@@ -435,8 +435,8 @@ func DetectWordPressCves(r *models.ScanResult, wpCnf config.WpScanConf) error {
 	return nil
 }
 
-// FillCvesWithNvdJvnFortinet fills CVE detail with NVD, JVN, Fortinet
-func FillCvesWithNvdJvnFortinet(r *models.ScanResult, cnf config.GoCveDictConf, logOpts logging.LogOpts) (err error) {
+// FillCvesWithGoCVEDictionary fills CVE detail with NVD, JVN, Fortinet, MITRE
+func FillCvesWithGoCVEDictionary(r *models.ScanResult, cnf config.GoCveDictConf, logOpts logging.LogOpts) (err error) {
 	cveIDs := []string{}
 	for _, v := range r.ScannedCves {
 		cveIDs = append(cveIDs, v.CveID)

--- a/detector/util.go
+++ b/detector/util.go
@@ -181,7 +181,7 @@ func getMinusDiffCves(previous, current models.ScanResult) models.VulnInfos {
 }
 
 func isCveInfoUpdated(cveID string, previous, current models.ScanResult) bool {
-	cTypes := append([]models.CveContentType{models.Nvd, models.Jvn}, models.GetCveContentTypes(current.Family)...)
+	cTypes := append([]models.CveContentType{models.Mitre, models.Nvd, models.Jvn}, models.GetCveContentTypes(current.Family)...)
 
 	prevLastModified := map[models.CveContentType][]time.Time{}
 	preVinfo, ok := previous.ScannedCves[cveID]

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/vulsio/go-cti v0.0.5-0.20240318121747-822b3ef289cb
-	github.com/vulsio/go-cve-dictionary v0.10.2-0.20240319004433-af03be313b77
+	github.com/vulsio/go-cve-dictionary v0.10.2-0.20240628072614-73f15707be8e
 	github.com/vulsio/go-exploitdb v0.4.7-0.20240318122115-ccb3abc151a1
 	github.com/vulsio/go-kev v0.1.4-0.20240318121733-b3386e67d3fb
 	github.com/vulsio/go-msfdb v0.2.4-0.20240318121704-8bfc812656dc
@@ -97,7 +97,7 @@ require (
 	github.com/Microsoft/hcsshim v0.12.0 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2 // indirect
-	github.com/PuerkitoBio/goquery v1.9.1 // indirect
+	github.com/PuerkitoBio/goquery v1.9.2 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/PuerkitoBio/goquery v1.9.1 h1:mTL6XjbJTZdpfL+Gwl5U2h1l9yEkJjhmlTeV9VPW7UI=
-github.com/PuerkitoBio/goquery v1.9.1/go.mod h1:cW1n6TmIMDoORQU5IU/P1T3tGFunOeXEpGP2WHRwkbY=
+github.com/PuerkitoBio/goquery v1.9.2 h1:4/wZksC3KgkQw7SQgkKotmKljk0M6V8TUvA8Wb4yPeE=
+github.com/PuerkitoBio/goquery v1.9.2/go.mod h1:GHPCaP0ODyyxqcNoFGYlAprUFH81NuRPd0GX3Zu2Mvk=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Ullaakut/nmap/v2 v2.2.2 h1:178Ety3d8T21sF6WZxyj7QVZUhnC1tL1J+tHLLW507Q=
@@ -1168,8 +1168,8 @@ github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinC
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/vulsio/go-cti v0.0.5-0.20240318121747-822b3ef289cb h1:aC6CqML20oYEI5Wjx04uwpARsXjdGCrOk4ken+l4dG8=
 github.com/vulsio/go-cti v0.0.5-0.20240318121747-822b3ef289cb/go.mod h1:MHlQMcrMMUGXVc9G1JBZg1J/frsugODntu7CfLInEFs=
-github.com/vulsio/go-cve-dictionary v0.10.2-0.20240319004433-af03be313b77 h1:utQlIgdHOqx+TOHecQm3vk4Bu9QHZcwkKj2DMQ4F3mo=
-github.com/vulsio/go-cve-dictionary v0.10.2-0.20240319004433-af03be313b77/go.mod h1:NYtVYgM43dITGd0wVGTGhBqGHYisdK7k6pLo+71rMzU=
+github.com/vulsio/go-cve-dictionary v0.10.2-0.20240628072614-73f15707be8e h1:z/rVzYJy6LCeSzoLFZuiAFfe45giUYdsyPL+iprlC78=
+github.com/vulsio/go-cve-dictionary v0.10.2-0.20240628072614-73f15707be8e/go.mod h1:Kxpy1CE1D/Wsu7HH+5K1RAQQ6PErMOPHZ2W0+bsxqNc=
 github.com/vulsio/go-exploitdb v0.4.7-0.20240318122115-ccb3abc151a1 h1:rQRTmiO2gYEhyjthvGseV34Qj+nwrVgZEnFvk6Z2AqM=
 github.com/vulsio/go-exploitdb v0.4.7-0.20240318122115-ccb3abc151a1/go.mod h1:ml2oTRyR37hUyyP4kWD9NSlBYIQuJUVNaAfbflSu4i4=
 github.com/vulsio/go-kev v0.1.4-0.20240318121733-b3386e67d3fb h1:j03zKKkR+WWaPoPzMBwNxpDsc1mYDtt9s1VrHaIxmfw=

--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -1,11 +1,13 @@
 package models
 
 import (
+	"cmp"
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 	"time"
+
+	"golang.org/x/exp/maps"
 
 	"github.com/future-architect/vuls/constant"
 )
@@ -17,18 +19,14 @@ type CveContents map[CveContentType][]CveContent
 func NewCveContents(conts ...CveContent) CveContents {
 	m := CveContents{}
 	for _, cont := range conts {
-		if cont.Type == Jvn {
-			found := false
-			for _, cveCont := range m[cont.Type] {
-				if cont.SourceLink == cveCont.SourceLink {
-					found = true
-					break
-				}
-			}
-			if !found {
+		switch cont.Type {
+		case Jvn:
+			if !slices.ContainsFunc(m[cont.Type], func(e CveContent) bool {
+				return cont.SourceLink == e.SourceLink
+			}) {
 				m[cont.Type] = append(m[cont.Type], cont)
 			}
-		} else {
+		default:
 			m[cont.Type] = []CveContent{cont}
 		}
 	}
@@ -45,14 +43,7 @@ type CveContentStr struct {
 func (v CveContents) Except(exceptCtypes ...CveContentType) (values CveContents) {
 	values = CveContents{}
 	for ctype, content := range v {
-		found := false
-		for _, exceptCtype := range exceptCtypes {
-			if ctype == exceptCtype {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(exceptCtypes, ctype) {
 			values[ctype] = content
 		}
 	}
@@ -65,37 +56,51 @@ func (v CveContents) PrimarySrcURLs(lang, myFamily, cveID string, confidences Co
 		return
 	}
 
-	if conts, found := v[Nvd]; found {
-		for _, cont := range conts {
-			for _, r := range cont.References {
-				for _, t := range r.Tags {
-					if t == "Vendor Advisory" {
-						values = append(values, CveContentStr{Nvd, r.Link})
+	for _, ctype := range append(append(CveContentTypes{Mitre, Nvd, Jvn}, GetCveContentTypes(myFamily)...), GitHub) {
+		for _, cont := range v[ctype] {
+			switch ctype {
+			case Nvd:
+				for _, r := range cont.References {
+					if slices.Contains(r.Tags, "Vendor Advisory") {
+						if !slices.ContainsFunc(values, func(e CveContentStr) bool {
+							return e.Type == ctype && e.Value == r.Link
+						}) {
+							values = append(values, CveContentStr{
+								Type:  ctype,
+								Value: r.Link,
+							})
+						}
 					}
 				}
-			}
-		}
-	}
-
-	order := append(append(CveContentTypes{Mitre, Nvd}, GetCveContentTypes(myFamily)...), GitHub)
-	for _, ctype := range order {
-		if conts, found := v[ctype]; found {
-			for _, cont := range conts {
-				if cont.SourceLink == "" {
-					continue
+				if cont.SourceLink != "" && !slices.ContainsFunc(values, func(e CveContentStr) bool {
+					return e.Type == ctype && e.Value == cont.SourceLink
+				}) {
+					values = append(values, CveContentStr{
+						Type:  ctype,
+						Value: cont.SourceLink,
+					})
 				}
-				values = append(values, CveContentStr{ctype, cont.SourceLink})
-			}
-		}
-	}
-
-	if lang == "ja" || slices.ContainsFunc(confidences, func(e Confidence) bool {
-		return e.DetectionMethod == JvnVendorProductMatchStr
-	}) {
-		if conts, found := v[Jvn]; found {
-			for _, cont := range conts {
-				if 0 < len(cont.SourceLink) {
-					values = append(values, CveContentStr{Jvn, cont.SourceLink})
+			case Jvn:
+				if lang == "ja" || slices.ContainsFunc(confidences, func(e Confidence) bool {
+					return e.DetectionMethod == JvnVendorProductMatchStr
+				}) {
+					if cont.SourceLink != "" && !slices.ContainsFunc(values, func(e CveContentStr) bool {
+						return e.Type == ctype && e.Value == cont.SourceLink
+					}) {
+						values = append(values, CveContentStr{
+							Type:  ctype,
+							Value: cont.SourceLink,
+						})
+					}
+				}
+			default:
+				if cont.SourceLink != "" && !slices.ContainsFunc(values, func(e CveContentStr) bool {
+					return e.Type == ctype && e.Value == cont.SourceLink
+				}) {
+					values = append(values, CveContentStr{
+						Type:  ctype,
+						Value: cont.SourceLink,
+					})
 				}
 			}
 		}
@@ -104,7 +109,7 @@ func (v CveContents) PrimarySrcURLs(lang, myFamily, cveID string, confidences Co
 	if len(values) == 0 && strings.HasPrefix(cveID, "CVE") {
 		return []CveContentStr{{
 			Type:  Nvd,
-			Value: "https://nvd.nist.gov/vuln/detail/" + cveID,
+			Value: fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", cveID),
 		}}
 	}
 	return values
@@ -112,17 +117,10 @@ func (v CveContents) PrimarySrcURLs(lang, myFamily, cveID string, confidences Co
 
 // PatchURLs returns link of patch
 func (v CveContents) PatchURLs() (urls []string) {
-	conts, found := v[Nvd]
-	if !found {
-		return
-	}
-
-	for _, cont := range conts {
+	for _, cont := range v[Nvd] {
 		for _, r := range cont.References {
-			for _, t := range r.Tags {
-				if t == "Patch" {
-					urls = append(urls, r.Link)
-				}
+			if slices.Contains(r.Tags, "Patch") && !slices.Contains(urls, r.Link) {
+				urls = append(urls, r.Link)
 			}
 		}
 	}
@@ -141,14 +139,17 @@ func (v CveContents) Cpes(myFamily string) (values []CveContentCpes) {
 	order = append(order, AllCveContetTypes.Except(order...)...)
 
 	for _, ctype := range order {
-		if conts, found := v[ctype]; found {
-			for _, cont := range conts {
-				if 0 < len(cont.Cpes) {
-					values = append(values, CveContentCpes{
-						Type:  ctype,
-						Value: cont.Cpes,
-					})
-				}
+		for _, cont := range v[ctype] {
+			if len(cont.Cpes) == 0 {
+				continue
+			}
+			if !slices.ContainsFunc(values, func(e CveContentCpes) bool {
+				return e.Type == ctype && slices.Equal(e.Value, cont.Cpes)
+			}) {
+				values = append(values, CveContentCpes{
+					Type:  ctype,
+					Value: cont.Cpes,
+				})
 			}
 		}
 	}
@@ -167,14 +168,19 @@ func (v CveContents) References(myFamily string) (values []CveContentRefs) {
 	order = append(order, AllCveContetTypes.Except(order...)...)
 
 	for _, ctype := range order {
-		if conts, found := v[ctype]; found {
-			for _, cont := range conts {
-				if 0 < len(cont.References) {
-					values = append(values, CveContentRefs{
-						Type:  ctype,
-						Value: cont.References,
-					})
-				}
+		for _, cont := range v[ctype] {
+			if len(cont.References) == 0 {
+				continue
+			}
+			if !slices.ContainsFunc(values, func(e CveContentRefs) bool {
+				return e.Type == ctype && slices.EqualFunc(e.Value, cont.References, func(e1, e2 Reference) bool {
+					return e1.Link == e2.Link && e1.RefID == e2.RefID && e1.Source == e2.Source && slices.Equal(e1.Tags, e2.Tags)
+				})
+			}) {
+				values = append(values, CveContentRefs{
+					Type:  ctype,
+					Value: cont.References,
+				})
 			}
 		}
 	}
@@ -187,20 +193,18 @@ func (v CveContents) CweIDs(myFamily string) (values []CveContentStr) {
 	order := GetCveContentTypes(myFamily)
 	order = append(order, AllCveContetTypes.Except(order...)...)
 	for _, ctype := range order {
-		if conts, found := v[ctype]; found {
-			for _, cont := range conts {
-				if 0 < len(cont.CweIDs) {
-					for _, cweID := range cont.CweIDs {
-						for _, val := range values {
-							if val.Value == cweID {
-								continue
-							}
-						}
-						values = append(values, CveContentStr{
-							Type:  ctype,
-							Value: cweID,
-						})
-					}
+		for _, cont := range v[ctype] {
+			if len(cont.CweIDs) == 0 {
+				continue
+			}
+			for _, cweID := range cont.CweIDs {
+				if !slices.ContainsFunc(values, func(e CveContentStr) bool {
+					return e.Type == ctype && e.Value == cweID
+				}) {
+					values = append(values, CveContentStr{
+						Type:  ctype,
+						Value: cweID,
+					})
 				}
 			}
 		}
@@ -209,15 +213,12 @@ func (v CveContents) CweIDs(myFamily string) (values []CveContentStr) {
 }
 
 // UniqCweIDs returns Uniq CweIDs
-func (v CveContents) UniqCweIDs(myFamily string) (values []CveContentStr) {
+func (v CveContents) UniqCweIDs(myFamily string) []CveContentStr {
 	uniq := map[string]CveContentStr{}
 	for _, cwes := range v.CweIDs(myFamily) {
 		uniq[cwes.Value] = cwes
 	}
-	for _, cwe := range uniq {
-		values = append(values, cwe)
-	}
-	return values
+	return maps.Values(uniq)
 }
 
 // CveContentSSVC has CveContentType and SSVC
@@ -227,11 +228,7 @@ type CveContentSSVC struct {
 }
 
 func (v CveContents) SSVC() (value []CveContentSSVC) {
-	conts, ok := v[Mitre]
-	if !ok {
-		return
-	}
-	for _, cont := range conts {
+	for _, cont := range v[Mitre] {
 		if cont.SSVC == nil {
 			continue
 		}
@@ -251,44 +248,20 @@ func (v CveContents) SSVC() (value []CveContentSSVC) {
 func (v CveContents) Sort() {
 	for contType, contents := range v {
 		// CVSS40 desc, CVSS3 desc, CVSS2 desc, SourceLink asc
-		sort.Slice(contents, func(i, j int) bool {
-			if contents[i].Cvss40Score > contents[j].Cvss40Score {
-				return true
-			}
-			if contents[i].Cvss40Score == contents[j].Cvss40Score {
-				if contents[i].Cvss3Score > contents[j].Cvss3Score {
-					return true
-				}
-				if contents[i].Cvss3Score == contents[i].Cvss3Score {
-					if contents[i].Cvss2Score > contents[j].Cvss2Score {
-						return true
-					}
-					if contents[i].Cvss2Score == contents[i].Cvss2Score {
-						if contents[i].SourceLink < contents[j].SourceLink {
-							return true
-						}
-					}
-				}
-			}
-			return false
+		slices.SortFunc(contents, func(a, b CveContent) int {
+			return cmp.Or(
+				cmp.Compare(b.Cvss40Score, a.Cvss40Score),
+				cmp.Compare(b.Cvss3Score, a.Cvss3Score),
+				cmp.Compare(b.Cvss2Score, a.Cvss2Score),
+				cmp.Compare(a.SourceLink, b.SourceLink),
+			)
 		})
-		v[contType] = contents
-	}
-	for contType, contents := range v {
 		for cveID, cont := range contents {
-			sort.Slice(cont.References, func(i, j int) bool {
-				return cont.References[i].Link < cont.References[j].Link
-			})
-			sort.Slice(cont.CweIDs, func(i, j int) bool {
-				return cont.CweIDs[i] < cont.CweIDs[j]
-			})
-			for i, ref := range cont.References {
-				// sort v.CveContents[].References[].Tags
-				sort.Slice(ref.Tags, func(j, k int) bool {
-					return ref.Tags[j] < ref.Tags[k]
-				})
-				cont.References[i] = ref
+			slices.SortFunc(cont.References, func(a, b Reference) int { return cmp.Compare(a.Link, b.Link) })
+			for i := range cont.References {
+				slices.Sort(cont.References[i].Tags)
 			}
+			slices.Sort(cont.CweIDs)
 			contents[cveID] = cont
 		}
 		v[contType] = contents
@@ -643,14 +616,7 @@ var AllCveContetTypes = CveContentTypes{
 // Except returns CveContentTypes except for given args
 func (c CveContentTypes) Except(excepts ...CveContentType) (excepted CveContentTypes) {
 	for _, ctype := range c {
-		found := false
-		for _, except := range excepts {
-			if ctype == except {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(excepts, ctype) {
 			excepted = append(excepted, ctype)
 		}
 	}

--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -220,7 +220,7 @@ func (v CveContents) UniqCweIDs(myFamily string) (values []CveContentStr) {
 	return values
 }
 
-// CveContentSSVCs has CveContentType and SSVC
+// CveContentSSVC has CveContentType and SSVC
 type CveContentSSVC struct {
 	Type  CveContentType
 	Value SSVC

--- a/models/cvecontents_test.go
+++ b/models/cvecontents_test.go
@@ -241,6 +241,48 @@ func TestCveContents_Sort(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "sort CVSS v4.0",
+			v: CveContents{
+				Mitre: []CveContent{
+					{Cvss40Score: 0},
+					{Cvss40Score: 6.9},
+				},
+			},
+			want: CveContents{
+				Mitre: []CveContent{
+					{Cvss40Score: 6.9},
+					{Cvss40Score: 0},
+				},
+			},
+		},
+		{
+			name: "sort CVSS v4.0 and CVSS v3",
+			v: CveContents{
+				Mitre: []CveContent{
+					{
+						Cvss40Score: 0,
+						Cvss3Score:  7.3,
+					},
+					{
+						Cvss40Score: 0,
+						Cvss3Score:  9.8,
+					},
+				},
+			},
+			want: CveContents{
+				Mitre: []CveContent{
+					{
+						Cvss40Score: 0,
+						Cvss3Score:  9.8,
+					},
+					{
+						Cvss40Score: 0,
+						Cvss3Score:  7.3,
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -305,6 +347,56 @@ func TestGetCveContentTypes(t *testing.T) {
 		t.Run(tt.family, func(t *testing.T) {
 			if got := GetCveContentTypes(tt.family); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetCveContentTypes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCveContents_SSVC(t *testing.T) {
+	tests := []struct {
+		name string
+		v    CveContents
+		want []CveContentSSVC
+	}{
+		{
+			name: "happy",
+			v: CveContents{
+				Mitre: []CveContent{
+					{
+						Type:     Mitre,
+						CveID:    "CVE-2024-5732",
+						Title:    "Clash Proxy Port improper authentication",
+						Optional: map[string]string{"source": "CNA"},
+					},
+					{
+						Type:  Mitre,
+						CveID: "CVE-2024-5732",
+						Title: "CISA ADP Vulnrichment",
+						SSVC: &SSVC{
+							Exploitation:    "none",
+							Automatable:     "no",
+							TechnicalImpact: "partial",
+						},
+						Optional: map[string]string{"source": "ADP:CISA-ADP"},
+					},
+				},
+			},
+			want: []CveContentSSVC{
+				{
+					Type: "mitre(ADP:CISA-ADP)",
+					Value: SSVC{
+						Exploitation:    "none",
+						Automatable:     "no",
+						TechnicalImpact: "partial",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.v.SSVC(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CveContents.SSVC() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/models/cvecontents_test.go
+++ b/models/cvecontents_test.go
@@ -7,26 +7,37 @@ import (
 	"github.com/future-architect/vuls/constant"
 )
 
-func TestExcept(t *testing.T) {
-	var tests = []struct {
-		in  CveContents
-		out CveContents
-	}{{
-		in: CveContents{
-			RedHat: []CveContent{{Type: RedHat}},
-			Ubuntu: []CveContent{{Type: Ubuntu}},
-			Debian: []CveContent{{Type: Debian}},
+func TestCveContents_Except(t *testing.T) {
+	type args struct {
+		exceptCtypes []CveContentType
+	}
+	tests := []struct {
+		name       string
+		v          CveContents
+		args       args
+		wantValues CveContents
+	}{
+		{
+			name: "happy",
+			v: CveContents{
+				RedHat: []CveContent{{Type: RedHat}},
+				Ubuntu: []CveContent{{Type: Ubuntu}},
+				Debian: []CveContent{{Type: Debian}},
+			},
+			args: args{
+				exceptCtypes: []CveContentType{Ubuntu, Debian},
+			},
+			wantValues: CveContents{
+				RedHat: []CveContent{{Type: RedHat}},
+			},
 		},
-		out: CveContents{
-			RedHat: []CveContent{{Type: RedHat}},
-		},
-	},
 	}
 	for _, tt := range tests {
-		actual := tt.in.Except(Ubuntu, Debian)
-		if !reflect.DeepEqual(tt.out, actual) {
-			t.Errorf("\nexpected: %v\n  actual: %v\n", tt.out, actual)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if gotValues := tt.v.Except(tt.args.exceptCtypes...); !reflect.DeepEqual(gotValues, tt.wantValues) {
+				t.Errorf("CveContents.Except() = %v, want %v", gotValues, tt.wantValues)
+			}
+		})
 	}
 }
 
@@ -85,12 +96,12 @@ func TestSourceLinks(t *testing.T) {
 					Value: "https://nvd.nist.gov/vuln/detail/CVE-2017-6074",
 				},
 				{
-					Type:  RedHat,
-					Value: "https://access.redhat.com/security/cve/CVE-2017-6074",
-				},
-				{
 					Type:  Jvn,
 					Value: "https://jvn.jp/vu/JVNVU93610402/",
+				},
+				{
+					Type:  RedHat,
+					Value: "https://access.redhat.com/security/cve/CVE-2017-6074",
 				},
 			},
 		},
@@ -159,6 +170,294 @@ func TestSourceLinks(t *testing.T) {
 		if !reflect.DeepEqual(tt.out, actual) {
 			t.Errorf("\n[%d] expected: %v\n  actual: %v\n", i, tt.out, actual)
 		}
+	}
+}
+
+func TestCveContents_PatchURLs(t *testing.T) {
+	tests := []struct {
+		name     string
+		v        CveContents
+		wantUrls []string
+	}{
+		{
+			name: "happy",
+			v: CveContents{
+				Nvd: []CveContent{
+					{
+						References: []Reference{
+							{
+								Link:   "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c52873e5a1ef72f845526d9f6a50704433f9c625",
+								Source: "cve@mitre.org",
+								Tags:   []string{"Patch", "Vendor Advisory"},
+							},
+							{
+								Link:   "https://lists.debian.org/debian-lts-announce/2020/01/msg00013.html",
+								Source: "cve@mitre.org",
+								Tags:   []string{"Mailing List", "Third Party Advisory"},
+							},
+						},
+					},
+					{
+						References: []Reference{
+							{
+								Link: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c52873e5a1ef72f845526d9f6a50704433f9c625",
+								Tags: []string{"Patch", "Vendor Advisory"},
+							},
+						},
+					},
+				},
+			},
+			wantUrls: []string{"https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c52873e5a1ef72f845526d9f6a50704433f9c625"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotUrls := tt.v.PatchURLs(); !reflect.DeepEqual(gotUrls, tt.wantUrls) {
+				t.Errorf("CveContents.PatchURLs() = %v, want %v", gotUrls, tt.wantUrls)
+			}
+		})
+	}
+}
+
+func TestCveContents_Cpes(t *testing.T) {
+	type args struct {
+		myFamily string
+	}
+	tests := []struct {
+		name       string
+		v          CveContents
+		args       args
+		wantValues []CveContentCpes
+	}{
+		{
+			name: "happy",
+			v: CveContents{
+				Nvd: []CveContent{{
+					Cpes: []Cpe{{
+						URI:             "cpe:/a:microsoft:internet_explorer:8.0.6001:beta",
+						FormattedString: "cpe:2.3:a:microsoft:internet_explorer:8.0.6001:beta:*:*:*:*:*:*",
+					}},
+				}},
+			},
+			args: args{myFamily: "redhat"},
+			wantValues: []CveContentCpes{{
+				Type: Nvd,
+				Value: []Cpe{{
+					URI:             "cpe:/a:microsoft:internet_explorer:8.0.6001:beta",
+					FormattedString: "cpe:2.3:a:microsoft:internet_explorer:8.0.6001:beta:*:*:*:*:*:*",
+				}},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotValues := tt.v.Cpes(tt.args.myFamily); !reflect.DeepEqual(gotValues, tt.wantValues) {
+				t.Errorf("CveContents.Cpes() = %v, want %v", gotValues, tt.wantValues)
+			}
+		})
+	}
+}
+func TestCveContents_References(t *testing.T) {
+	type args struct {
+		myFamily string
+	}
+	tests := []struct {
+		name       string
+		v          CveContents
+		args       args
+		wantValues []CveContentRefs
+	}{
+		{
+			name: "happy",
+			v: CveContents{
+				Mitre: []CveContent{{CveID: "CVE-2024-0001"}},
+				Nvd: []CveContent{
+					{
+						References: []Reference{
+							{
+								Link:   "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c52873e5a1ef72f845526d9f6a50704433f9c625",
+								Source: "cve@mitre.org",
+								Tags:   []string{"Patch", "Vendor Advisory"},
+							},
+							{
+								Link:   "https://lists.debian.org/debian-lts-announce/2020/01/msg00013.html",
+								Source: "cve@mitre.org",
+								Tags:   []string{"Mailing List", "Third Party Advisory"},
+							},
+						},
+					},
+					{
+						References: []Reference{
+							{
+								Link: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c52873e5a1ef72f845526d9f6a50704433f9c625",
+								Tags: []string{"Patch", "Vendor Advisory"},
+							},
+						},
+					},
+				},
+			},
+			wantValues: []CveContentRefs{
+				{
+					Type: Nvd,
+					Value: []Reference{
+						{
+							Link:   "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c52873e5a1ef72f845526d9f6a50704433f9c625",
+							Source: "cve@mitre.org",
+							Tags:   []string{"Patch", "Vendor Advisory"},
+						},
+						{
+							Link:   "https://lists.debian.org/debian-lts-announce/2020/01/msg00013.html",
+							Source: "cve@mitre.org",
+							Tags:   []string{"Mailing List", "Third Party Advisory"},
+						},
+					},
+				},
+				{
+					Type: Nvd,
+					Value: []Reference{
+						{
+							Link: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c52873e5a1ef72f845526d9f6a50704433f9c625",
+							Tags: []string{"Patch", "Vendor Advisory"},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotValues := tt.v.References(tt.args.myFamily); !reflect.DeepEqual(gotValues, tt.wantValues) {
+				t.Errorf("CveContents.References() = %v, want %v", gotValues, tt.wantValues)
+			}
+		})
+	}
+}
+
+func TestCveContents_CweIDs(t *testing.T) {
+	type args struct {
+		myFamily string
+	}
+	tests := []struct {
+		name       string
+		v          CveContents
+		args       args
+		wantValues []CveContentStr
+	}{
+		{
+			name: "happy",
+			v: CveContents{
+				Mitre: []CveContent{{CweIDs: []string{"CWE-001"}}},
+				Nvd: []CveContent{
+					{CweIDs: []string{"CWE-001"}},
+					{CweIDs: []string{"CWE-001"}},
+				},
+			},
+			args: args{myFamily: "redhat"},
+			wantValues: []CveContentStr{
+				{
+					Type:  Mitre,
+					Value: "CWE-001",
+				},
+				{
+					Type:  Nvd,
+					Value: "CWE-001",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotValues := tt.v.CweIDs(tt.args.myFamily); !reflect.DeepEqual(gotValues, tt.wantValues) {
+				t.Errorf("CveContents.CweIDs() = %v, want %v", gotValues, tt.wantValues)
+			}
+		})
+	}
+}
+
+func TestCveContents_UniqCweIDs(t *testing.T) {
+	type args struct {
+		myFamily string
+	}
+	tests := []struct {
+		name string
+		v    CveContents
+		args args
+		want []CveContentStr
+	}{
+		{
+			name: "happy",
+			v: CveContents{
+				Mitre: []CveContent{{CweIDs: []string{"CWE-001"}}},
+				Nvd: []CveContent{
+					{CweIDs: []string{"CWE-001"}},
+					{CweIDs: []string{"CWE-001"}},
+				},
+			},
+			args: args{myFamily: "redhat"},
+			want: []CveContentStr{
+				{
+					Type:  Nvd,
+					Value: "CWE-001",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.v.UniqCweIDs(tt.args.myFamily); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CveContents.UniqCweIDs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCveContents_SSVC(t *testing.T) {
+	tests := []struct {
+		name string
+		v    CveContents
+		want []CveContentSSVC
+	}{
+		{
+			name: "happy",
+			v: CveContents{
+				Mitre: []CveContent{
+					{
+						Type:     Mitre,
+						CveID:    "CVE-2024-5732",
+						Title:    "Clash Proxy Port improper authentication",
+						Optional: map[string]string{"source": "CNA"},
+					},
+					{
+						Type:  Mitre,
+						CveID: "CVE-2024-5732",
+						Title: "CISA ADP Vulnrichment",
+						SSVC: &SSVC{
+							Exploitation:    "none",
+							Automatable:     "no",
+							TechnicalImpact: "partial",
+						},
+						Optional: map[string]string{"source": "ADP:CISA-ADP"},
+					},
+				},
+			},
+			want: []CveContentSSVC{
+				{
+					Type: "mitre(ADP:CISA-ADP)",
+					Value: SSVC{
+						Exploitation:    "none",
+						Automatable:     "no",
+						TechnicalImpact: "partial",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.v.SSVC(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CveContents.SSVC() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -294,6 +593,47 @@ func TestCveContents_Sort(t *testing.T) {
 	}
 }
 
+func TestCveContent_Empty(t *testing.T) {
+	type fields struct {
+		Type    CveContentType
+		CveID   string
+		Title   string
+		Summary string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "empty",
+			fields: fields{
+				Summary: "",
+			},
+			want: true,
+		},
+		{
+			name: "not empty",
+			fields: fields{
+				Summary: "summary",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := (CveContent{
+				Type:    tt.fields.Type,
+				CveID:   tt.fields.CveID,
+				Title:   tt.fields.Title,
+				Summary: tt.fields.Summary,
+			}).Empty(); got != tt.want {
+				t.Errorf("CveContent.Empty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNewCveContentType(t *testing.T) {
 	tests := []struct {
 		name string
@@ -352,51 +692,29 @@ func TestGetCveContentTypes(t *testing.T) {
 	}
 }
 
-func TestCveContents_SSVC(t *testing.T) {
+func TestCveContentTypes_Except(t *testing.T) {
+	type args struct {
+		excepts []CveContentType
+	}
 	tests := []struct {
-		name string
-		v    CveContents
-		want []CveContentSSVC
+		name         string
+		c            CveContentTypes
+		args         args
+		wantExcepted CveContentTypes
 	}{
 		{
 			name: "happy",
-			v: CveContents{
-				Mitre: []CveContent{
-					{
-						Type:     Mitre,
-						CveID:    "CVE-2024-5732",
-						Title:    "Clash Proxy Port improper authentication",
-						Optional: map[string]string{"source": "CNA"},
-					},
-					{
-						Type:  Mitre,
-						CveID: "CVE-2024-5732",
-						Title: "CISA ADP Vulnrichment",
-						SSVC: &SSVC{
-							Exploitation:    "none",
-							Automatable:     "no",
-							TechnicalImpact: "partial",
-						},
-						Optional: map[string]string{"source": "ADP:CISA-ADP"},
-					},
-				},
+			c:    CveContentTypes{Ubuntu, UbuntuAPI},
+			args: args{
+				excepts: []CveContentType{Ubuntu},
 			},
-			want: []CveContentSSVC{
-				{
-					Type: "mitre(ADP:CISA-ADP)",
-					Value: SSVC{
-						Exploitation:    "none",
-						Automatable:     "no",
-						TechnicalImpact: "partial",
-					},
-				},
-			},
+			wantExcepted: CveContentTypes{UbuntuAPI},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.v.SSVC(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("CveContents.SSVC() = %v, want %v", got, tt.want)
+			if gotExcepted := tt.c.Except(tt.args.excepts...); !reflect.DeepEqual(gotExcepted, tt.wantExcepted) {
+				t.Errorf("CveContentTypes.Except() = %v, want %v", gotExcepted, tt.wantExcepted)
 			}
 		})
 	}

--- a/models/vulninfos_test.go
+++ b/models/vulninfos_test.go
@@ -917,6 +917,50 @@ func TestMaxCvssScores(t *testing.T) {
 				},
 			},
 		},
+		// 6 : CVSSv4.0 and CVSSv3.1
+		{
+			in: VulnInfo{
+				CveContents: CveContents{
+					Mitre: []CveContent{
+						{
+							Type:           Mitre,
+							Cvss40Score:    6.9,
+							Cvss40Vector:   "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+							Cvss40Severity: "MEDIUM",
+							Cvss3Score:     7.3,
+							Cvss3Vector:    "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+							Cvss3Severity:  "HIGH",
+							Optional:       map[string]string{"source": "CNA"},
+						},
+					},
+					Nvd: []CveContent{
+						{
+							Type:          Nvd,
+							Cvss3Score:    9.8,
+							Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+							Cvss3Severity: "CRITICAL",
+							Optional:      map[string]string{"source": "nvd@nist.gov"},
+						},
+						{
+							Type:          Nvd,
+							Cvss3Score:    7.3,
+							Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+							Cvss3Severity: "HIGH",
+							Optional:      map[string]string{"source": "cna@vuldb.com"},
+						},
+					},
+				},
+			},
+			out: CveContentCvss{
+				Type: Mitre,
+				Value: Cvss{
+					Type:     CVSS40,
+					Score:    6.9,
+					Severity: "MEDIUM",
+					Vector:   "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+				},
+			},
+		},
 		// Empty
 		{
 			in: VulnInfo{},
@@ -1855,6 +1899,112 @@ func TestVulnInfo_PatchStatus(t *testing.T) {
 			}
 			if got := v.PatchStatus(tt.args.packs); got != tt.want {
 				t.Errorf("VulnInfo.PatchStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVulnInfo_Cvss40Scores(t *testing.T) {
+	type fields struct {
+		CveID       string
+		CveContents CveContents
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []CveContentCvss
+	}{
+		{
+			name: "happy",
+			fields: fields{
+				CveID: "CVE-2024-5732",
+				CveContents: CveContents{
+					Mitre: []CveContent{
+						{
+							Type:           Mitre,
+							Cvss40Score:    6.9,
+							Cvss40Vector:   "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+							Cvss40Severity: "MEDIUM",
+							Cvss3Score:     7.3,
+							Cvss3Vector:    "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+							Cvss3Severity:  "HIGH",
+							Optional:       map[string]string{"source": "CNA"},
+						},
+					},
+				},
+			},
+			want: []CveContentCvss{
+				{
+					Type: Mitre,
+					Value: Cvss{
+						Type:     CVSS40,
+						Score:    6.9,
+						Severity: "MEDIUM",
+						Vector:   "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := (VulnInfo{
+				CveID:       tt.fields.CveID,
+				CveContents: tt.fields.CveContents,
+			}).Cvss40Scores(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("VulnInfo.Cvss40Scores() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVulnInfo_MaxCvss40Score(t *testing.T) {
+	type fields struct {
+		CveID       string
+		CveContents CveContents
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   CveContentCvss
+	}{
+		{
+			name: "happy",
+			fields: fields{
+				CveID: "CVE-2024-5732",
+				CveContents: CveContents{
+					Mitre: []CveContent{
+						{
+							Type:           Mitre,
+							Cvss40Score:    6.9,
+							Cvss40Vector:   "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+							Cvss40Severity: "MEDIUM",
+							Cvss3Score:     7.3,
+							Cvss3Vector:    "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+							Cvss3Severity:  "HIGH",
+							Optional:       map[string]string{"source": "CNA"},
+						},
+					},
+				},
+			},
+			want: CveContentCvss{
+				Type: Mitre,
+				Value: Cvss{
+					Type:     CVSS40,
+					Score:    6.9,
+					Severity: "MEDIUM",
+					Vector:   "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := (VulnInfo{
+				CveID:       tt.fields.CveID,
+				CveContents: tt.fields.CveContents,
+			}).MaxCvss40Score(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("VulnInfo.MaxsCvss40Score() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/reporter/sbom/cyclonedx.go
+++ b/reporter/sbom/cyclonedx.go
@@ -424,6 +424,9 @@ func cdxRatings(cveContents models.CveContents) *[]cdx.VulnerabilityRating {
 			if content.Cvss3Score != 0 || content.Cvss3Vector != "" || content.Cvss3Severity != "" {
 				ratings = append(ratings, cdxCVSS3Rating(string(content.Type), content.Cvss3Vector, content.Cvss3Score, content.Cvss3Severity))
 			}
+			if content.Cvss40Score != 0 || content.Cvss40Vector != "" || content.Cvss40Severity != "" {
+				ratings = append(ratings, cdxCVSS40Rating(string(content.Type), content.Cvss40Vector, content.Cvss40Score, content.Cvss40Severity))
+			}
 		}
 	}
 	return &ratings
@@ -459,6 +462,32 @@ func cdxCVSS3Rating(source, vector string, score float64, severity string) cdx.V
 	}
 	if strings.HasPrefix(vector, "CVSS:3.1") {
 		r.Method = cdx.ScoringMethodCVSSv31
+	}
+	if score != 0 {
+		r.Score = &score
+	}
+	switch strings.ToLower(severity) {
+	case "critical":
+		r.Severity = cdx.SeverityCritical
+	case "high":
+		r.Severity = cdx.SeverityHigh
+	case "medium":
+		r.Severity = cdx.SeverityMedium
+	case "low":
+		r.Severity = cdx.SeverityLow
+	case "none":
+		r.Severity = cdx.SeverityNone
+	default:
+		r.Severity = cdx.SeverityUnknown
+	}
+	return r
+}
+
+func cdxCVSS40Rating(source, vector string, score float64, severity string) cdx.VulnerabilityRating {
+	r := cdx.VulnerabilityRating{
+		Source: &cdx.Source{Name: source},
+		Method: cdx.ScoringMethodCVSSv4,
+		Vector: vector,
 	}
 	if score != 0 {
 		r.Score = &score

--- a/reporter/slack.go
+++ b/reporter/slack.go
@@ -253,7 +253,7 @@ func (w SlackWriter) attachmentText(vinfo models.VulnInfo, cweDict map[string]mo
 	maxCvss := vinfo.MaxCvssScore()
 	vectors := []string{}
 
-	scores := append(vinfo.Cvss3Scores(), vinfo.Cvss2Scores()...)
+	scores := append(vinfo.Cvss40Scores(), append(vinfo.Cvss3Scores(), vinfo.Cvss2Scores()...)...)
 	for _, cvss := range scores {
 		if cvss.Value.Severity == "" {
 			continue
@@ -268,6 +268,8 @@ func (w SlackWriter) attachmentText(vinfo models.VulnInfo, cweDict map[string]mo
 			calcURL = fmt.Sprintf(
 				"https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?name=%s",
 				vinfo.CveID)
+		case models.CVSS40:
+			calcURL = fmt.Sprintf("https://www.first.org/cvss/calculator/4.0#%s", cvss.Value.Vector)
 		}
 
 		if conts, ok := vinfo.CveContents[cvss.Type]; ok {

--- a/reporter/syslog.go
+++ b/reporter/syslog.go
@@ -73,6 +73,11 @@ func (w SyslogWriter) encodeSyslog(result models.ScanResult) (messages []string)
 			kvPairs = append(kvPairs, fmt.Sprintf(`cvss_vector_%s_v3="%s"`, cvss.Type, cvss.Value.Vector))
 		}
 
+		for _, cvss := range vinfo.Cvss40Scores() {
+			kvPairs = append(kvPairs, fmt.Sprintf(`cvss_score_%s_v40="%.2f"`, cvss.Type, cvss.Value.Score))
+			kvPairs = append(kvPairs, fmt.Sprintf(`cvss_vector_%s_v40="%s"`, cvss.Type, cvss.Value.Vector))
+		}
+
 		if conts, ok := vinfo.CveContents[models.Nvd]; ok {
 			for _, cont := range conts {
 				cwes := strings.Join(cont.CweIDs, ",")

--- a/reporter/util.go
+++ b/reporter/util.go
@@ -337,16 +337,24 @@ No CVE-IDs are found in updatable packages.
 	for _, vuln := range r.ScannedCves.ToSortedSlice() {
 		data := [][]string{}
 		data = append(data, []string{"Max Score", vuln.FormatMaxCvssScore()})
+		for _, cvss := range vuln.Cvss40Scores() {
+			if cvssstr := cvss.Value.Format(); cvssstr != "" {
+				data = append(data, []string{string(cvss.Type), cvssstr})
+			}
+		}
 		for _, cvss := range vuln.Cvss3Scores() {
 			if cvssstr := cvss.Value.Format(); cvssstr != "" {
 				data = append(data, []string{string(cvss.Type), cvssstr})
 			}
 		}
-
 		for _, cvss := range vuln.Cvss2Scores() {
 			if cvssstr := cvss.Value.Format(); cvssstr != "" {
 				data = append(data, []string{string(cvss.Type), cvssstr})
 			}
+		}
+
+		for _, ssvc := range vuln.CveContents.SSVC() {
+			data = append(data, []string{fmt.Sprintf("SSVC[%s]", ssvc.Type), fmt.Sprintf("Exploitation    : %s\nAutomatable     : %s\nTechnicalImpact : %s", ssvc.Value.Exploitation, ssvc.Value.Automatable, ssvc.Value.TechnicalImpact)})
 		}
 
 		data = append(data, []string{"Summary", vuln.Summaries(
@@ -770,7 +778,7 @@ func getMinusDiffCves(previous, current models.ScanResult) models.VulnInfos {
 }
 
 func isCveInfoUpdated(cveID string, previous, current models.ScanResult) bool {
-	cTypes := append([]models.CveContentType{models.Nvd, models.Jvn}, models.GetCveContentTypes(current.Family)...)
+	cTypes := append([]models.CveContentType{models.Mitre, models.Nvd, models.Jvn}, models.GetCveContentTypes(current.Family)...)
 
 	prevLastModifieds := map[models.CveContentType][]time.Time{}
 	preVinfo, ok := previous.ScannedCves[cveID]

--- a/server/server.go
+++ b/server/server.go
@@ -76,7 +76,7 @@ func (h VulsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	logging.Log.Infof("Fill CVE detailed with CVE-DB")
-	if err := detector.FillCvesWithNvdJvnFortinet(&r, config.Conf.CveDict, config.Conf.LogOpts); err != nil {
+	if err := detector.FillCvesWithGoCVEDictionary(&r, config.Conf.CveDict, config.Conf.LogOpts); err != nil {
 		logging.Log.Errorf("Failed to fill with CVE: %+v", err)
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 	}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -899,6 +899,7 @@ func setChangelogLayout(g *gocui.Gui) error {
 type dataForTmpl struct {
 	CveID            string
 	Cvsses           string
+	SSVC             []models.CveContentSSVC
 	Exploits         []models.Exploit
 	Metasploits      []models.Metasploit
 	Summary          string
@@ -979,7 +980,7 @@ func detailLines() (string, error) {
 	table := uitable.New()
 	table.MaxColWidth = 100
 	table.Wrap = true
-	scores := append(vinfo.Cvss3Scores(), vinfo.Cvss2Scores()...)
+	scores := append(vinfo.Cvss40Scores(), append(vinfo.Cvss3Scores(), vinfo.Cvss2Scores()...)...)
 	var cols []interface{}
 	for _, score := range scores {
 		cols = []interface{}{
@@ -1002,6 +1003,7 @@ func detailLines() (string, error) {
 	data := dataForTmpl{
 		CveID:       vinfo.CveID,
 		Cvsses:      fmt.Sprintf("%s\n", table),
+		SSVC:        vinfo.CveContents.SSVC(),
 		Summary:     fmt.Sprintf("%s (%s)", summary.Value, summary.Type),
 		Mitigation:  strings.Join(mitigations, "\n"),
 		PatchURLs:   vinfo.CveContents.PatchURLs(),
@@ -1026,6 +1028,17 @@ const mdTemplate = `
 CVSS Scores
 -----------
 {{.Cvsses }}
+
+{{if .SSVC}}
+SSVC
+-----------
+{{range $ssvc := .SSVC -}}
+* {{$ssvc.Type}}
+  Exploitation    : {{$ssvc.Value.Exploitation}}
+  Automatable     : {{$ssvc.Value.Automatable}}
+  TechnicalImpact : {{$ssvc.Value.TechnicalImpact}}
+{{end}}
+{{end}}
 
 Summary
 -----------


### PR DESCRIPTION
# What did you implement:

A new `mitre` will be added to the go-cve-dictionary data source.
https://github.com/vulsio/go-cve-dictionary/pull/392 

`mitre` includes CVSSv4 and SSVC evaluations by CISA ADP, and this information is added to the detected vulnerabilities.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```console
$ go-cve-dictionary fetch mitre 2024
$ go-cve-dictionary fetch nvd 2024

$ cat config.toml
...
[servers]
[servers.pseudo]
type = "pseudo"
cpeNames = [
"cpe:2.3:a:clashforwindows:clash:0.1.0:*:*:*:*:windows:*:*"
]

$ vuls scan
$ vuls report
$ cat results/2024-06-27T22-16-01+0900/pseudo.json | jq '.scannedCves[].cveContents.mitre'
[
  {
    "type": "mitre",
    "cveID": "CVE-2024-5732",
    "title": "Clash Proxy Port improper authentication",
    "summary": "A vulnerability was found in Clash up to 0.20.1 on Windows. It has been declared as critical. This vulnerability affects unknown code of the component Proxy Port. The manipulation leads to improper authentication. The attack can be initiated remotely. The exploit has been disclosed to the public and may be used. It is recommended to change the configuration settings. VDB-267406 is the identifier assigned to this vulnerability.",
    "cvss2Score": 7.5,
    "cvss2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
    "cvss2Severity": "",
    "cvss3Score": 7.3,
    "cvss3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
    "cvss3Severity": "HIGH",
    "cvss40Score": 6.9,
    "cvss40Vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N",
    "cvss40Severity": "MEDIUM",
    "sourceLink": "https://www.cve.org/CVERecord?id=CVE-2024-5732",
    "references": [
      {
        "link": "https://github.com/GTA12138/vul/blob/main/clash%20for%20windows.md",
        "tags": [
          "exploit"
        ]
      },
      {
        "link": "https://vuldb.com/?ctiid.267406",
        "tags": [
          "permissions-required",
          "signature"
        ]
      },
      {
        "link": "https://vuldb.com/?id.267406",
        "tags": [
          "vdb-entry"
        ]
      },
      {
        "link": "https://vuldb.com/?submit.345469",
        "tags": [
          "third-party-advisory"
        ]
      }
    ],
    "cweIDs": [
      "CWE-287"
    ],
    "published": "2024-06-07T10:00:04.02Z",
    "lastModified": "2024-06-07T14:50:46.944Z",
    "optional": {
      "source": "CNA:VulDB"
    }
  },
  {
    "type": "mitre",
    "cveID": "CVE-2024-5732",
    "title": "CISA ADP Vulnrichment",
    "summary": "",
    "cvss2Score": 0,
    "cvss2Vector": "",
    "cvss2Severity": "",
    "cvss3Score": 0,
    "cvss3Vector": "",
    "cvss3Severity": "",
    "cvss40Score": 0,
    "cvss40Vector": "",
    "cvss40Severity": "",
    "ssvc": {
      "exploitation": "none",
      "automatable": "no",
      "technical_impact": "partial"
    },
    "sourceLink": "https://www.cve.org/CVERecord?id=CVE-2024-5732",
    "published": "2024-06-07T10:00:04.02Z",
    "lastModified": "2024-06-07T14:50:46.944Z",
    "optional": {
      "source": "ADP:CISA-ADP"
    }
  }
]
```

- vuls tui 
![image](https://github.com/future-architect/vuls/assets/16035056/f6a47032-1557-4ad0-a588-263fcdf2c2ee)

- vuls report --format-full-text
![image](https://github.com/future-architect/vuls/assets/16035056/48629eb3-4482-4c42-81bd-6205ca0139cd)


# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://github.com/vulsio/go-cve-dictionary/pull/392