### PR TITLE
fix(actions): Add security-events write permission to CodeQL results upload

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,7 @@ on:
 
 permissions: 
   contents: read  
+  security-events: write
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
# What did you implement:

fix: https://github.com/future-architect/vuls/actions/runs/14102397791/job/39501261403

for details, see
https://github.com/github/codeql-action?tab=readme-ov-file#workflow-permissions

```
Workflow Permissions
All advanced setup code scanning workflows must have the security-events: write permission. Workflows in private repositories must additionally have the contents: read permission. For more information, see "[Assigning permissions to jobs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)."
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES