### PR TITLE
fix(models/cvecontents): a little more accurate sort

### DIFF
--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -253,6 +253,10 @@ func (v CveContents) Sort() {
 				cmp.Compare(b.Cvss3Score, a.Cvss3Score),
 				cmp.Compare(b.Cvss2Score, a.Cvss2Score),
 				cmp.Compare(a.SourceLink, b.SourceLink),
+				cmp.Compare(a.Cvss40Vector, b.Cvss40Vector),
+				cmp.Compare(a.Cvss3Vector, b.Cvss3Vector),
+				cmp.Compare(a.Cvss2Vector, b.Cvss2Vector),
+				cmp.Compare(fmt.Sprintf("%#v", a.Optional), fmt.Sprintf("%#v", b.Optional)),
 			)
 		})
 		for cveID, cont := range contents {


### PR DESCRIPTION
# What did you implement:

Add some fields to sort logic.
Before this PR, "make diff" produces supurious diffs even if vuls.old and vuls.new are the same binary, such as:

```
diff -c /home/shino/g/vuls/integration/results/2025-02-04T15-50-09+0900/bundler.json /home/shino/g/vuls/integration/results/2025-02-04T15-50-10+0900/bundler.json
*** /home/shino/g/vuls/integration/results/2025-02-04T15-50-09+0900/bundler.json        Tue Feb  4 15:50:34 2025
--- /home/shino/g/vuls/integration/results/2025-02-04T15-50-10+0900/bundler.json        Tue Feb  4 15:50:34 2025
***************
*** 106600,106606 ****
                          "cvss2Vector": "",
                          "cvss2Severity": "",
                          "cvss3Score": 6.1,
!                         "cvss3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
                          "cvss3Severity": "MEDIUM",
                          "cvss40Score": 0,
                          "cvss40Vector": "",
--- 106600,106606 ----
                          "cvss2Vector": "",
                          "cvss2Severity": "",
                          "cvss3Score": 6.1,
!                         "cvss3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
                          "cvss3Severity": "MEDIUM",
                          "cvss40Score": 0,
                          "cvss40Vector": "",
***************
```

```
*** 108099,108105 ****
                          "published": "2022-12-14T18:15:17.56Z",
                          "lastModified": "2024-02-01T16:52:23.247Z",
                          "optional": {
!                             "source": "security-advisories@github.com"
                          }
                      },
                      {
--- 108099,108105 ----
                          "published": "2022-12-14T18:15:17.56Z",
                          "lastModified": "2024-02-01T16:52:23.247Z",
                          "optional": {
!                             "source": "nvd@nist.gov"
                          }
                      },
                      {
```

With this PR, "make diff" produces no diffs.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

make diff

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

