### PR TITLE
refactor: remove old buildtag

### DIFF
--- a/detector/cti.go
+++ b/detector/cti.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package detector
 

--- a/detector/cve_client.go
+++ b/detector/cve_client.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package detector
 

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package detector
 

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package detector
 

--- a/detector/exploitdb.go
+++ b/detector/exploitdb.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package detector
 

--- a/detector/github.go
+++ b/detector/github.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package detector
 

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 // Package javadb implements functions that wrap trivy-java-db module.
 package javadb

--- a/detector/kevuln.go
+++ b/detector/kevuln.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package detector
 

--- a/detector/library.go
+++ b/detector/library.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package detector
 

--- a/detector/msf.go
+++ b/detector/msf.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package detector
 

--- a/detector/util.go
+++ b/detector/util.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package detector
 

--- a/detector/wordpress.go
+++ b/detector/wordpress.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package detector
 

--- a/detector/wordpress_test.go
+++ b/detector/wordpress_test.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package detector
 

--- a/gost/debian.go
+++ b/gost/debian.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package gost
 

--- a/gost/debian_test.go
+++ b/gost/debian_test.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package gost
 

--- a/gost/gost.go
+++ b/gost/gost.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package gost
 

--- a/gost/gost_test.go
+++ b/gost/gost_test.go
@@ -1,4 +1,3 @@
 //go:build !scanner
-// +build !scanner
 
 package gost

--- a/gost/microsoft.go
+++ b/gost/microsoft.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package gost
 

--- a/gost/microsoft_test.go
+++ b/gost/microsoft_test.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package gost
 

--- a/gost/pseudo.go
+++ b/gost/pseudo.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package gost
 

--- a/gost/redhat.go
+++ b/gost/redhat.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package gost
 

--- a/gost/redhat_test.go
+++ b/gost/redhat_test.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package gost
 

--- a/gost/ubuntu.go
+++ b/gost/ubuntu.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package gost
 

--- a/gost/util.go
+++ b/gost/util.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package gost
 

--- a/models/utils.go
+++ b/models/utils.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package models
 

--- a/oval/alpine.go
+++ b/oval/alpine.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package oval
 

--- a/oval/debian.go
+++ b/oval/debian.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package oval
 

--- a/oval/oval.go
+++ b/oval/oval.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package oval
 

--- a/oval/redhat.go
+++ b/oval/redhat.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package oval
 

--- a/oval/redhat_test.go
+++ b/oval/redhat_test.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package oval
 

--- a/oval/suse.go
+++ b/oval/suse.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package oval
 

--- a/oval/suse_test.go
+++ b/oval/suse_test.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package oval
 

--- a/oval/util.go
+++ b/oval/util.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package oval
 

--- a/oval/util_test.go
+++ b/oval/util_test.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package oval
 

--- a/server/server.go
+++ b/server/server.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package server
 

--- a/subcmds/server.go
+++ b/subcmds/server.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package subcmds
 

--- a/subcmds/tui.go
+++ b/subcmds/tui.go
@@ -1,5 +1,4 @@
 //go:build !scanner
-// +build !scanner
 
 package subcmds
 


### PR DESCRIPTION
# What did you implement:

As of Go 1.18, the old build tag form `// +build` is deprecated. Remove it.

```console
$ go fix -fix buildtag ./...
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

