### PR TITLE
fix(report): omit empty CWE and rating fields in CycloneDX SBOM

### DIFF
--- a/reporter/sbom/cyclonedx.go
+++ b/reporter/sbom/cyclonedx.go
@@ -391,6 +391,11 @@ func cdxRatings(cveContents models.CveContents) *[]cdx.VulnerabilityRating {
 			}
 		}
 	}
+
+	if len(ratings) == 0 {
+		return nil
+	}
+
 	return &ratings
 }
 
@@ -522,6 +527,11 @@ func cdxCWEs(cveContents models.CveContents) *[]int {
 			}
 		}
 	}
+
+	if len(m) == 0 {
+		return nil
+	}
+
 	cweIDs := slices.Collect(maps.Keys(m))
 	return &cweIDs
 }


### PR DESCRIPTION
# What did you implement:

This pull request updates the CycloneDX SBOM generation logic to omit the `cwes` and `ratings` fields within each `vulnerability` object when they are empty, instead of including them as `null`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
$ vuls report -to-localfile -format-cyclonedx-json
or 
$ vuls report -to-localfile -format-cyclonedx-xml
```

## before

```json
{
  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
  ...
  "vulnerabilities": [
    {
      "id": "CVE-2024-9370",
      "ratings": null,
      "cwes": null,
      ...
    },
    ...
  ]
}
```

## after

```json
{
  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
  ...
  "vulnerabilities": [
    {
      "id": "CVE-2024-9370",
      ...
    },
    ...
  ]
}
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES
