### PR TITLE
fix(scanner/suse): skip table header in zypper -q lu

### DIFF
--- a/scanner/suse_test.go
+++ b/scanner/suse_test.go
@@ -68,6 +68,22 @@ v | Update repository with updates from SUSE Linux Enterprise 15 | git-core | 2.
 				},
 			},
 		},
+		{
+			name: "table header",
+			args: args{
+				stdout: `S  | Repository                                                   | Name     | Current Version | Available Version | Arch
+---+--------------------------------------------------------------+----------+-----------------+-------------------+-------
+v  | Update repository with updates from SUSE Linux Enterprise 15 | iproute2 | 5.14-150400.1.8 | 6.4-150600.7.3.1  | x86_64`,
+			},
+			want: models.Packages{
+				"iproute2": {
+					Name:       "iproute2",
+					NewVersion: "6.4",
+					NewRelease: "150600.7.3.1",
+					Arch:       "x86_64",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

The current method of skipping table headers in the output of `zypper -q lu` does not work when spaces are added. 
So, until we read a line consisting only of `-+`, we assume it is a table header.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```console
a2c6f9dcb28a:~ # zypper -q lu
S  | Repository                                                   | Name     | Current Version | Available Version | Arch
---+--------------------------------------------------------------+----------+-----------------+-------------------+-------
v  | Update repository with updates from SUSE Linux Enterprise 15 | iproute2 | 5.14-150400.1.8 | 6.4-150600.7.3.1  | x86_64
```

## before
```console
$ vuls scan -debug
...
[Dec 18 20:36:05] DEBUG [docker] Executing... zypper -q --no-color lu
[Dec 18 20:36:07] DEBUG [docker] execResult: servername: docker
  cmd: /usr/bin/ssh -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/cm-a3722a6d-%C -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -o PasswordAuthentication=no 127.0.0.1
  exitstatus: 0
  stdout: S  | Repository                                                   | Name     | Current Version | Available Version | Arch
---+--------------------------------------------------------------+----------+-----------------+-------------------+-------
v  | Update repository with updates from SUSE Linux Enterprise 15 | iproute2 | 5.14-150400.1.8 | 6.4-150600.7.3.1  | x86_64

  stderr: stty: 'standard input': Inappropriate ioctl for device

  err: %!s(<nil>)
[Dec 18 20:36:07] DEBUG [localhost] Panic: runtime error: index out of range [1] with length 1 on docker
```

## after
```console
$ vuls scan -debug
...
Scan Summary
================
docker	opensuse.leap15.6	148 installed, 1 updatable
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
