### PR TITLE
fix(scanner/suse): skip new line in zyper -q lu

### DIFF
--- a/scanner/suse.go
+++ b/scanner/suse.go
@@ -231,7 +231,7 @@ func (o *suse) parseZypperLULines(stdout string) (models.Packages, error) {
 	scanner := bufio.NewScanner(strings.NewReader(stdout))
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.Contains(line, "S | Repository") || strings.Contains(line, "--+----------------") || warnRepoPattern.MatchString(line) {
+		if line == "" || strings.Contains(line, "S | Repository") || strings.Contains(line, "--+----------------") || warnRepoPattern.MatchString(line) {
 			continue
 		}
 		pack, err := o.parseZypperLUOneLine(line)


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Fixes #1977 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## setup
```console
$ git clone https://github.com/MaineK00n/vuls-targets.git
$ cd vuls-targets/suse/leap/15.6
$ vagrant up --provision
// TODO: add known_hosts

$ cat config.toml
[servers.vagrant]
host = "127.0.0.1"
port = "2222"
user = "vagrant"
keyPath = "/home/vuls/vuls-targets/.ssh/id_rsa"
scanMode           = ["fast-root"]
scanModules        = ["ospkg"]
```

## before
```console
$ vuls scan
[Jul  4 14:57:44]  INFO [localhost] vuls-v0.26.0-build-20240704_144346_ac55380
...
[Jul  4 14:57:47]  INFO [localhost] (1/1) vagrant is running on other
[Jul  4 14:57:47]  INFO [vagrant] Scanning OS pkg in fast-root mode
[Jul  4 14:57:48]  WARN [vagrant] err: Failed to scan updatable packages:
    github.com/future-architect/vuls/scanner.(*suse).scanPackages
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/suse.go:192
  - zypper -q lu Unknown format: :
    github.com/future-architect/vuls/scanner.(*suse).parseZypperLUOneLine
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/suse.go:249
[Jul  4 14:57:50]  WARN [localhost] Some warnings occurred during scanning on vagrant. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to scan updatable packages:
    github.com/future-architect/vuls/scanner.(*suse).scanPackages
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/suse.go:192
  - zypper -q lu Unknown format: :
    github.com/future-architect/vuls/scanner.(*suse).parseZypperLUOneLine
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/suse.go:249]


Scan Summary
================
vagrant	opensuse.leap15.6	275 installed, 0 updatable

Warning: [Failed to scan updatable packages:
    github.com/future-architect/vuls/scanner.(*suse).scanPackages
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/suse.go:192
  - zypper -q lu Unknown format: :
    github.com/future-architect/vuls/scanner.(*suse).parseZypperLUOneLine
        /home/mainek00n/github/github.com/MaineK00n/vuls/scanner/suse.go:249]



To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

## after
```console
$ vuls scan
[Jul  4 14:59:39]  INFO [localhost] vuls-v0.26.0-build-20240704_145807_67df9ce
...
[Jul  4 14:59:41]  INFO [localhost] (1/1) vagrant is running on other
[Jul  4 14:59:41]  INFO [vagrant] Scanning OS pkg in fast-root mode


Scan Summary
================
vagrant	opensuse.leap15.6	275 installed, 122 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

