### PR TITLE
fix(scanner/redhatbase): don't return error when parse failure of source file

### DIFF
--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -582,9 +582,10 @@ func (o *redhatBase) parseInstalledPackagesLine(line string) (*models.Package, *
 			case "(none)":
 				return nil, nil
 			default:
-				n, v, r, err := splitFileName(fields[5])
+				n, v, r, _, _, err := splitFileName(fields[5])
 				if err != nil {
-					return nil, xerrors.Errorf("Failed to parse source rpm file. err: %w", err)
+					o.warns = append(o.warns, xerrors.Errorf("Failed to parse source rpm file. err: %w", err))
+					return nil, nil
 				}
 				return &models.SrcPackage{
 					Name: n,
@@ -637,9 +638,10 @@ func (o *redhatBase) parseInstalledPackagesLineFromRepoquery(line string) (*mode
 			case "(none)":
 				return nil, nil
 			default:
-				n, v, r, err := splitFileName(fields[5])
+				n, v, r, _, _, err := splitFileName(fields[5])
 				if err != nil {
-					return nil, xerrors.Errorf("Failed to parse source rpm file. err: %w", err)
+					o.warns = append(o.warns, xerrors.Errorf("Failed to parse source rpm file. err: %w", err))
+					return nil, nil
 				}
 				return &models.SrcPackage{
 					Name: n,
@@ -686,29 +688,41 @@ func (o *redhatBase) parseInstalledPackagesLineFromRepoquery(line string) (*mode
 	}
 }
 
-// https://github.com/aquasecurity/trivy/blob/51f2123c5ccc4f7a37d1068830b6670b4ccf9ac8/pkg/fanal/analyzer/pkg/rpm/rpm.go#L212-L241
-func splitFileName(filename string) (name, ver, rel string, err error) {
-	filename = strings.TrimSuffix(filename, ".rpm")
+// splitFileName returns a name, version, release, epoch, arch:
+//
+//	e.g.
+//		foo-1.0-1.i386.rpm => foo, 1.0, 1, i386
+//		1:bar-9-123a.ia64.rpm => bar, 9, 123a, 1, ia64
+//
+// https://github.com/rpm-software-management/yum/blob/043e869b08126c1b24e392f809c9f6871344c60d/rpmUtils/miscutils.py#L301
+func splitFileName(filename string) (name, ver, rel, epoch, arch string, err error) {
+	basename := strings.TrimSuffix(filename, ".rpm")
 
-	archIndex := strings.LastIndex(filename, ".")
+	archIndex := strings.LastIndex(basename, ".")
 	if archIndex == -1 {
-		return "", "", "", xerrors.Errorf("unexpected file name. expected: %q, actual: %q", "<name>-<version>-<release>.<arch>.rpm", filename)
+		return "", "", "", "", "", xerrors.Errorf("unexpected file name. expected: %q, actual: %q", "<name>-<version>-<release>.<arch>.rpm", fmt.Sprintf("%s.rpm", filename))
 	}
+	arch = basename[archIndex+1:]
 
-	relIndex := strings.LastIndex(filename[:archIndex], "-")
+	relIndex := strings.LastIndex(basename[:archIndex], "-")
 	if relIndex == -1 {
-		return "", "", "", xerrors.Errorf("unexpected file name. expected: %q, actual: %q", "<name>-<version>-<release>.<arch>.rpm", filename)
+		return "", "", "", "", "", xerrors.Errorf("unexpected file name. expected: %q, actual: %q", "<name>-<version>-<release>.<arch>.rpm", fmt.Sprintf("%s.rpm", filename))
 	}
-	rel = filename[relIndex+1 : archIndex]
+	rel = basename[relIndex+1 : archIndex]
 
-	verIndex := strings.LastIndex(filename[:relIndex], "-")
+	verIndex := strings.LastIndex(basename[:relIndex], "-")
 	if verIndex == -1 {
-		return "", "", "", xerrors.Errorf("unexpected file name. expected: %q, actual: %q", "<name>-<version>-<release>.<arch>.rpm", filename)
+		return "", "", "", "", "", xerrors.Errorf("unexpected file name. expected: %q, actual: %q", "<name>-<version>-<release>.<arch>.rpm", fmt.Sprintf("%s.rpm", filename))
 	}
-	ver = filename[verIndex+1 : relIndex]
+	ver = basename[verIndex+1 : relIndex]
 
-	name = filename[:verIndex]
-	return name, ver, rel, nil
+	epochIndex := strings.Index(basename, ":")
+	if epochIndex != -1 {
+		epoch = basename[:epochIndex]
+	}
+
+	name = basename[epochIndex+1 : verIndex]
+	return name, ver, rel, epoch, arch, nil
 }
 
 func (o *redhatBase) parseRpmQfLine(line string) (pkg *models.Package, ignored bool, err error) {

--- a/scanner/redhatbase_test.go
+++ b/scanner/redhatbase_test.go
@@ -343,6 +343,22 @@ func Test_redhatBase_parseInstalledPackagesLine(t *testing.T) {
 			wantsp: nil,
 		},
 		{
+			name: "epoch in source package",
+			args: args{line: "bar 1 9 123a ia64 1:bar-9-123a.src.rpm"},
+			wantbp: &models.Package{
+				Name:    "bar",
+				Version: "1:9",
+				Release: "123a",
+				Arch:    "ia64",
+			},
+			wantsp: &models.SrcPackage{
+				Name:        "bar",
+				Version:     "1:9-123a",
+				Arch:        "src",
+				BinaryNames: []string{"bar"},
+			},
+		},
+		{
 			name: "new: package 1",
 			args: args{line: "gpg-pubkey 0 f5282ee4 58ac92a3 (none) (none)"},
 			wantbp: &models.Package{
@@ -401,6 +417,17 @@ func Test_redhatBase_parseInstalledPackagesLine(t *testing.T) {
 				Arch:        "src",
 				BinaryNames: []string{"community-mysql"},
 			},
+		},
+		{
+			name: "invalid source package",
+			args: args{line: "elasticsearch 0 8.17.0 1 x86_64 elasticsearch-8.17.0-1-src.rpm (none)"},
+			wantbp: &models.Package{
+				Name:    "elasticsearch",
+				Version: "8.17.0",
+				Release: "1",
+				Arch:    "x86_64",
+			},
+			wantsp: nil,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION

If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Before this PR, some rpms with not-very-good source file name format let vuls scan failed with errors like:

```
[Dec 18 18:11:36] ERROR [localhost] Error on vt-alma8, err: [Failed to scan installed packages:
    github.com/future-architect/vuls/scanner.(*redhatBase).scanPackages
        /home/runner/work/vuls/vuls/scanner/redhatbase.go:421
  - Failed to parse installed packages. err:
    github.com/future-architect/vuls/scanner.(*redhatBase).scanInstalledPackages
        /home/runner/work/vuls/vuls/scanner/redhatbase.go:499
  - Failed to parse sourcepkg. err:
    github.com/future-architect/vuls/scanner.(*redhatBase).parseInstalledPackagesLine
        /home/runner/work/vuls/vuls/scanner/redhatbase.go:605
  - Failed to parse source rpm file. err:
    github.com/future-architect/vuls/scanner.(*redhatBase).parseInstalledPackagesLine.func1
        /home/runner/work/vuls/vuls/scanner/redhatbase.go:587
  - unexpected file name. expected: "<name>-<version>-<release>.<arch>.rpm", actual: "elasticsearch-8.17.0-1-src":
    github.com/future-architect/vuls/scanner.splitFileName
        /home/runner/work/vuls/vuls/scanner/redhatbase.go:706]
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Preparation:
Install elasticsearch with the steps described in https://www.elastic.co/guide/en/elasticsearch/reference/current/rpm.html

Package list output from rpm command is:

```
[root@788d5f4c7bb6 ~]# rpm -qa --queryformat "%{NAME} %{EPOCHNUM} %{VERSION} %{RELEASE} %{ARCH} %{SOURCERPM} %{MODULARITYLABEL}\n" | grep elas
elasticsearch 0 8.17.0 1 x86_64 elasticsearch-8.17.0-1-src.rpm (none)
```

The filename column value is `-src.rpm`, not `.src.rpm`.

Before:
```
% ./bin.lo/vuls.v0.28.0 scan vt-alma8
[Dec 18 18:11:33]  INFO [localhost] vuls-0.28.0-703ba6616050cba7c67365a12e7d98eb06f459ba-2024-12-08T08:37:23Z
[Dec 18 18:11:33]  INFO [localhost] Start scanning
[Dec 18 18:11:33]  INFO [localhost] config: /home/shino/g/vuls/config.toml
[Dec 18 18:11:33]  INFO [localhost] Validating config...
[Dec 18 18:11:33]  INFO [localhost] Detecting Server/Container OS...
[Dec 18 18:11:33]  INFO [localhost] Detecting OS of servers...
[Dec 18 18:11:34]  INFO [localhost] (1/1) Detected: vt-alma8: alma 8.10
[Dec 18 18:11:34]  INFO [localhost] Detecting OS of containers...
[Dec 18 18:11:34]  INFO [localhost] Checking Scan Modes...
[Dec 18 18:11:34]  INFO [localhost] Detecting Platforms...
[Dec 18 18:11:36]  INFO [localhost] (1/1) vt-alma8 is running on other
[Dec 18 18:11:36]  INFO [vt-alma8] Scanning OS pkg in fast-root mode
[Dec 18 18:11:36] ERROR [localhost] Error on vt-alma8, err: [Failed to scan installed packages:
    github.com/future-architect/vuls/scanner.(*redhatBase).scanPackages
        /home/runner/work/vuls/vuls/scanner/redhatbase.go:421
  - Failed to parse installed packages. err:
    github.com/future-architect/vuls/scanner.(*redhatBase).scanInstalledPackages
        /home/runner/work/vuls/vuls/scanner/redhatbase.go:499
  - Failed to parse sourcepkg. err:
    github.com/future-architect/vuls/scanner.(*redhatBase).parseInstalledPackagesLine
        /home/runner/work/vuls/vuls/scanner/redhatbase.go:605
  - Failed to parse source rpm file. err:
    github.com/future-architect/vuls/scanner.(*redhatBase).parseInstalledPackagesLine.func1
        /home/runner/work/vuls/vuls/scanner/redhatbase.go:587
  - unexpected file name. expected: "<name>-<version>-<release>.<arch>.rpm", actual: "elasticsearch-8.17.0-1-src":
    github.com/future-architect/vuls/scanner.splitFileName
        /home/runner/work/vuls/vuls/scanner/redhatbase.go:706]


Scan Summary
================
vt-alma8        Error           Use configtest subcommand or scan with --debug to view the details


[Dec 18 18:11:36] ERROR [localhost] Failed to scan: Failed to scan. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        /home/runner/work/vuls/vuls/scanner/scanner.go:111
  - An error occurred on [vt-alma8]
```

After:

```
% go run cmd/vuls/main.go scan vt-alma8
[Dec 18 18:52:25]  INFO [localhost] vuls-`make build` or `make install` will show the version-
[Dec 18 18:52:25]  INFO [localhost] Start scanning
[Dec 18 18:52:25]  INFO [localhost] config: /home/shino/g/vuls/config.toml
[Dec 18 18:52:25]  INFO [localhost] Validating config...
[Dec 18 18:52:25]  INFO [localhost] Detecting Server/Container OS...
[Dec 18 18:52:25]  INFO [localhost] Detecting OS of servers...
[Dec 18 18:52:25]  INFO [localhost] (1/1) Detected: vt-alma8: alma 8.10
[Dec 18 18:52:25]  INFO [localhost] Detecting OS of containers...
[Dec 18 18:52:25]  INFO [localhost] Checking Scan Modes...
[Dec 18 18:52:25]  INFO [localhost] Detecting Platforms...
[Dec 18 18:52:26]  INFO [localhost] (1/1) vt-alma8 is running on other
[Dec 18 18:52:26]  INFO [vt-alma8] Scanning OS pkg in fast-root mode
[Dec 18 18:52:28]  WARN [vt-alma8] Failed to detect a init system: File: /proc/1/exe -> /usr/sbin/sshd
[Dec 18 18:52:28]  INFO [vt-alma8] Scanning listen port...
[Dec 18 18:52:28]  INFO [vt-alma8] Using Port Scanner: Vuls built-in Scanner
[Dec 18 18:52:28]  WARN [localhost] Some warnings occurred during scanning on vt-alma8. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to parse source rpm file. value: "elasticsearch-8.17.0-1-src.rpm", err:
    github.com/future-architect/vuls/scanner.(*redhatBase).parseInstalledPackagesLine.func1
        /home/shino/g/vuls/scanner/redhatbase.go:587
  - unexpected file name. expected: "<name>-<version>-<release>.<arch>.rpm", actual: "elasticsearch-8.17.0-1-src.rpm":
    github.com/future-architect/vuls/scanner.splitFileName
        /home/shino/g/vuls/scanner/redhatbase.go:708]


Scan Summary
================
vt-alma8        alma8.10        176 installed, 0 updatable

Warning: [Failed to parse source rpm file. value: "elasticsearch-8.17.0-1-src.rpm", err:
    github.com/future-architect/vuls/scanner.(*redhatBase).parseInstalledPackagesLine.func1
        /home/shino/g/vuls/scanner/redhatbase.go:587
  - unexpected file name. expected: "<name>-<version>-<release>.<arch>.rpm", actual: "elasticsearch-8.17.0-1-src.rpm":
    github.com/future-architect/vuls/scanner.splitFileName
        /home/shino/g/vuls/scanner/redhatbase.go:708]



To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

```
% cat results/2024-12-18T18-52-26+0900/vt-alma8.json | jq -Cr '.warnings | .[]'
Failed to parse source rpm file. value: "elasticsearch-8.17.0-1-src.rpm", err:
    github.com/future-architect/vuls/scanner.(*redhatBase).parseInstalledPackagesLine.func1
        /home/shino/g/vuls/scanner/redhatbase.go:587
  - unexpected file name. expected: "<name>-<version>-<release>.<arch>.rpm", actual: "elasticsearch-8.17.0-1-src.rpm":
    github.com/future-architect/vuls/scanner.splitFileName
        /home/shino/g/vuls/scanner/redhatbase.go:708
```


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

