### PR TITLE
fix(detect/oracle): handle ksplice advisories

### DIFF
--- a/oval/util.go
+++ b/oval/util.go
@@ -406,8 +406,8 @@ func isOvalDefAffected(def ovalmodels.Definition, req request, family, release s
 			continue
 		}
 
-		// https://github.com/aquasecurity/trivy/pull/745
-		if strings.Contains(req.versionRelease, ".ksplice1.") != strings.Contains(ovalPack.Version, ".ksplice1.") {
+		// https://github.com/aquasecurity/trivy/blob/08cc14bd2171afdc1973c6d614dd0d1fb82b7623/pkg/detector/ospkg/oracle/oracle.go#L72-L77
+		if family == constant.Oracle && extractOracleKsplice(ovalPack.Version) != extractOracleKsplice(req.versionRelease) {
 			continue
 		}
 
@@ -589,6 +589,15 @@ var rhelRebuildOSVerPattern = regexp.MustCompile(`\.[es]l(\d+)(?:_\d+)?(?:\.(cen
 
 func rhelRebuildOSVersionToRHEL(ver string) string {
 	return rhelRebuildOSVerPattern.ReplaceAllString(ver, ".el$1")
+}
+
+func extractOracleKsplice(v string) string {
+	for _, s := range strings.Split(v, ".") {
+		if strings.HasPrefix(s, "ksplice") {
+			return s
+		}
+	}
+	return ""
 }
 
 // NewOVALClient returns a client for OVAL database

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -1887,6 +1887,48 @@ func TestIsOvalDefAffected(t *testing.T) {
 			affected: true,
 			fixedIn:  "2:2.17-106.0.1.ksplice1.el7_2.4",
 		},
+		// .ksplice2.
+		{
+			in: in{
+				family: constant.Oracle,
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:    "nginx",
+							Version: "2:2.17-106.0.1.ksplice2.el7_2.4",
+							Arch:    "x86_64",
+						},
+					},
+				},
+				req: request{
+					packName:       "nginx",
+					versionRelease: "2:2.17-107",
+					arch:           "x86_64",
+				},
+			},
+			affected: false,
+		},
+		// in: .ksplice1. , req: .ksplice2.
+		{
+			in: in{
+				family: constant.Oracle,
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:    "nginx",
+							Version: "2:2.17-106.0.1.ksplice1.el7_2.4",
+							Arch:    "x86_64",
+						},
+					},
+				},
+				req: request{
+					packName:       "nginx",
+					versionRelease: "2:2.17-105.0.1.ksplice2.el7_2.4",
+					arch:           "x86_64",
+				},
+			},
+			affected: false,
+		},
 		// same arch
 		{
 			in: in{


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Previously, for Oracle's ksplice advisory, we only considered `.ksplice1.`, but sometimes it was `.ksplice2.`. This PR makes the comparison for ksplice advisory more accurate.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ vuls report
docker (oracle8.10)
===================
Total: 14 (Critical:0 High:6 Medium:7 Low:1 ?:0)
14/14 Fixed, 0 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
235 installed

+----------------+------+--------+-----+-----------+---------+--------------------------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |            PACKAGES            |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2016-10228 |  8.9 |        |     |           |   fixed | glibc, glibc-common,           |
|                |      |        |     |           |         | glibc-langpack-en              |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2019-25013 |  8.9 |        |     |           |   fixed | glibc, glibc-common,           |
|                |      |        |     |           |         | glibc-langpack-en              |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2019-9169  |  8.9 |        |     |           |   fixed | glibc, glibc-common,           |
|                |      |        |     |           |         | glibc-langpack-en              |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2020-27618 |  8.9 |        |     |           |   fixed | glibc, glibc-common,           |
|                |      |        |     |           |         | glibc-langpack-en              |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2021-3326  |  8.9 |        |     |           |   fixed | glibc, glibc-common,           |
|                |      |        |     |           |         | glibc-langpack-en              |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2021-40528 |  8.9 |        |     |           |   fixed | libgcrypt                      |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2021-20231 |  6.9 |        |     |           |   fixed | gnutls                         |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2021-20232 |  6.9 |        |     |           |   fixed | gnutls                         |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2021-33560 |  6.9 |        |     |           |   fixed | libgcrypt                      |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2021-3580  |  6.9 |        |     |           |   fixed | gnutls                         |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2024-0553  |  6.9 |        |     |           |   fixed | gnutls                         |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2024-28182 |  6.9 |        |     |           |   fixed | libnghttp2                     |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2024-28834 |  6.9 |        |     |           |   fixed | gnutls                         |
+----------------+------+--------+-----+-----------+---------+--------------------------------+
| CVE-2023-2953  |  3.9 |        |     |           |   fixed | openldap                       |
+----------------+------+--------+-----+-----------+---------+--------------------------------+

$ cat results/2024-08-09T11-53-49+0900/docker.json | jq '.packages.glibc'
{
  "name": "glibc",
  "version": "2.28",
  "release": "251.0.2.el8_10.2",
  "newVersion": "2.28",
  "newRelease": "251.0.2.el8_10.2",
  "arch": "x86_64",
  "repository": "",
  "modularitylabel": ""
}

$ cat results/2024-08-09T11-53-49+0900/docker.json | jq '.scannedCves."CVE-2016-10228".affectedPackages'
[
  {
    "name": "glibc",
    "fixedIn": "2:2.28-151.0.1.ksplice2.el8"
  },
  {
    "name": "glibc-common",
    "fixedIn": "2:2.28-151.0.1.ksplice2.el8"
  },
  {
    "name": "glibc-langpack-en",
    "fixedIn": "2:2.28-151.0.1.ksplice2.el8"
  }
]
```

## after
```console
$ vuls report
...
docker (oracle8.10)
===================
Total: 9 (Critical:0 High:1 Medium:7 Low:1 ?:0)
9/9 Fixed, 0 poc, 0 exploits, cisa: 0, uscert: 0, jpcert: 0 alerts
235 installed

+----------------+------+--------+-----+-----------+---------+------------+
|     CVE-ID     | CVSS | ATTACK | POC |   ALERT   |  FIXED  |  PACKAGES  |
+----------------+------+--------+-----+-----------+---------+------------+
| CVE-2021-40528 |  8.9 |        |     |           |   fixed | libgcrypt  |
+----------------+------+--------+-----+-----------+---------+------------+
| CVE-2021-20231 |  6.9 |        |     |           |   fixed | gnutls     |
+----------------+------+--------+-----+-----------+---------+------------+
| CVE-2021-20232 |  6.9 |        |     |           |   fixed | gnutls     |
+----------------+------+--------+-----+-----------+---------+------------+
| CVE-2021-33560 |  6.9 |        |     |           |   fixed | libgcrypt  |
+----------------+------+--------+-----+-----------+---------+------------+
| CVE-2021-3580  |  6.9 |        |     |           |   fixed | gnutls     |
+----------------+------+--------+-----+-----------+---------+------------+
| CVE-2024-0553  |  6.9 |        |     |           |   fixed | gnutls     |
+----------------+------+--------+-----+-----------+---------+------------+
| CVE-2024-28182 |  6.9 |        |     |           |   fixed | libnghttp2 |
+----------------+------+--------+-----+-----------+---------+------------+
| CVE-2024-28834 |  6.9 |        |     |           |   fixed | gnutls     |
+----------------+------+--------+-----+-----------+---------+------------+
| CVE-2023-2953  |  3.9 |        |     |           |   fixed | openldap   |
+----------------+------+--------+-----+-----------+---------+------------+
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

