### PR TITLE
feat(oval/oracle): ignore fips patched version for non fips package versions

### DIFF
--- a/oval/util.go
+++ b/oval/util.go
@@ -415,6 +415,9 @@ func isOvalDefAffected(def ovalmodels.Definition, req request, family, release s
 			if extractOracleKsplice(ovalPack.Version) != extractOracleKsplice(req.versionRelease) {
 				continue
 			}
+			if strings.HasSuffix(ovalPack.Version, "_fips") != strings.HasSuffix(req.versionRelease, "_fips") {
+				continue
+			}
 		case constant.SUSEEnterpriseServer:
 			if strings.Contains(ovalPack.Version, ".TDC.") != strings.Contains(req.versionRelease, ".TDC.") {
 				continue

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -1929,6 +1929,70 @@ func TestIsOvalDefAffected(t *testing.T) {
 			},
 			affected: false,
 		},
+		// in: _fips , req: not fips
+		{
+			in: in{
+				family: constant.Oracle,
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:    "gnutls",
+							Version: "10:3.6.16-4.0.1.el8_fips",
+							Arch:    "x86_64",
+						},
+					},
+				},
+				req: request{
+					packName:       "gnutls",
+					versionRelease: "3.6.16-4.el8",
+					arch:           "x86_64",
+				},
+			},
+			affected: false,
+		},
+		// in: _fips , req: _fips
+		{
+			in: in{
+				family: constant.Oracle,
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:    "gnutls",
+							Version: "10:3.6.16-8.el8_9.3_fips",
+							Arch:    "x86_64",
+						},
+					},
+				},
+				req: request{
+					packName:       "gnutls",
+					versionRelease: "10:3.6.16-4.0.1.el8_fips",
+					arch:           "x86_64",
+				},
+			},
+			affected: true,
+			fixedIn:  "10:3.6.16-8.el8_9.3_fips",
+		},
+		// in: non fips (upstream?), req: _fips
+		{
+			in: in{
+				family: constant.Oracle,
+				def: ovalmodels.Definition{
+					AffectedPacks: []ovalmodels.Package{
+						{
+							Name:    "gnutls",
+							Version: "0:3.6.16-5.el8_6",
+							Arch:    "x86_64",
+						},
+					},
+				},
+				req: request{
+					packName:       "gnutls",
+					versionRelease: "10:3.6.16-4.0.1.el8_fips",
+					arch:           "x86_64",
+				},
+			},
+			affected: false,
+		},
 		// same arch
 		{
 			in: in{


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

like the ksplice and TDC in SUSE, we need not to report fips patched versions for non fips packages

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

by unit test

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

