### PR TITLE
fix(cmd/saas): add timeout option

### DIFF
--- a/saas/saas.go
+++ b/saas/saas.go
@@ -88,7 +88,6 @@ func (w Writer) Write(rs ...models.ScanResult) error {
 		return err
 	}
 	defer resp.Body.Close()
-	logging.Log.Infof("StatusCode: %d", resp.StatusCode)
 	if resp.StatusCode != 200 {
 		return xerrors.Errorf("Failed to get Credential. Request JSON : %s,", string(body))
 	}

--- a/saas/saas.go
+++ b/saas/saas.go
@@ -80,7 +80,6 @@ func (w Writer) Write(rs ...models.ScanResult) error {
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	// TODO Don't use global variable
 	client, err := util.GetHTTPClient(w.Proxy)
 	if err != nil {
 		return err

--- a/subcmds/saas.go
+++ b/subcmds/saas.go
@@ -18,6 +18,7 @@ import (
 // SaaSCmd is subcommand for FutureVuls
 type SaaSCmd struct {
 	configPath string
+	timeoutSec int
 }
 
 // Name return subcommand name
@@ -35,6 +36,7 @@ func (*SaaSCmd) Usage() string {
 		[-log-to-file]
 		[-log-dir=/path/to/log]
 		[-http-proxy=http://192.168.0.1:8080]
+	  [-timeout=10]
 		[-debug]
 		[-quiet]
 `
@@ -55,6 +57,10 @@ func (p *SaaSCmd) SetFlags(f *flag.FlagSet) {
 	defaultLogDir := logging.GetDefaultLogDir()
 	f.StringVar(&config.Conf.LogDir, "log-dir", defaultLogDir, "/path/to/log")
 	f.BoolVar(&config.Conf.LogToFile, "log-to-file", false, "Output log to file")
+
+	f.IntVar(&p.timeoutSec, "timeout", 10,
+		"Number of seconds for uploading scan reports to saas",
+	)
 
 	f.StringVar(
 		&config.Conf.HTTPProxy, "http-proxy", "",
@@ -114,7 +120,9 @@ func (p *SaaSCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 		return subcommands.ExitFailure
 	}
 
-	var w reporter.ResultWriter = saas.Writer{}
+	var w reporter.ResultWriter = saas.Writer{
+		TimeoutSec: p.timeoutSec,
+	}
 	if err := w.Write(res...); err != nil {
 		logging.Log.Errorf("Failed to upload. err: %+v", err)
 		return subcommands.ExitFailure

--- a/subcmds/saas.go
+++ b/subcmds/saas.go
@@ -36,7 +36,7 @@ func (*SaaSCmd) Usage() string {
 		[-log-to-file]
 		[-log-dir=/path/to/log]
 		[-http-proxy=http://192.168.0.1:8080]
-	  [-timeout=10]
+		[-timeout=10]
 		[-debug]
 		[-quiet]
 `

--- a/subcmds/saas.go
+++ b/subcmds/saas.go
@@ -120,7 +120,7 @@ func (p *SaaSCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 		return subcommands.ExitFailure
 	}
 
-	var w reporter.ResultWriter = saas.Writer{
+	w := saas.Writer{
 		TimeoutSec: p.timeoutSec,
 	}
 	if err := w.Write(res...); err != nil {

--- a/subcmds/saas.go
+++ b/subcmds/saas.go
@@ -121,6 +121,8 @@ func (p *SaaSCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 	}
 
 	w := saas.Writer{
+		Cnf:        config.Conf.Saas,
+		Proxy:      config.Conf.HTTPProxy,
 		TimeoutSec: p.timeoutSec,
 	}
 	if err := w.Write(res...); err != nil {


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Added timeout option to the vuls-saas command.
```
C:\Program Files\vuls-saas>vuls.exe saas -h
saas:
        saas
                [-config=/path/to/config.toml]
                [-results-dir=/path/to/results]
                [-log-to-file]
                [-log-dir=/path/to/log]
                [-http-proxy=http://192.168.0.1:8080]
                [-timeout=10]
                [-debug]
                [-quiet]
  -config string
        /path/to/toml (default "C:\\Program Files\\vuls-saas\\config.toml")
  -debug
        debug mode
  -http-proxy string
        http://proxy-url:port (default: empty)
  -log-dir string
        /path/to/log (default "C:\\Users\\ome-202304wada\\AppData\\Roaming\\vuls")
  -log-to-file
        Output log to file
  -quiet
        Quiet mode. No output on stdout
  -results-dir string
        /path/to/results (default "C:\\Program Files\\vuls-saas\\results")
  -timeout int
        Number of seconds for uploading scan reports to saas (default 10)
```


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

To reproduce an environment where communication times out, a mock server was set up to delay the response.
```
package main

import (
	"fmt"
	"net/http"
	"time"
)

func main() {
	http.HandleFunc("/upload", func(w http.ResponseWriter, r *http.Request) {
		fmt.Println("Received request, delaying...")

		time.Sleep(10 * time.Second)

		fmt.Println("Done.")
		w.WriteHeader(http.StatusOK)
		w.Write([]byte(`{"status":"ok"}`))
	})

	fmt.Println("Mock server running on :8080")
	http.ListenAndServe(":8080", nil)
}

```
Changed URL in config.toml to that of the mock server.
```
# See README for details: https://vuls.io/docs/en/usage-settings.html

version = "v2"

[saas]
  GroupID = xxxx
  Token = "xxxx"
  URL = "http://localhost:8080/upload"
```

Executed vuls saas command with timeout option
The timeout is set to 5 seconds because the response from the mock server comes back after a 10-second delay.
```
C:\Program Files\vuls-saas>vuls.exe saas -timeout=5
time="Apr 23 16:51:28" level=info msg="vuls--build-20250423_164702_b6f382c"
time="Apr 23 16:51:28" level=info msg="Validating config..."
time="Apr 23 16:51:28" level=info msg="Loaded: C:\\Program Files\\vuls-saas\\results\\2025-04-23T11-57-49+0900"
time="Apr 23 16:51:33" level=error msg="Failed to upload. err: Post \"http://localhost:8080/upload\": context deadline exceeded"
```
Errors are output correctly when the context times out.

The timeout is set to 15 seconds
```
C:\Program Files\vuls-saas>vuls.exe saas -timeout=15
time="Apr 23 18:09:54" level=info msg="vuls--build-20250423_164702_b6f382c"
time="Apr 23 18:09:54" level=info msg="Validating config..."
time="Apr 23 18:09:54" level=info msg="Loaded: C:\\Program Files\\vuls-saas\\results\\2025-04-23T11-57-49+0900"
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x39b0a75]

goroutine 1 [running]:
github.com/future-architect/vuls/saas.Writer.Write({0xc000d09000?}, {0xc000cb2a08, 0x1, 0xc000cb2a08?})
        github.com/future-architect/vuls/saas/saas.go:107 +0x935
github.com/future-architect/vuls/subcmds.(*SaaSCmd).Execute(0xc000009de8, {0xc00008cbe0?, 0xc000b3ddc0?}, 0xc000891110, {0x1?, 0x3c4c320?, 0xc000b3dd01?})
        github.com/future-architect/vuls/subcmds/saas.go:126 +0x97c
github.com/google/subcommands.(*Commander).Execute(0xc0000ee700, {0x5451bf0, 0x77a48e0}, {0x0, 0x0, 0x0})
        github.com/google/subcommands@v1.2.0/subcommands.go:209 +0x37a
github.com/google/subcommands.Execute(...)
        github.com/google/subcommands@v1.2.0/subcommands.go:492
main.main()
        github.com/future-architect/vuls/cmd/scanner/main.go:35 +0x12d4
```

The mock server response is returned before the timeout, and the expected error is output.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

