### PR TITLE
feat(trivy): add new cveContentType trivy:azure

### DIFF
--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -354,6 +354,8 @@ func NewCveContentType(name string) CveContentType {
 		return TrivyFedora
 	case "trivy:amazon":
 		return TrivyAmazon
+	case "trivy:azure":
+		return TrivyAzure
 	case "trivy:oracle-oval":
 		return TrivyOracleOVAL
 	case "trivy:suse-cvrf":
@@ -417,7 +419,7 @@ func GetCveContentTypes(family string) []CveContentType {
 	case constant.Windows:
 		return []CveContentType{Microsoft}
 	case string(Trivy):
-		return []CveContentType{Trivy, TrivyNVD, TrivyRedHat, TrivyRedHatOVAL, TrivyDebian, TrivyUbuntu, TrivyCentOS, TrivyRocky, TrivyFedora, TrivyAmazon, TrivyOracleOVAL, TrivySuseCVRF, TrivyAlpine, TrivyArchLinux, TrivyAlma, TrivyCBLMariner, TrivyPhoton, TrivyRubySec, TrivyPhpSecurityAdvisories, TrivyNodejsSecurityWg, TrivyGHSA, TrivyGLAD, TrivyOSV, TrivyWolfi, TrivyChainguard, TrivyBitnamiVulndb, TrivyK8sVulnDB, TrivyGoVulnDB}
+		return []CveContentType{Trivy, TrivyNVD, TrivyRedHat, TrivyRedHatOVAL, TrivyDebian, TrivyUbuntu, TrivyCentOS, TrivyRocky, TrivyFedora, TrivyAmazon, TrivyAzure, TrivyOracleOVAL, TrivySuseCVRF, TrivyAlpine, TrivyArchLinux, TrivyAlma, TrivyCBLMariner, TrivyPhoton, TrivyRubySec, TrivyPhpSecurityAdvisories, TrivyNodejsSecurityWg, TrivyGHSA, TrivyGLAD, TrivyOSV, TrivyWolfi, TrivyChainguard, TrivyBitnamiVulndb, TrivyK8sVulnDB, TrivyGoVulnDB}
 	default:
 		return nil
 	}
@@ -501,6 +503,9 @@ const (
 
 	// TrivyAmazon is TrivyAmazon
 	TrivyAmazon CveContentType = "trivy:amazon"
+
+	// TrivyAzure is TrivyAzure
+	TrivyAzure CveContentType = "trivy:azure"
 
 	// TrivyOracleOVAL is TrivyOracle
 	TrivyOracleOVAL CveContentType = "trivy:oracle-oval"
@@ -592,6 +597,7 @@ var AllCveContetTypes = CveContentTypes{
 	TrivyRocky,
 	TrivyFedora,
 	TrivyAmazon,
+	TrivyAzure,
 	TrivyOracleOVAL,
 	TrivySuseCVRF,
 	TrivyAlpine,


### PR DESCRIPTION
# What did you implement:
As a result of Trivy supporting Azure Linux, ```trivy:azure``` is now included in the cveContentType of vuls detection results. Therefore, add ```trivy:azure``` as a constant in vuls.
- https://github.com/aquasecurity/trivy-db/pull/409

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES