### PR TITLE
fix(models/cvecontents): use cve content type Alma, Rocky

### DIFF
--- a/detector/vuls2/vendor.go
+++ b/detector/vuls2/vendor.go
@@ -172,6 +172,10 @@ func advisoryReferenceSource(family string, r referenceTypes.Reference) string {
 	switch family {
 	case constant.RedHat, constant.CentOS:
 		return "RHSA"
+	case constant.Alma:
+		return "ALSA"
+	case constant.Rocky:
+		return "RLSA"
 	default:
 		return r.Source
 	}
@@ -179,7 +183,7 @@ func advisoryReferenceSource(family string, r referenceTypes.Reference) string {
 
 func cveContentSourceLink(ccType models.CveContentType, v vulnerabilityTypes.Vulnerability) string {
 	switch ccType {
-	case models.RedHat:
+	case models.RedHat, models.Alma, models.Rocky:
 		return fmt.Sprintf("https://access.redhat.com/security/cve/%s", v.Content.ID)
 	default:
 		return ""

--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -309,8 +309,12 @@ func NewCveContentType(name string) CveContentType {
 		return Nvd
 	case "jvn":
 		return Jvn
-	case "redhat", "centos", "alma", "rocky":
+	case "redhat", "centos":
 		return RedHat
+	case "alma":
+		return Alma
+	case "rocky":
+		return Rocky
 	case "fedora":
 		return Fedora
 	case "oracle":
@@ -401,8 +405,12 @@ func NewCveContentType(name string) CveContentType {
 // GetCveContentTypes return CveContentTypes
 func GetCveContentTypes(family string) []CveContentType {
 	switch family {
-	case constant.RedHat, constant.CentOS, constant.Alma, constant.Rocky:
+	case constant.RedHat, constant.CentOS:
 		return []CveContentType{RedHat, RedHatAPI}
+	case constant.Alma:
+		return []CveContentType{Alma}
+	case constant.Rocky:
+		return []CveContentType{Rocky}
 	case constant.Fedora:
 		return []CveContentType{Fedora}
 	case constant.Oracle:
@@ -442,6 +450,12 @@ const (
 
 	// RedHatAPI is RedHat
 	RedHatAPI CveContentType = "redhat_api"
+
+	// Alma is Alma
+	Alma CveContentType = "alma"
+
+	// Rocky is Rocky
+	Rocky CveContentType = "rocky"
 
 	// DebianSecurityTracker is Debian Security tracker
 	DebianSecurityTracker CveContentType = "debian_security_tracker"
@@ -578,6 +592,8 @@ var AllCveContetTypes = CveContentTypes{
 	Fortinet,
 	RedHat,
 	RedHatAPI,
+	Alma,
+	Rocky,
 	Debian,
 	DebianSecurityTracker,
 	Ubuntu,

--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -539,7 +539,7 @@ func (v VulnInfo) Cvss2Scores() (values []CveContentCvss) {
 
 // Cvss3Scores returns CVSS V3 Score
 func (v VulnInfo) Cvss3Scores() (values []CveContentCvss) {
-	order := append([]CveContentType{RedHatAPI, RedHat, SUSE, Microsoft, Fortinet, Nvd, Mitre, Jvn}, GetCveContentTypes(string(Trivy))...)
+	order := append([]CveContentType{RedHatAPI, RedHat, Rocky, SUSE, Microsoft, Fortinet, Nvd, Mitre, Jvn}, GetCveContentTypes(string(Trivy))...)
 	for _, ctype := range order {
 		if conts, found := v.CveContents[ctype]; found {
 			for _, cont := range conts {


### PR DESCRIPTION
# What did you implement:

add cve content type Alma, Rocky

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

vuls report ...

```json
        "CVE-2024-43854": {
            "cveID": "CVE-2024-43854",
            "confidences": [
                {
                    "score": 100,
                    "detectionMethod": "OvalMatch"
                }
            ],
            "affectedPackages": [
                {
                    "name": "kernel",
                    "fixedIn": "0:5.14.0-427.42.1.el9_4"
                }
            ],
            "distroAdvisories": [
                {
                    "advisoryID": "ALSA-2024:8617",
                    "severity": "moderate",
                    "issued": "2024-10-30T00:00:00Z",
                    "updated": "2024-11-03T19:17:17Z",
                    "description": "The kernel packages contain the Linux kernel, the core of any Linux operating system.  \n\nSecurity Fix(es):  \n\n  * hw: cpu: intel: Native Branch History Injection (BHI) (CVE-2024-2201)\n  * kernel: tcp: add sanity checks to rx zerocopy (CVE-2024-26640)\n  * kernel: mptcp: fix data re-injection from stale subflow (CVE-2024-26826)\n  * kernel: af_unix: Fix garbage collector racing against connect() (CVE-2024-26923)\n  * kernel: mac802154: fix llsec key resources release in mac802154_llsec_key_del (CVE-2024-26961)\n  * kernel: scsi: core: Fix unremoved procfs host directory regression (CVE-2024-26935)\n  * kernel: tty: Fix out-of-bound vmalloc access in imageblit (CVE-2021-47383)\n  * kernel: net/sched: taprio: extend minimum interval restriction to entire cycle too (CVE-2024-36244)\n  * kernel: xfs: fix log recovery buffer allocation for the legacy h_size fixup (CVE-2024-39472)\n  * kernel: netfilter: nft_inner: validate mandatory meta and payload (CVE-2024-39504)\n  * kernel: USB: class: cdc-wdm: Fix CPU lockup caused by excessive log messages (CVE-2024-40904)\n  * kernel: mptcp: ensure snd_una is properly initialized on connect (CVE-2024-40931)\n  * kernel: ipv6: prevent possible NULL dereference in rt6_probe() (CVE-2024-40960)\n  * kernel: ext4: do not create EA inode under buffer lock (CVE-2024-40972)\n  * kernel: wifi: mt76: mt7921s: fix potential hung tasks during chip recovery (CVE-2024-40977)\n  * kernel: net/sched: act_api: fix possible infinite loop in tcf_idr_check_alloc() (CVE-2024-40995)\n  * kernel: ext4: fix uninitialized ratelimit_state-\u0026gt;lock access in __ext4_fill_super() (CVE-2024-40998)\n  * kernel: netpoll: Fix race condition in netpoll_owner_active (CVE-2024-41005)\n  * kernel: xfs: don\u0026#39;t walk off the end of a directory data block (CVE-2024-41013)\n  * kernel: xfs: add bounds checking to xlog_recover_process_data (CVE-2024-41014)\n  * kernel: block: initialize integrity buffer to zero before writing it to media (CVE-2024-43854)\n  * kernel: netfilter: flowtable: initialise extack before use (CVE-2024-45018)\n\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n"
                }
            ],
            "cveContents": {
                "alma": [
                    {
                        "type": "alma",
                        "cveID": "CVE-2024-43854",
                        "title": "Moderate: kernel security update",
                        "summary": "The kernel packages contain the Linux kernel, the core of any Linux operating system.  \n\nSecurity Fix(es):  \n\n  * hw: cpu: intel: Native Branch History Injection (BHI) (CVE-2024-2201)\n  * kernel: tcp: add sanity checks to rx zerocopy (CVE-2024-26640)\n  * kernel: mptcp: fix data re-injection from stale subflow (CVE-2024-26826)\n  * kernel: af_unix: Fix garbage collector racing against connect() (CVE-2024-26923)\n  * kernel: mac802154: fix llsec key resources release in mac802154_llsec_key_del (CVE-2024-26961)\n  * kernel: scsi: core: Fix unremoved procfs host directory regression (CVE-2024-26935)\n  * kernel: tty: Fix out-of-bound vmalloc access in imageblit (CVE-2021-47383)\n  * kernel: net/sched: taprio: extend minimum interval restriction to entire cycle too (CVE-2024-36244)\n  * kernel: xfs: fix log recovery buffer allocation for the legacy h_size fixup (CVE-2024-39472)\n  * kernel: netfilter: nft_inner: validate mandatory meta and payload (CVE-2024-39504)\n  * kernel: USB: class: cdc-wdm: Fix CPU lockup caused by excessive log messages (CVE-2024-40904)\n  * kernel: mptcp: ensure snd_una is properly initialized on connect (CVE-2024-40931)\n  * kernel: ipv6: prevent possible NULL dereference in rt6_probe() (CVE-2024-40960)\n  * kernel: ext4: do not create EA inode under buffer lock (CVE-2024-40972)\n  * kernel: wifi: mt76: mt7921s: fix potential hung tasks during chip recovery (CVE-2024-40977)\n  * kernel: net/sched: act_api: fix possible infinite loop in tcf_idr_check_alloc() (CVE-2024-40995)\n  * kernel: ext4: fix uninitialized ratelimit_state-\u0026gt;lock access in __ext4_fill_super() (CVE-2024-40998)\n  * kernel: netpoll: Fix race condition in netpoll_owner_active (CVE-2024-41005)\n  * kernel: xfs: don\u0026#39;t walk off the end of a directory data block (CVE-2024-41013)\n  * kernel: xfs: add bounds checking to xlog_recover_process_data (CVE-2024-41014)\n  * kernel: block: initialize integrity buffer to zero before writing it to media (CVE-2024-43854)\n  * kernel: netfilter: flowtable: initialise extack before use (CVE-2024-45018)\n\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n",
                        "cvss2Score": 0,
                        "cvss2Vector": "",
                        "cvss2Severity": "",
                        "cvss3Score": 0,
                        "cvss3Vector": "",
                        "cvss3Severity": "moderate",
                        "cvss40Score": 0,
                        "cvss40Vector": "",
                        "cvss40Severity": "",
                        "sourceLink": "https://access.redhat.com/security/cve/CVE-2024-43854",
                        "references": [
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2021-47383",
                                "source": "CVE",
                                "refID": "CVE-2021-47383"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-2201",
                                "source": "CVE",
                                "refID": "CVE-2024-2201"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-26640",
                                "source": "CVE",
                                "refID": "CVE-2024-26640"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-26826",
                                "source": "CVE",
                                "refID": "CVE-2024-26826"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-26923",
                                "source": "CVE",
                                "refID": "CVE-2024-26923"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-26935",
                                "source": "CVE",
                                "refID": "CVE-2024-26935"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-26961",
                                "source": "CVE",
                                "refID": "CVE-2024-26961"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-36244",
                                "source": "CVE",
                                "refID": "CVE-2024-36244"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-39472",
                                "source": "CVE",
                                "refID": "CVE-2024-39472"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-39504",
                                "source": "CVE",
                                "refID": "CVE-2024-39504"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-40904",
                                "source": "CVE",
                                "refID": "CVE-2024-40904"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-40931",
                                "source": "CVE",
                                "refID": "CVE-2024-40931"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-40960",
                                "source": "CVE",
                                "refID": "CVE-2024-40960"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-40972",
                                "source": "CVE",
                                "refID": "CVE-2024-40972"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-40977",
                                "source": "CVE",
                                "refID": "CVE-2024-40977"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-40995",
                                "source": "CVE",
                                "refID": "CVE-2024-40995"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-40998",
                                "source": "CVE",
                                "refID": "CVE-2024-40998"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-41005",
                                "source": "CVE",
                                "refID": "CVE-2024-41005"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-41013",
                                "source": "CVE",
                                "refID": "CVE-2024-41013"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-41014",
                                "source": "CVE",
                                "refID": "CVE-2024-41014"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-43854",
                                "source": "CVE",
                                "refID": "CVE-2024-43854"
                            },
                            {
                                "link": "https://access.redhat.com/security/cve/CVE-2024-45018",
                                "source": "CVE",
                                "refID": "CVE-2024-45018"
                            },
                            {
                                "link": "https://errata.almalinux.org/9/ALSA-2024-8617.html",
                                "source": "ALSA",
                                "refID": "ALSA-2024:8617"
                            }
                        ],
                        "published": "2024-10-30T00:00:00Z",
                        "lastModified": "2024-11-03T19:17:17Z"
                    }
                ]
            },
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

