### PR TITLE
feat!(scanner/rpm): change queryformat (add sourcerpm)

### DIFF
--- a/scanner/suse.go
+++ b/scanner/suse.go
@@ -168,9 +168,9 @@ func (o *suse) sudoNoPasswdCmdsFastRoot() []cmd {
 	}
 }
 
-func (o *suse) scanPackages() error {
+func (o *suse) scanPackages() (err error) {
 	o.log.Infof("Scanning OS pkg in %s", o.getServerInfo().Mode)
-	installed, err := o.scanInstalledPackages()
+	o.Packages, o.SrcPackages, err = o.scanInstalledPackages()
 	if err != nil {
 		o.log.Errorf("Failed to scan installed packages: %s", err)
 		return err
@@ -185,7 +185,6 @@ func (o *suse) scanPackages() error {
 	}
 
 	if o.getServerInfo().Mode.IsOffline() {
-		o.Packages = installed
 		return nil
 	}
 
@@ -196,10 +195,8 @@ func (o *suse) scanPackages() error {
 		o.warns = append(o.warns, err)
 		// Only warning this error
 	} else {
-		installed.MergeNewVersion(updatable)
+		o.Packages.MergeNewVersion(updatable)
 	}
-
-	o.Packages = installed
 	return nil
 }
 


### PR DESCRIPTION
# What did you implement:

collect source package from rpm package manager

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

[results.zip](https://github.com/user-attachments/files/18045501/results.zip)

## alma 8
### before
```console
$ vuls report --format-one-line-text 2024-12-07T09-18-39+0900
[Dec  7 09:53:17]  INFO [localhost] vuls-v0.27.0-build-20241206_201629_1ab4c79
...

One Line Summary
================
vagrant	Total: 1994 (Critical:19 High:955 Medium:982 Low:37 ?:1)	1309/1994 Fixed	547 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts
```

### after
```console
$ vuls report --format-one-line-text 2024-12-07T09-22-52+0900
[Dec  7 09:53:04]  INFO [localhost] vuls-v0.27.0-build-20241207_091638_97dc992
...

One Line Summary
================
vagrant	Total: 1994 (Critical:19 High:955 Medium:982 Low:37 ?:1)	1309/1994 Fixed	547 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts
```

## alma 9
### before
```console
$ vuls report --format-one-line-text 2024-12-07T09-29-41+0900
[Dec  7 09:56:07]  INFO [localhost] vuls-v0.27.0-build-20241206_201629_1ab4c79
...


One Line Summary
================
vagrant	Total: 2168 (Critical:3 High:562 Medium:1566 Low:30 ?:7)	1222/2168 Fixed	620 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts
```

### after
```console
$ vuls report --format-one-line-text 2024-12-07T09-29-48+0900
[Dec  7 09:56:24]  INFO [localhost] vuls-v0.27.0-build-20241207_091638_97dc992
...


One Line Summary
================
vagrant	Total: 2168 (Critical:3 High:562 Medium:1566 Low:30 ?:7)	1222/2168 Fixed	620 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts
```

## rocky 8
### before
```console
$ vuls report --format-one-line-text 2024-12-07T09-33-54+0900
[Dec  7 09:57:43]  INFO [localhost] vuls-v0.27.0-build-20241206_201629_1ab4c79
...


One Line Summary
================
vagrant	Total: 1935 (Critical:13 High:893 Medium:992 Low:36 ?:1)	1238/1935 Fixed	474 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts
```

### after
```console
$ vuls report --format-one-line-text 2024-12-07T09-34-00+0900
[Dec  7 09:57:54]  INFO [localhost] vuls-v0.27.0-build-20241207_091638_97dc992
...


One Line Summary
================
vagrant	Total: 1935 (Critical:13 High:893 Medium:992 Low:36 ?:1)	1238/1935 Fixed	474 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts
```

## rocky 9
### before
```console
$ vuls report --format-one-line-text 2024-12-07T09-37-21+0900
[Dec  7 09:59:08]  INFO [localhost] vuls-v0.27.0-build-20241206_201629_1ab4c79
...


One Line Summary
================
vagrant	Total: 2081 (Critical:3 High:507 Medium:1518 Low:46 ?:7)	1078/2081 Fixed	495 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts
```

### after
```console
$ vuls report --format-one-line-text 2024-12-07T09-37-31+0900
[Dec  7 09:59:24]  INFO [localhost] vuls-v0.27.0-build-20241207_091638_97dc992
...


One Line Summary
================
vagrant	Total: 2081 (Critical:3 High:507 Medium:1518 Low:46 ?:7)	1078/2081 Fixed	495 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts
```

## redhat 7
### before
```console
$ vuls report --format-one-line-text 2024-12-07T09-41-08+0900
[Dec  7 10:00:29]  INFO [localhost] vuls-v0.27.0-build-20241206_201629_1ab4c79
...


One Line Summary
================
vagrant	Total: 3760 (Critical:29 High:934 Medium:2623 Low:162 ?:12)	957/3760 Fixed	405 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts

Warning for vagrant: [Standard OS support is EOL(End-of-Life). Purchase extended support if available or Upgrading your OS is strongly recommended. Extended support available until 2026-06-30. Check the vendor site.]
```

### after
```console
$ vuls report --format-one-line-text 2024-12-07T09-41-17+0900
[Dec  7 10:00:44]  INFO [localhost] vuls-v0.27.0-build-20241207_091638_97dc992
...


One Line Summary
================
vagrant	Total: 3760 (Critical:29 High:934 Medium:2623 Low:162 ?:12)	957/3760 Fixed	405 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts

Warning for vagrant: [Standard OS support is EOL(End-of-Life). Purchase extended support if available or Upgrading your OS is strongly recommended. Extended support available until 2026-06-30. Check the vendor site.]
```

## redhat 8
### before
```console
$ vuls report --format-one-line-text 2024-12-07T09-44-39+0900
[Dec  7 10:01:45]  INFO [localhost] vuls-v0.27.0-build-20241206_201629_1ab4c79
...

One Line Summary
================
vagrant	Total: 1345 (Critical:2 High:516 Medium:797 Low:29 ?:1)	654/1345 Fixed	509 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts
```

### after
```console
$ vuls report --format-one-line-text 2024-12-07T09-44-45+0900
[Dec  7 10:01:58]  INFO [localhost] vuls-v0.27.0-build-20241207_091638_97dc992
...

One Line Summary
================
vagrant	Total: 1345 (Critical:2 High:516 Medium:797 Low:29 ?:1)	654/1345 Fixed	509 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts
```

## redhat 9
### before
```console
$ vuls report --format-one-line-text 2024-12-07T09-49-34+0900
[Dec  7 10:02:42]  INFO [localhost] vuls-v0.27.0-build-20241206_201629_1ab4c79
...

One Line Summary
================
vagrant	Total: 2224 (Critical:3 High:592 Medium:1590 Low:32 ?:7)	1237/2224 Fixed	524 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts
```

### after
```console
$ vuls report --format-one-line-text 2024-12-07T09-49-40+0900
[Dec  7 10:03:01]  INFO [localhost] vuls-v0.27.0-build-20241207_091638_97dc992
...

One Line Summary
================
vagrant	Total: 2224 (Critical:3 High:592 Medium:1590 Low:32 ?:7)	1237/2224 Fixed	524 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [x] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://github.com/vulsdoc/vuls/pull/252