### PR TITLE
feat(detector/microsoft): set WindowsRoughMatch if KB or Version to be fixed is unknown

### DIFF
--- a/gost/microsoft_test.go
+++ b/gost/microsoft_test.go
@@ -1,0 +1,443 @@
+//go:build !scanner
+// +build !scanner
+
+package gost
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/future-architect/vuls/constant"
+	"github.com/future-architect/vuls/models"
+	gostmodels "github.com/vulsio/gost/models"
+)
+
+func TestMicrosoft_detect(t *testing.T) {
+	type args struct {
+		r         *models.ScanResult
+		cve       gostmodels.MicrosoftCVE
+		applied   []string
+		unapplied []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *models.VulnInfo
+		wantErr bool
+	}{
+		{
+			name: "microsoft windows not affected",
+			args: args{
+				r: &models.ScanResult{
+					Family:  constant.Windows,
+					Release: "Windows Server 2012 R2",
+				},
+				cve: gostmodels.MicrosoftCVE{
+					CveID: "CVE-2023-21554",
+					Products: []gostmodels.MicrosoftProduct{
+						{
+							Name: "Windows Server 2012 R2",
+							KBs: []gostmodels.MicrosoftKB{
+								{
+									Article:    "5025285",
+									FixedBuild: "6.3.9600.20919",
+								},
+								{
+									Article:    "5025288",
+									FixedBuild: "6.3.9600.20919",
+								},
+							},
+						},
+					},
+				},
+				applied: []string{"5025288"},
+			},
+		},
+		{
+			name: "microsoft windows not affected2",
+			args: args{
+				r: &models.ScanResult{
+					Family:  constant.Windows,
+					Release: "Windows 10 Version 21H2 for x64-based Systems",
+				},
+				cve: gostmodels.MicrosoftCVE{
+					CveID: "CVE-2023-21554",
+					Products: []gostmodels.MicrosoftProduct{
+						{
+							Name: "Windows 10 Version 21H2 for x64-based Systems",
+							KBs: []gostmodels.MicrosoftKB{
+								{
+									Article:    "5025221",
+									FixedBuild: "10.0.19044.2846",
+								},
+							},
+						},
+					},
+				},
+				unapplied: []string{"5026361"},
+			},
+		},
+		{
+			name: "microsoft windows fixed",
+			args: args{
+				r: &models.ScanResult{
+					Family:  constant.Windows,
+					Release: "Windows 10 Version 21H2 for x64-based Systems",
+				},
+				cve: gostmodels.MicrosoftCVE{
+					CveID: "CVE-2023-21554",
+					Products: []gostmodels.MicrosoftProduct{
+						{
+							Name: "Windows 10 Version 21H2 for x64-based Systems",
+							KBs: []gostmodels.MicrosoftKB{
+								{
+									Article:    "5025221",
+									FixedBuild: "10.0.19044.2846",
+								},
+							},
+						},
+					},
+				},
+				unapplied: []string{"5025221"},
+			},
+			want: &models.VulnInfo{
+				CveID:       "CVE-2023-21554",
+				Confidences: models.Confidences{models.WindowsUpdateSearch},
+				DistroAdvisories: models.DistroAdvisories{
+					{
+						AdvisoryID:  "KB5025221",
+						Description: "Microsoft Knowledge Base",
+					},
+				},
+				CveContents: models.CveContents{
+					models.Microsoft: []models.CveContent{
+						{
+							Type:  models.Microsoft,
+							CveID: "CVE-2023-21554",
+						},
+					},
+				},
+				WindowsKBFixedIns: []string{"KB5025221"},
+			},
+		},
+		{
+			name: "microsoft windows unfixed",
+			args: args{
+				r: &models.ScanResult{
+					Family:  constant.Windows,
+					Release: "Windows 10 Version 21H2 for x64-based Systems",
+				},
+				cve: gostmodels.MicrosoftCVE{
+					CveID: "CVE-2013-3900",
+					Products: []gostmodels.MicrosoftProduct{
+						{
+							Name: "Windows 10 Version 21H2 for x64-based Systems",
+						},
+					},
+				},
+			},
+			want: &models.VulnInfo{
+				CveID:       "CVE-2013-3900",
+				Confidences: models.Confidences{models.WindowsUpdateSearch},
+				AffectedPackages: models.PackageFixStatuses{
+					{
+						Name:     "Windows 10 Version 21H2 for x64-based Systems",
+						FixState: "unfixed",
+					},
+				},
+				CveContents: models.CveContents{
+					models.Microsoft: []models.CveContent{
+						{
+							Type:  models.Microsoft,
+							CveID: "CVE-2013-3900",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "microsoft edge not installed",
+			args: args{
+				r: &models.ScanResult{
+					Family:  constant.Windows,
+					Release: "Windows 10 Version 21H2 for x64-based Systems",
+				},
+				cve: gostmodels.MicrosoftCVE{
+					CveID: "CVE-2024-8639",
+					Products: []gostmodels.MicrosoftProduct{
+						{
+							Name: "Microsoft Edge (Chromium-based)",
+							KBs: []gostmodels.MicrosoftKB{
+								{
+									Article:    "Release Notes",
+									FixedBuild: "128.0.2739.79",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "microsoft edge not affected",
+			args: args{
+				r: &models.ScanResult{
+					Family:  constant.Windows,
+					Release: "Windows 10 Version 21H2 for x64-based Systems",
+					Packages: models.Packages{
+						"Microsoft Edge": {
+							Name:    "Microsoft Edge",
+							Version: "128.0.2739.79",
+						},
+					},
+				},
+				cve: gostmodels.MicrosoftCVE{
+					CveID: "CVE-2024-8639",
+					Products: []gostmodels.MicrosoftProduct{
+						{
+							Name: "Microsoft Edge (Chromium-based)",
+							KBs: []gostmodels.MicrosoftKB{
+								{
+									Article:    "Release Notes",
+									FixedBuild: "128.0.2739.79",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "microsoft edge fixed",
+			args: args{
+				r: &models.ScanResult{
+					Family:  constant.Windows,
+					Release: "Windows Server 2016",
+					Packages: models.Packages{
+						"Microsoft Edge": {
+							Name:    "Microsoft Edge",
+							Version: "38.14393",
+						},
+					},
+				},
+				cve: gostmodels.MicrosoftCVE{
+					CveID: "CVE-2016-7195",
+					Products: []gostmodels.MicrosoftProduct{
+						{
+							Name: "Internet Explorer 11 on Windows Server 2016",
+							KBs: []gostmodels.MicrosoftKB{
+								{
+									Article: "3200970",
+								},
+							},
+						},
+						{
+							Name: "Microsoft Edge (EdgeHTML-based) on Windows Server 2016",
+							KBs: []gostmodels.MicrosoftKB{
+								{
+									Article: "3200970",
+								},
+							},
+						},
+					},
+				},
+				unapplied: []string{"3200970"},
+			},
+			want: &models.VulnInfo{
+				CveID:       "CVE-2016-7195",
+				Confidences: models.Confidences{models.WindowsUpdateSearch},
+				DistroAdvisories: models.DistroAdvisories{
+					{
+						AdvisoryID:  "KB3200970",
+						Description: "Microsoft Knowledge Base",
+					},
+				},
+				CveContents: models.CveContents{
+					models.Microsoft: []models.CveContent{
+						{
+							Type:  models.Microsoft,
+							CveID: "CVE-2016-7195",
+						},
+					},
+				},
+				WindowsKBFixedIns: []string{"KB3200970"},
+			},
+		},
+		{
+			name: "microsoft edge fixed2",
+			args: args{
+				r: &models.ScanResult{
+					Family:  constant.Windows,
+					Release: "Windows 10 Version 21H2 for x64-based Systems",
+					Packages: models.Packages{
+						"Microsoft Edge": {
+							Name:    "Microsoft Edge",
+							Version: "111.0.1661.41",
+						},
+					},
+				},
+				cve: gostmodels.MicrosoftCVE{
+					CveID: "CVE-2024-8639",
+					Products: []gostmodels.MicrosoftProduct{
+						{
+							Name: "Microsoft Edge (Chromium-based)",
+							KBs: []gostmodels.MicrosoftKB{
+								{
+									Article:    "Release Notes",
+									FixedBuild: "128.0.2739.79",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &models.VulnInfo{
+				CveID:       "CVE-2024-8639",
+				Confidences: models.Confidences{models.WindowsUpdateSearch},
+				AffectedPackages: models.PackageFixStatuses{
+					{
+						Name:     "Microsoft Edge",
+						FixState: "fixed",
+						FixedIn:  "128.0.2739.79",
+					},
+				},
+				CveContents: models.CveContents{
+					models.Microsoft: []models.CveContent{
+						{
+							Type:  models.Microsoft,
+							CveID: "CVE-2024-8639",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "microsoft edge unknown",
+			args: args{
+				r: &models.ScanResult{
+					Family:  constant.Windows,
+					Release: "Windows 10 Version 21H2 for x64-based Systems",
+					Packages: models.Packages{
+						"Microsoft Edge": {
+							Name:    "Microsoft Edge",
+							Version: "111.0.1661.41",
+						},
+					},
+				},
+				cve: gostmodels.MicrosoftCVE{
+					CveID: "CVE-2020-1195",
+					Products: []gostmodels.MicrosoftProduct{
+						{
+							Name: "Microsoft Edge (Chromium-based)",
+						},
+					},
+				},
+			},
+			want: &models.VulnInfo{
+				CveID:       "CVE-2020-1195",
+				Confidences: models.Confidences{models.WindowsRoughMatch},
+				AffectedPackages: models.PackageFixStatuses{
+					{
+						Name:     "Microsoft Edge",
+						FixState: "unknown",
+					},
+				},
+				CveContents: models.CveContents{
+					models.Microsoft: []models.CveContent{
+						{
+							Type:  models.Microsoft,
+							CveID: "CVE-2020-1195",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "microsoft edge unknown2",
+			args: args{
+				r: &models.ScanResult{
+					Family:  constant.Windows,
+					Release: "Windows 10 Version 21H2 for x64-based Systems",
+					Packages: models.Packages{
+						"Microsoft Edge": {
+							Name:    "Microsoft Edge",
+							Version: "111.0.1661.41",
+						},
+					},
+				},
+				cve: gostmodels.MicrosoftCVE{
+					CveID: "CVE-2022-4135",
+					Products: []gostmodels.MicrosoftProduct{
+						{
+							Name: "Microsoft Edge (Chromium-based)",
+							KBs: []gostmodels.MicrosoftKB{
+								{
+									Article: "Release Notes",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &models.VulnInfo{
+				CveID:       "CVE-2022-4135",
+				Confidences: models.Confidences{models.WindowsRoughMatch},
+				AffectedPackages: models.PackageFixStatuses{
+					{
+						Name:     "Microsoft Edge",
+						FixState: "unknown",
+					},
+				},
+				CveContents: models.CveContents{
+					models.Microsoft: []models.CveContent{
+						{
+							Type:  models.Microsoft,
+							CveID: "CVE-2022-4135",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "microsoft other product",
+			args: args{
+				r: &models.ScanResult{
+					Family:  constant.Windows,
+					Release: "Windows 10 Version 21H2 for x64-based Systems",
+					Packages: models.Packages{
+						"Microsoft Visual Studio Code": {
+							Name:    "Microsoft Visual Studio Code",
+							Version: "1.76.0",
+						},
+					},
+				},
+				cve: gostmodels.MicrosoftCVE{
+					CveID: "CVE-2024-26165",
+					Products: []gostmodels.MicrosoftProduct{
+						{
+							Name: "Visual Studio Code",
+							KBs: []gostmodels.MicrosoftKB{
+								{
+									Article:    "Release Notes",
+									FixedBuild: "1.87.2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := (Microsoft{}).detect(tt.args.r, tt.args.cve, tt.args.applied, tt.args.unapplied)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Microsoft.detect() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Microsoft.detect() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -1100,22 +1100,22 @@ var (
 	// OvalMatch is a ranking how confident the CVE-ID was detected correctly
 	OvalMatch = Confidence{100, OvalMatchStr, 0}
 
-	// RedHatAPIMatch ranking how confident the CVE-ID was detected correctly
+	// RedHatAPIMatch is a ranking how confident the CVE-ID was detected correctly
 	RedHatAPIMatch = Confidence{100, RedHatAPIStr, 0}
 
-	// DebianSecurityTrackerMatch ranking how confident the CVE-ID was detected correctly
+	// DebianSecurityTrackerMatch is a ranking how confident the CVE-ID was detected correctly
 	DebianSecurityTrackerMatch = Confidence{100, DebianSecurityTrackerMatchStr, 0}
 
-	// UbuntuAPIMatch ranking how confident the CVE-ID was detected correctly
+	// UbuntuAPIMatch is a ranking how confident the CVE-ID was detected correctly
 	UbuntuAPIMatch = Confidence{100, UbuntuAPIMatchStr, 0}
 
-	// WindowsUpdateSearch ranking how confident the CVE-ID was detected correctly
+	// WindowsUpdateSearch is a ranking how confident the CVE-ID was detected correctly
 	WindowsUpdateSearch = Confidence{100, WindowsUpdateSearchStr, 0}
 
-	// WindowsRoughMatch ranking how confident the CVE-ID was detected correctly
+	// WindowsRoughMatch is a ranking how confident the CVE-ID was detected correctly
 	WindowsRoughMatch = Confidence{30, WindowsRoughMatchStr, 0}
 
-	// TrivyMatch ranking how confident the CVE-ID was detected correctly
+	// TrivyMatch is a ranking how confident the CVE-ID was detected correctly
 	TrivyMatch = Confidence{100, TrivyMatchStr, 0}
 
 	// ChangelogExactMatch is a ranking how confident the CVE-ID was detected correctly
@@ -1133,7 +1133,7 @@ var (
 	// NvdExactVersionMatch is a ranking how confident the CVE-ID was detected correctly
 	NvdExactVersionMatch = Confidence{100, NvdExactVersionMatchStr, 1}
 
-	// NvdRoughVersionMatch NvdExactVersionMatch is a ranking how confident the CVE-ID was detected correctly
+	// NvdRoughVersionMatch is a ranking how confident the CVE-ID was detected correctly
 	NvdRoughVersionMatch = Confidence{80, NvdRoughVersionMatchStr, 1}
 
 	// NvdVendorProductMatch is a ranking how confident the CVE-ID was detected correctly
@@ -1145,7 +1145,7 @@ var (
 	// FortinetExactVersionMatch is a ranking how confident the CVE-ID was detected correctly
 	FortinetExactVersionMatch = Confidence{100, FortinetExactVersionMatchStr, 1}
 
-	// FortinetRoughVersionMatch FortinetExactVersionMatch is a ranking how confident the CVE-ID was detected correctly
+	// FortinetRoughVersionMatch is a ranking how confident the CVE-ID was detected correctly
 	FortinetRoughVersionMatch = Confidence{80, FortinetRoughVersionMatchStr, 1}
 
 	// FortinetVendorProductMatch is a ranking how confident the CVE-ID was detected correctly

--- a/models/vulninfos_test.go
+++ b/models/vulninfos_test.go
@@ -1874,17 +1874,72 @@ func TestVulnInfo_PatchStatus(t *testing.T) {
 			want: "fixed",
 		},
 		{
-			name: "windows unfixed",
+			name: "WindowsRoughMatch",
+			fields: fields{
+				Confidences: Confidences{WindowsRoughMatch},
+			},
+			want: "unknown",
+		},
+		{
+			name: "WindowsRoughMatch and WindowsUpdateSearch",
+			fields: fields{
+				Confidences: Confidences{WindowsRoughMatch, WindowsUpdateSearch},
+			},
+			want: "unknown",
+		},
+		{
+			name: "WindowsUpdateSearch unknown",
+			fields: fields{
+				Confidences: Confidences{WindowsUpdateSearch},
+				AffectedPackages: PackageFixStatuses{
+					{
+						Name:     "Microsoft Edge",
+						FixState: "unknown",
+					},
+				},
+			},
+			want: "unknown",
+		},
+		{
+			name: "WindowsUpdateSearch unfixed",
+			fields: fields{
+				Confidences: Confidences{WindowsUpdateSearch},
+				AffectedPackages: PackageFixStatuses{
+					{
+						Name:     "Windows 10 Version 21H2 for x64-based Systems",
+						FixState: "unfixed",
+					},
+				},
+				WindowsKBFixedIns: []string{"000000"},
+			},
+			want: "unfixed",
+		},
+		{
+			name: "WindowsUpdateSearch unfixed2",
 			fields: fields{
 				Confidences: Confidences{WindowsUpdateSearch},
 			},
 			want: "unfixed",
 		},
 		{
-			name: "windows fixed",
+			name: "WindowsUpdateSearch fixed",
 			fields: fields{
 				Confidences:       Confidences{WindowsUpdateSearch},
 				WindowsKBFixedIns: []string{"000000"},
+			},
+			want: "fixed",
+		},
+		{
+			name: "WindowsUpdateSearch fixed2",
+			fields: fields{
+				Confidences: Confidences{WindowsUpdateSearch},
+				AffectedPackages: PackageFixStatuses{
+					{
+						Name:     "Microsoft Edge",
+						FixState: "fixed",
+						FixedIn:  "128.0.2739.79",
+					},
+				},
 			},
 			want: "fixed",
 		},


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Among the vulnerabilities detected in Windows, particularly in Edge, even those for which the KB or fixed build to fix them is unknown are set with a confidence level of 100, called WindowsUpdateSearch.
Because cases like this are very noisy, we set WindowsRoughMatch, which lowers the reliability to 30.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

## before
```console
$ vuls report --refresh-cve
$ cat results/2024-10-04T02-18-44+0900/localhost.json | jq '.scannedCves."CVE-2023-6112" | [.confidences,.affectedPackages]'
[
  [
    {
      "score": 100,
      "detectionMethod": "WindowsUpdateSearch"
    }
  ],
  [
    {
      "name": "Microsoft Edge",
      "fixState": "unknown"
    }
  ]
]
```

## after
```console
$ vuls report --refresh-cve
$ cat results/2024-10-04T02-18-44+0900/localhost.json | jq '.scannedCves."CVE-2023-6112" | [.confidences,.affectedPackages]'
[
  [
    {
      "score": 30,
      "detectionMethod": "WindowsRoughMatch"
    }
  ],
  [
    {
      "name": "Microsoft Edge",
      "fixState": "unknown"
    }
  ]
]
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
