### PR TITLE
feat!(scanner/redhatbase): change cmd in scanUpdatablePackages

### DIFF
--- a/scanner/alma.go
+++ b/scanner/alma.go
@@ -44,23 +44,24 @@ func (o *alma) checkDeps() error {
 }
 
 func (o *alma) depsFast() []string {
-	if o.getServerInfo().Mode.IsOffline() {
-		return []string{}
-	}
-
-	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma8, Rocky8
-	return []string{"yum-utils"}
+	return []string{}
 }
 
 func (o *alma) depsFastRoot() []string {
-	if o.getServerInfo().Mode.IsOffline() {
-		return []string{}
+	var deps []string
+
+	if !o.getServerInfo().Mode.IsOffline() {
+		deps = append(deps, "yum-utils")
 	}
 
-	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma8, Rocky8
-	return []string{"yum-utils"}
+	deps = append(deps,
+		"which",
+		"lsof",
+		"procps-ng",
+		"iproute",
+	)
+
+	return deps
 }
 
 func (o *alma) depsDeep() []string {
@@ -78,25 +79,35 @@ func (o *alma) checkIfSudoNoPasswd() error {
 }
 
 func (o *alma) sudoNoPasswdCmdsFast() []cmd {
+	if !o.getServerInfo().Mode.IsOffline() {
+		return []cmd{
+			{"dnf repoquery -h", exitStatusZero},
+		}
+	}
 	return []cmd{}
 }
 
 func (o *alma) sudoNoPasswdCmdsFastRoot() []cmd {
-	if !o.ServerInfo.IsContainer() {
-		return []cmd{
-			{"repoquery -h", exitStatusZero},
-			{"needs-restarting", exitStatusZero},
-			{"which which", exitStatusZero},
-			{"stat /proc/1/exe", exitStatusZero},
-			{"ls -l /proc/1/exe", exitStatusZero},
-			{"cat /proc/1/maps", exitStatusZero},
-			{"lsof -i -P -n", exitStatusZero},
-		}
+	var cs []cmd
+
+	if !o.getServerInfo().Mode.IsOffline() {
+		cs = append(cs,
+			cmd{"dnf repoquery -h", exitStatusZero},
+			cmd{"needs-restarting", exitStatusZero},
+		)
 	}
-	return []cmd{
-		{"repoquery -h", exitStatusZero},
-		{"needs-restarting", exitStatusZero},
+
+	if !o.getServerInfo().IsContainer() {
+		cs = append(cs,
+			cmd{"which which", exitStatusZero},
+			cmd{"stat /proc/1/exe", exitStatusZero},
+			cmd{"ls -l /proc/1/exe", exitStatusZero},
+			cmd{"cat /proc/1/maps", exitStatusZero},
+			cmd{"lsof -i -P -n", exitStatusZero},
+		)
 	}
+
+	return cs
 }
 
 func (o *alma) sudoNoPasswdCmdsDeep() []cmd {

--- a/scanner/centos.go
+++ b/scanner/centos.go
@@ -1,6 +1,8 @@
 package scanner
 
 import (
+	"strings"
+
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
@@ -44,23 +46,43 @@ func (o *centos) checkDeps() error {
 }
 
 func (o *centos) depsFast() []string {
-	if o.getServerInfo().Mode.IsOffline() {
+	if o.getServerInfo().Mode.IsOffline() || strings.HasPrefix(o.getDistro().Release, "stream") {
 		return []string{}
 	}
 
-	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma8, Rocky8
-	return []string{"yum-utils"}
+	if v, _ := o.getDistro().MajorVersion(); v < 8 {
+		return []string{"yum-utils"}
+	}
+
+	return []string{}
 }
 
 func (o *centos) depsFastRoot() []string {
-	if o.getServerInfo().Mode.IsOffline() {
-		return []string{}
+	var deps []string
+
+	if !o.getServerInfo().Mode.IsOffline() {
+		deps = append(deps, "yum-utils")
 	}
 
-	// repoquery
-	// `rpm -qa` shows dnf-utils as yum-utils on RHEL8, CentOS8, Alma8, Rocky8
-	return []string{"yum-utils"}
+	v, _ := o.getDistro().MajorVersion()
+	switch {
+	case v < 7:
+		deps = append(deps,
+			"which",
+			"lsof",
+			"procps",
+			"iproute",
+		)
+	default:
+		deps = append(deps,
+			"which",
+			"lsof",
+			"procps-ng",
+			"iproute",
+		)
+	}
+
+	return deps
 }
 
 func (o *centos) depsDeep() []string {
@@ -78,23 +100,55 @@ func (o *centos) checkIfSudoNoPasswd() error {
 }
 
 func (o *centos) sudoNoPasswdCmdsFast() []cmd {
-	return []cmd{}
+	if o.getServerInfo().Mode.IsOffline() {
+		return []cmd{}
+	}
+
+	if strings.HasPrefix(o.getDistro().Release, "stream") {
+		return []cmd{
+			{"dnf repoquery -h", exitStatusZero},
+		}
+	}
+
+	if v, _ := o.getDistro().MajorVersion(); v < 8 {
+		return []cmd{
+			{"repoquery -h", exitStatusZero},
+		}
+	}
+
+	return []cmd{
+		{"dnf repoquery -h", exitStatusZero},
+	}
 }
 
 func (o *centos) sudoNoPasswdCmdsFastRoot() []cmd {
-	if !o.ServerInfo.IsContainer() {
-		return []cmd{
-			{"needs-restarting", exitStatusZero},
-			{"which which", exitStatusZero},
-			{"stat /proc/1/exe", exitStatusZero},
-			{"ls -l /proc/1/exe", exitStatusZero},
-			{"cat /proc/1/maps", exitStatusZero},
-			{"lsof -i -P -n", exitStatusZero},
+	var cs []cmd
+
+	if !o.getServerInfo().Mode.IsOffline() {
+		if v, _ := o.getDistro().MajorVersion(); v < 8 {
+			cs = append(cs,
+				cmd{"repoquery -h", exitStatusZero},
+				cmd{"needs-restarting", exitStatusZero},
+			)
+		} else {
+			cs = append(cs,
+				cmd{"dnf repoquery -h", exitStatusZero},
+				cmd{"needs-restarting", exitStatusZero},
+			)
 		}
 	}
-	return []cmd{
-		{"needs-restarting", exitStatusZero},
+
+	if !o.getServerInfo().IsContainer() {
+		cs = append(cs,
+			cmd{"which which", exitStatusZero},
+			cmd{"stat /proc/1/exe", exitStatusZero},
+			cmd{"ls -l /proc/1/exe", exitStatusZero},
+			cmd{"cat /proc/1/maps", exitStatusZero},
+			cmd{"lsof -i -P -n", exitStatusZero},
+		)
 	}
+
+	return cs
 }
 
 func (o *centos) sudoNoPasswdCmdsDeep() []cmd {

--- a/scanner/fedora.go
+++ b/scanner/fedora.go
@@ -48,8 +48,14 @@ func (o *fedora) depsFast() []string {
 		return []string{}
 	}
 
-	// repoquery
-	return []string{"dnf-utils"}
+	v, _ := o.getDistro().MajorVersion()
+	if v < 22 {
+		return []string{"yum-utils"}
+	}
+	if v < 26 {
+		return []string{"dnf-utils"}
+	}
+	return []string{}
 }
 
 func (o *fedora) depsFastRoot() []string {
@@ -57,8 +63,17 @@ func (o *fedora) depsFastRoot() []string {
 		return []string{}
 	}
 
-	// repoquery
-	return []string{"dnf-utils"}
+	v, _ := o.getDistro().MajorVersion()
+	if v < 22 {
+		return []string{"yum-utils"}
+	}
+	if v < 26 {
+		return []string{
+			"dnf-plugins-core",
+			"python3-dnf-plugins-core",
+		}
+	}
+	return []string{}
 }
 
 func (o *fedora) depsDeep() []string {
@@ -76,25 +91,54 @@ func (o *fedora) checkIfSudoNoPasswd() error {
 }
 
 func (o *fedora) sudoNoPasswdCmdsFast() []cmd {
-	return []cmd{}
-}
+	if o.getServerInfo().Mode.IsOffline() {
+		return []cmd{}
+	}
 
-func (o *fedora) sudoNoPasswdCmdsFastRoot() []cmd {
-	if !o.ServerInfo.IsContainer() {
+	v, _ := o.getDistro().MajorVersion()
+	if v < 26 {
 		return []cmd{
 			{"repoquery -h", exitStatusZero},
-			{"needs-restarting", exitStatusZero},
-			{"which which", exitStatusZero},
-			{"stat /proc/1/exe", exitStatusZero},
-			{"ls -l /proc/1/exe", exitStatusZero},
-			{"cat /proc/1/maps", exitStatusZero},
-			{"lsof -i -P -n", exitStatusZero},
+		}
+	}
+	if v < 41 {
+		return []cmd{
+			{"dnf repoquery -h", exitStatusZero},
 		}
 	}
 	return []cmd{
-		{"repoquery -h", exitStatusZero},
-		{"needs-restarting", exitStatusZero},
+		{"dnf5 repoquery -h", exitStatusZero},
 	}
+}
+
+func (o *fedora) sudoNoPasswdCmdsFastRoot() []cmd {
+	var cs []cmd
+
+	if !o.getServerInfo().Mode.IsOffline() {
+		v, _ := o.getDistro().MajorVersion()
+		switch {
+		case v < 26:
+			cs = append(cs, cmd{"repoquery -h", exitStatusZero})
+		case v < 41:
+			cs = append(cs, cmd{"dnf repoquery -h", exitStatusZero})
+		default:
+			cs = append(cs, cmd{"dnf5 repoquery -h", exitStatusZero})
+		}
+	}
+
+	cs = append(cs, cmd{"needs-restarting", exitStatusZero})
+
+	if !o.ServerInfo.IsContainer() {
+		cs = append(cs,
+			cmd{"which which", exitStatusZero},
+			cmd{"stat /proc/1/exe", exitStatusZero},
+			cmd{"ls -l /proc/1/exe", exitStatusZero},
+			cmd{"cat /proc/1/maps", exitStatusZero},
+			cmd{"lsof -i -P -n", exitStatusZero},
+		)
+	}
+
+	return cs
 }
 
 func (o *fedora) sudoNoPasswdCmdsDeep() []cmd {

--- a/scanner/oracle.go
+++ b/scanner/oracle.go
@@ -47,12 +47,40 @@ func (o *oracle) depsFast() []string {
 	if o.getServerInfo().Mode.IsOffline() {
 		return []string{}
 	}
-	// repoquery
-	return []string{"yum-utils"}
+
+	if v, _ := o.getDistro().MajorVersion(); v < 8 {
+		return []string{"yum-utils"}
+	}
+
+	return []string{}
 }
 
 func (o *oracle) depsFastRoot() []string {
-	return []string{"yum-utils"}
+	var deps []string
+
+	if !o.getServerInfo().Mode.IsOffline() {
+		deps = append(deps, "yum-utils")
+	}
+
+	v, _ := o.getDistro().MajorVersion()
+	switch {
+	case v < 7:
+		deps = append(deps,
+			"which",
+			"lsof",
+			"procps",
+			"iproute",
+		)
+	default:
+		deps = append(deps,
+			"which",
+			"lsof",
+			"procps-ng",
+			"iproute",
+		)
+	}
+
+	return deps
 }
 
 func (o *oracle) depsDeep() []string {
@@ -70,24 +98,48 @@ func (o *oracle) checkIfSudoNoPasswd() error {
 }
 
 func (o *oracle) sudoNoPasswdCmdsFast() []cmd {
-	return []cmd{}
+	if o.getServerInfo().Mode.IsOffline() {
+		return []cmd{}
+	}
+
+	if v, _ := o.getDistro().MajorVersion(); v < 8 {
+		return []cmd{
+			{"repoquery -h", exitStatusZero},
+		}
+	}
+
+	return []cmd{
+		{"dnf repoquery -h", exitStatusZero},
+	}
 }
 
 func (o *oracle) sudoNoPasswdCmdsFastRoot() []cmd {
-	if !o.ServerInfo.IsContainer() {
-		return []cmd{
-			{"repoquery -h", exitStatusZero},
-			{"needs-restarting", exitStatusZero},
-			{"which which", exitStatusZero},
-			{"stat /proc/1/exe", exitStatusZero},
-			{"ls -l /proc/1/exe", exitStatusZero},
-			{"cat /proc/1/maps", exitStatusZero},
+	var cs []cmd
+
+	if !o.getServerInfo().Mode.IsOffline() {
+		if v, _ := o.getDistro().MajorVersion(); v < 8 {
+			cs = append(cs,
+				cmd{"repoquery -h", exitStatusZero},
+				cmd{"needs-restarting", exitStatusZero},
+			)
+		} else {
+			cs = append(cs,
+				cmd{"dnf repoquery -h", exitStatusZero},
+				cmd{"needs-restarting", exitStatusZero},
+			)
 		}
 	}
-	return []cmd{
-		{"repoquery -h", exitStatusZero},
-		{"needs-restarting", exitStatusZero},
+
+	if !o.ServerInfo.IsContainer() {
+		cs = append(cs,
+			cmd{"which which", exitStatusZero},
+			cmd{"stat /proc/1/exe", exitStatusZero},
+			cmd{"ls -l /proc/1/exe", exitStatusZero},
+			cmd{"cat /proc/1/maps", exitStatusZero},
+		)
 	}
+
+	return cs
 }
 
 func (o *oracle) sudoNoPasswdCmdsDeep() []cmd {


### PR DESCRIPTION
# What did you implement:

In Fedora 41, the package manager is now DNF5, and the existing repoquery command cannot be executed.
dnf and dnf5 have a subcommand called repoquery, and we will change the command to use that subcommand. 
Also, you do not need to install yum-utils or dnf-utils to install the repoquery command.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

```console
$ vuls scan
[Dec 11 21:41:30]  INFO [localhost] vuls-v0.28.0-build-20241211_213827_8ab8366
[Dec 11 21:41:30]  INFO [localhost] Start scanning
[Dec 11 21:41:30]  INFO [localhost] config: /home/vuls/vuls/config.toml
[Dec 11 21:41:30]  INFO [localhost] Validating config...
[Dec 11 21:41:30]  INFO [localhost] Detecting Server/Container OS... 
[Dec 11 21:41:30]  INFO [localhost] Detecting OS of servers... 
[Dec 11 21:41:31]  INFO [localhost] (1/1) Detected: docker: fedora 41
[Dec 11 21:41:31]  INFO [localhost] Detecting OS of containers... 
[Dec 11 21:41:31]  INFO [localhost] Checking Scan Modes... 
[Dec 11 21:41:31]  INFO [localhost] Detecting Platforms... 
[Dec 11 21:41:33]  INFO [localhost] (1/1) docker is running on other
[Dec 11 21:41:33]  INFO [docker] Scanning OS pkg in fast-root mode
[Dec 11 21:41:34]  WARN [docker] Failed to detect a init system: File: /proc/1/exe -> /usr/sbin/sshd
[Dec 11 21:41:35]  WARN [localhost] Some warnings occurred during scanning on docker. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family: fedora Release: 41`]


Scan Summary
================
docker	fedora41	216 installed, 0 updatable

Warning: [Failed to check EOL. Register the issue to https://github.com/future-architect/vuls/issues with the information in `Family: fedora Release: 41`]



To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
- https://github.com/vulsio/vulsctl/pull/84
