### PR TITLE
fix(detector/cpe): do not overwrite distro advisories

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -638,7 +638,9 @@ func DetectCpeURIsCves(r *models.ScanResult, cpes []Cpe, cnf config.GoCveDictCon
 			if val, ok := r.ScannedCves[detail.CveID]; ok {
 				val.CpeURIs = util.AppendIfMissing(val.CpeURIs, cpe.CpeURI)
 				val.Confidences.AppendIfMissing(maxConfidence)
-				val.DistroAdvisories = advisories
+				for _, adv := range advisories {
+					val.DistroAdvisories.AppendIfMissing(&adv)
+				}
 				r.ScannedCves[detail.CveID] = val
 			} else {
 				v := models.VulnInfo{


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

There was a bug where when a vulnerability was detected on a CPE and that vulnerability had already been detected by another method, the information in DistroAdvisories was overwritten, resulting in the loss of the information from the previous detection.
For example, [JVNDB-2024-000098](https://github.com/vulsio/vuls-data-raw-jvn-feed-rss/blob/5224a56349ff02c7cd4a561b8a05361e43c373d5/2024/JVNDB-2024-000098.json) and [JVNDB-2024-005553](https://github.com/vulsio/vuls-data-raw-jvn-feed-rss/blob/5224a56349ff02c7cd4a561b8a05361e43c373d5/2024/JVNDB-2024-005553.json), both of which are related to CVE-2024-7263.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## setup
```console
$ go-cve-dictionary fetch jvn 2024
$ cat config.toml
...
[servers]
[servers.pseudo]
type = "pseudo"
cpeNames = [
  "cpe:2.3:a:kingsoft:wps_office:v12.2.0.13489:*:*:*:*:*:*:*",
  "cpe:2.3:a:kingsoft:wps_cloud:v11.2.0.10693:*:*:*:*:*:*:*"
]
$ vuls scan
```

## before
```console
$ vuls report --refresh-cve
$ cat results/2024-10-02T03-56-59+0900/pseudo.json | jq '.scannedCves."CVE-2024-7263".distroAdvisories'
[
  {
    "advisoryID": "JVNDB-2024-000098",
    "severity": "",
    "issued": "0001-01-01T00:00:00Z",
    "updated": "0001-01-01T00:00:00Z",
    "description": ""
  }
]
```

## after
```console
$ vuls report --refresh-cve
$ cat results/2024-10-02T03-56-59+0900/pseudo.json | jq '.scannedCves."CVE-2024-7263".distroAdvisories'
[
  {
    "advisoryID": "JVNDB-2024-000098",
    "severity": "",
    "issued": "0001-01-01T00:00:00Z",
    "updated": "0001-01-01T00:00:00Z",
    "description": ""
  },
  {
    "advisoryID": "JVNDB-2024-005553",
    "severity": "",
    "issued": "0001-01-01T00:00:00Z",
    "updated": "0001-01-01T00:00:00Z",
    "description": ""
  }
]
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

