### PR TITLE
feat(scanner): skip SSH configuration validation when ssh-key(scan|gen) failed

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -447,7 +447,8 @@ func validateSSHConfig(c *config.ServerInfo) error {
 	sshScanCmd := strings.Join([]string{sshKeyscanBinaryPath, "-p", c.Port, sshConfig.hostname}, " ")
 	r := localExec(*c, sshScanCmd, noSudo)
 	if !r.isSuccess() {
-		return xerrors.Errorf("Failed to ssh-keyscan. cmd: %s, err: %w", sshScanCmd, r.Error)
+		logging.Log.Warnf("SSH configuration validation is skipped. err: Failed to ssh-keyscan. cmd: %s, err: %s", sshScanCmd, r.Error)
+		return nil
 	}
 	serverKeys := parseSSHScan(r.Stdout)
 
@@ -471,7 +472,8 @@ func validateSSHConfig(c *config.ServerInfo) error {
 		if r := localExec(*c, cmd, noSudo); r.isSuccess() {
 			keyType, clientKey, err := parseSSHKeygen(r.Stdout)
 			if err != nil {
-				return xerrors.Errorf("Failed to parse ssh-keygen result. stdout: %s, err: %w", r.Stdout, r.Error)
+				logging.Log.Warnf("SSH configuration validation is skipped. err: Failed to parse ssh-keygen result. stdout: %s, err: %s", r.Stdout, r.Error)
+				return nil
 			}
 			if serverKey, ok := serverKeys[keyType]; ok && serverKey == clientKey {
 				return nil


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

There are cases where ssh succeeds but ssh-keyscan fails, as shown below.
What vuls actually needs is for ssh to be successful, and ssh-keyscan is merely a hint to find the cause when ssh fails.
Therefore, if ssh-keyscan and ssh-keygen fail to execute, vuls will not fail to execute, but rather it will assume that SSH configuration validation has failed, and that SSH will be possible as is, and vuls will continue to execute.
```console
PS C:\Users\shino\vagrant-vms\debian12> ssh vagrant@172.23.181.106 -i .\.vagrant\machines\default\hyperv\private_key
Last login: Tue Nov 12 01:59:54 2024 from 172.23.176.1
vagrant@debian12:~$ cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
vagrant@debian12:~$ exit
logout
Connection to 172.23.181.106 closed.

PS C:\Users\shino\vagrant-vms\debian12> ssh-keyscan.exe -p 22 172.23.181.106
# 172.23.181.106:22 SSH-2.0-OpenSSH_9.2p1 Debian-2+deb12u2
choose_kex: unsupported KEX method sntrup761x25519-sha512@openssh.com
# 172.23.181.106:22 SSH-2.0-OpenSSH_9.2p1 Debian-2+deb12u2
choose_kex: unsupported KEX method sntrup761x25519-sha512@openssh.com
# 172.23.181.106:22 SSH-2.0-OpenSSH_9.2p1 Debian-2+deb12u2
choose_kex: unsupported KEX method sntrup761x25519-sha512@openssh.com
# 172.23.181.106:22 SSH-2.0-OpenSSH_9.2p1 Debian-2+deb12u2
choose_kex: unsupported KEX method sntrup761x25519-sha512@openssh.com
# 172.23.181.106:22 SSH-2.0-OpenSSH_9.2p1 Debian-2+deb12u2
choose_kex: unsupported KEX method sntrup761x25519-sha512@openssh.com
PS C:\Users\shino\vagrant-vms\debian12> echo $?
False
```


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
PS C:\Users\shino\vagrant-vms\debian12> ./vuls.exe scan
time="Nov 12 11:08:46" level=info msg="vuls-v0.27.0-build-20241112_104945_c0b267d"
time="Nov 12 11:08:46" level=info msg="Start scanning"
time="Nov 12 11:08:46" level=info msg="config: C:\\Users\\shino\\vagrant-vms\\debian12\\config.toml"
time="Nov 12 11:08:46" level=info msg="Validating config..."
time="Nov 12 11:08:46" level=info msg="Detecting Server/Container OS... "
time="Nov 12 11:08:46" level=info msg="Detecting OS of servers... "
time="Nov 12 11:08:52" level=error msg="(1/1) Failed: debian12, err: [Failed to ssh-keyscan. cmd: ssh-keyscan.exe -p 22 172.23.181.106, err:\n    github.com/future-architect/vuls/scanner.validateSSHConfig\n        /home/shino/g/vuls/scanner/scanner.go:450\n  - exit status 1]"
time="Nov 12 11:08:52" level=info msg="Detecting OS of containers... "
time="Nov 12 11:08:52" level=info msg="Checking Scan Modes... "
time="Nov 12 11:08:52" level=info msg="Detecting Platforms... "
time="Nov 12 11:08:52" level=warning msg="Some warnings occurred during scanning on debian12. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family:  Release: `]"
Scan Summary
================
debian12        Error           Use configtest subcommand or scan with --debug to view the details
Warning: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family:  Release: `]
time="Nov 12 11:08:52" level=error msg="Failed to scan: Failed to scan. err:\n    github.com/future-architect/vuls/scanner.Scanner.Scan\n        /home/shino/g/vuls/scanner/scanner.go:111\n  - An error occurred on [debian12]"
```

## after
```console
PS C:\Users\shino\vagrant-vms\debian12> .\vuls.exe scan
time="Nov 12 11:56:57" level=info msg="vuls-`make build` or `make install` will show the version-"
time="Nov 12 11:56:57" level=info msg="Start scanning"
time="Nov 12 11:56:57" level=info msg="config: C:\\Users\\shino\\vagrant-vms\\debian12\\config.toml"
time="Nov 12 11:56:57" level=info msg="Validating config..."
time="Nov 12 11:56:57" level=info msg="Detecting Server/Container OS... "
time="Nov 12 11:56:57" level=info msg="Detecting OS of servers... "
time="Nov 12 11:57:03" level=warning msg="SSH configuration validation is skipped. err: Failed to ssh-keyscan. cmd: ssh-keyscan.exe -p 22 172.23.181.106, err: exit status 1"
time="Nov 12 11:57:05" level=info msg="(1/1) Detected: debian12: debian 12"
time="Nov 12 11:57:05" level=info msg="Detecting OS of containers... "
time="Nov 12 11:57:05" level=info msg="Checking Scan Modes... "
time="Nov 12 11:57:05" level=info msg="Detecting Platforms... "
time="Nov 12 11:57:08" level=info msg="(1/1) debian12 is running on other"
time="Nov 12 11:57:08" level=info msg="Scanning OS pkg in fast-root mode"
time="Nov 12 11:57:09" level=info msg="apt-get update..."
time="Nov 12 11:57:27" level=warning msg="Failed to find a running pkg: hyperv-daemons"
time="Nov 12 11:57:28" level=warning msg="Failed to find a running pkg: hyperv-daemons"
time="Nov 12 11:57:29" level=warning msg="Failed to find a running pkg: hyperv-daemons"
time="Nov 12 11:57:30" level=warning msg="err: Failed to scan need-restarting processes:\n    github.com/future-architect/vuls/scanner.(*debian).postScan\n        /home/shino/g/vuls/scanner/debian.go:259\n  - Failed to LANGUAGE=en_US.UTF-8 checkrestart. status: 1, stdout: , stderr: stty: 'standard input': Inappropriate ioctl for device\n    sudo: checkrestart: command not found:\n    github.com/future-architect/vuls/scanner.(*debian).checkrestart\n        /home/shino/g/vuls/scanner/debian.go:1182"
time="Nov 12 11:57:30" level=info msg="Scanning listen port..."
time="Nov 12 11:57:30" level=info msg="Using Port Scanner: Vuls built-in Scanner"
time="Nov 12 11:57:30" level=warning msg="Some warnings occurred during scanning on debian12. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to scan need-restarting processes:\n    github.com/future-architect/vuls/scanner.(*debian).postScan\n        /home/shino/g/vuls/scanner/debian.go:259\n  - Failed to LANGUAGE=en_US.UTF-8 checkrestart. status: 1, stdout: , stderr: stty: 'standard input': Inappropriate ioctl for device\n    sudo: checkrestart: command not found:\n    github.com/future-architect/vuls/scanner.(*debian).checkrestart\n        /home/shino/g/vuls/scanner/debian.go:1182]"
Scan Summary
================
debian12        debian12        357 installed, 72 updatable
Warning: [Failed to scan need-restarting processes:
    github.com/future-architect/vuls/scanner.(*debian).postScan
        /home/shino/g/vuls/scanner/debian.go:259
  - Failed to LANGUAGE=en_US.UTF-8 checkrestart. status: 1, stdout: , stderr: stty: 'standard input': Inappropriate ioctl for device
    sudo: checkrestart: command not found:
    github.com/future-architect/vuls/scanner.(*debian).checkrestart
        /home/shino/g/vuls/scanner/debian.go:1182]
To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://github.com/PowerShell/Win32-OpenSSH/issues/2140
