### PR TITLE
fix(detect/windows) use existing confidence

### DIFF
--- a/gost/microsoft.go
+++ b/gost/microsoft.go
@@ -323,8 +323,7 @@ func (ms Microsoft) detect(r *models.ScanResult, cve gostmodels.MicrosoftCVE, ap
 	}
 
 	confs, err := func() (models.Confidences, error) {
-		var cs models.Confidences
-
+		cs := vinfo.Confidences
 		if len(vinfo.WindowsKBFixedIns) > 0 {
 			cs.AppendIfMissing(models.WindowsUpdateSearch)
 		}


### PR DESCRIPTION
# What did you implement:

Added processing to use the confidence value if vulnInfo already contains confidence.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ x ] Enable "Allow edits from maintainers" for this PR
- [ x ] Update the messages below

***Is this ready for review?:*** YES 

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

