### PR TITLE
feat!(detector): timeout can be set, default is no timeout

### DIFF
--- a/config/vulnDictConf.go
+++ b/config/vulnDictConf.go
@@ -39,6 +39,12 @@ type VulnDict struct {
 	SQLite3Path string
 
 	DebugSQL bool
+
+	// Timeout for entire request (type: http only)
+	TimeoutSec uint
+
+	// Timeout for each request (type: http only)
+	TimeoutSecPerRequest uint
 }
 
 // GetType returns type

--- a/detector/cti.go
+++ b/detector/cti.go
@@ -192,7 +192,7 @@ func httpGetCTI(url string, req ctiRequest, resChan chan<- ctiResponse, errChan 
 		return nil
 	}
 	notify := func(err error, t time.Duration) {
-		logging.Log.Warnf("Failed to HTTP GET. retrying in %s seconds. err: %+v", t, err)
+		logging.Log.Warnf("Failed to HTTP GET. retrying in %f seconds. err: %+v", t.Seconds(), err)
 	}
 	if err := backoff.RetryNotify(f, backoff.NewExponentialBackOff(), notify); err != nil {
 		errChan <- xerrors.Errorf("HTTP Error %w", err)

--- a/detector/cve_client.go
+++ b/detector/cve_client.go
@@ -128,7 +128,7 @@ func httpGet(key, url string, resChan chan<- response, errChan chan<- error) {
 		return nil
 	}
 	notify := func(err error, t time.Duration) {
-		logging.Log.Warnf("Failed to HTTP GET. retrying in %s seconds. err: %+v", t, err)
+		logging.Log.Warnf("Failed to HTTP GET. retrying in %f seconds. err: %+v", t.Seconds(), err)
 	}
 	err := backoff.RetryNotify(f, backoff.NewExponentialBackOff(), notify)
 	if err != nil {
@@ -198,7 +198,7 @@ func httpPost(url string, query map[string]string) ([]cvemodels.CveDetail, error
 		return nil
 	}
 	notify := func(err error, t time.Duration) {
-		logging.Log.Warnf("Failed to HTTP POST. retrying in %s seconds. err: %+v", t, err)
+		logging.Log.Warnf("Failed to HTTP POST. retrying in %f seconds. err: %+v", t.Seconds(), err)
 	}
 	err := backoff.RetryNotify(f, backoff.NewExponentialBackOff(), notify)
 	if err != nil {

--- a/detector/cve_client.go
+++ b/detector/cve_client.go
@@ -117,7 +117,7 @@ func httpGet(key, url string, resChan chan<- response, errChan chan<- error) {
 	var resp *http.Response
 	f := func() (err error) {
 		req := gorequest.New().Get(url)
-		if config.Conf.OvalDict.TimeoutSecPerRequest > 0 {
+		if config.Conf.CveDict.TimeoutSecPerRequest > 0 {
 			req = req.Timeout(time.Duration(config.Conf.CveDict.TimeoutSecPerRequest) * time.Second)
 		}
 		resp, body, errs = req.End()

--- a/detector/exploitdb.go
+++ b/detector/exploitdb.go
@@ -181,7 +181,10 @@ func getExploitsViaHTTP(cveIDs []string, urlPrefix string) (
 		}
 	}
 
-	timeout := time.After(2 * 60 * time.Second)
+	var timeout <-chan time.Time
+	if config.Conf.Exploit.TimeoutSec > 0 {
+		timeout = time.After(time.Duration(config.Conf.Exploit.TimeoutSec) * time.Second)
+	}
 	var errs []error
 	for i := 0; i < nReq; i++ {
 		select {
@@ -209,8 +212,11 @@ func httpGetExploit(url string, req exploitRequest, resChan chan<- exploitRespon
 	var resp *http.Response
 	count, retryMax := 0, 3
 	f := func() (err error) {
-		//  resp, body, errs = gorequest.New().SetDebug(config.Conf.Debug).Get(url).End()
-		resp, body, errs = gorequest.New().Timeout(10 * time.Second).Get(url).End()
+		req := gorequest.New().Get(url)
+		if config.Conf.Exploit.TimeoutSecPerRequest > 0 {
+			req = req.Timeout(time.Duration(config.Conf.Exploit.TimeoutSecPerRequest) * time.Second)
+		}
+		resp, body, errs = req.End()
 		if 0 < len(errs) || resp == nil || resp.StatusCode != 200 {
 			count++
 			if count == retryMax {

--- a/detector/exploitdb.go
+++ b/detector/exploitdb.go
@@ -227,7 +227,7 @@ func httpGetExploit(url string, req exploitRequest, resChan chan<- exploitRespon
 		return nil
 	}
 	notify := func(err error, t time.Duration) {
-		logging.Log.Warnf("Failed to HTTP GET. retrying in %s seconds. err: %+v", t, err)
+		logging.Log.Warnf("Failed to HTTP GET. retrying in %f seconds. err: %+v", t.Seconds(), err)
 	}
 	err := backoff.RetryNotify(f, backoff.NewExponentialBackOff(), notify)
 	if err != nil {

--- a/detector/kevuln.go
+++ b/detector/kevuln.go
@@ -322,7 +322,7 @@ func httpGetKEVuln(url string, req kevulnRequest, resChan chan<- kevulnResponse,
 		return nil
 	}
 	notify := func(err error, t time.Duration) {
-		logging.Log.Warnf("Failed to HTTP GET. retrying in %s seconds. err: %+v", t, err)
+		logging.Log.Warnf("Failed to HTTP GET. retrying in %f seconds. err: %+v", t.Seconds(), err)
 	}
 	err := backoff.RetryNotify(f, backoff.NewExponentialBackOff(), notify)
 	if err != nil {

--- a/detector/msf.go
+++ b/detector/msf.go
@@ -147,7 +147,10 @@ func getMetasploitsViaHTTP(cveIDs []string, urlPrefix string) (
 		}
 	}
 
-	timeout := time.After(2 * 60 * time.Second)
+	var timeout <-chan time.Time
+	if config.Conf.Metasploit.TimeoutSec > 0 {
+		timeout = time.After(time.Duration(config.Conf.Metasploit.TimeoutSec) * time.Second)
+	}
 	var errs []error
 	for i := 0; i < nReq; i++ {
 		select {
@@ -175,8 +178,11 @@ func httpGetMetasploit(url string, req metasploitRequest, resChan chan<- metaspl
 	var resp *http.Response
 	count, retryMax := 0, 3
 	f := func() (err error) {
-		//  resp, body, errs = gorequest.New().SetDebug(config.Conf.Debug).Get(url).End()
-		resp, body, errs = gorequest.New().Timeout(10 * time.Second).Get(url).End()
+		req := gorequest.New().Get(url)
+		if config.Conf.Metasploit.TimeoutSecPerRequest > 0 {
+			req = req.Timeout(time.Duration(config.Conf.Metasploit.TimeoutSecPerRequest) * time.Second)
+		}
+		resp, body, errs = req.End()
 		if 0 < len(errs) || resp == nil || resp.StatusCode != 200 {
 			count++
 			if count == retryMax {

--- a/detector/msf.go
+++ b/detector/msf.go
@@ -193,7 +193,7 @@ func httpGetMetasploit(url string, req metasploitRequest, resChan chan<- metaspl
 		return nil
 	}
 	notify := func(err error, t time.Duration) {
-		logging.Log.Warnf("Failed to HTTP GET. retrying in %s seconds. err: %+v", t, err)
+		logging.Log.Warnf("Failed to HTTP GET. retrying in %f seconds. err: %+v", t.Seconds(), err)
 	}
 	err := backoff.RetryNotify(f, backoff.NewExponentialBackOff(), notify)
 	if err != nil {

--- a/gost/microsoft.go
+++ b/gost/microsoft.go
@@ -59,7 +59,7 @@ func (ms Microsoft) DetectCVEs(r *models.ScanResult, _ bool) (nCVEs int, err err
 			return nil
 		}
 		notify := func(err error, t time.Duration) {
-			logging.Log.Warnf("Failed to HTTP POST. retrying in %s seconds. err: %+v", t, err)
+			logging.Log.Warnf("Failed to HTTP POST. retrying in %f seconds. err: %+v", t.Seconds(), err)
 		}
 		if err := backoff.RetryNotify(f, backoff.NewExponentialBackOff(), notify); err != nil {
 			return 0, xerrors.Errorf("HTTP Error: %w", err)
@@ -104,7 +104,7 @@ func (ms Microsoft) DetectCVEs(r *models.ScanResult, _ bool) (nCVEs int, err err
 			return nil
 		}
 		notify := func(err error, t time.Duration) {
-			logging.Log.Warnf("Failed to HTTP POST. retrying in %s seconds. err: %+v", t, err)
+			logging.Log.Warnf("Failed to HTTP POST. retrying in %f seconds. err: %+v", t.Seconds(), err)
 		}
 		if err := backoff.RetryNotify(f, backoff.NewExponentialBackOff(), notify); err != nil {
 			return 0, xerrors.Errorf("HTTP Error: %w", err)
@@ -171,7 +171,7 @@ func (ms Microsoft) DetectCVEs(r *models.ScanResult, _ bool) (nCVEs int, err err
 			return nil
 		}
 		notify := func(err error, t time.Duration) {
-			logging.Log.Warnf("Failed to HTTP POST. retrying in %s seconds. err: %+v", t, err)
+			logging.Log.Warnf("Failed to HTTP POST. retrying in %f seconds. err: %+v", t.Seconds(), err)
 		}
 		if err := backoff.RetryNotify(f, backoff.NewExponentialBackOff(), notify); err != nil {
 			return 0, xerrors.Errorf("HTTP Error: %w", err)

--- a/gost/microsoft.go
+++ b/gost/microsoft.go
@@ -18,6 +18,7 @@ import (
 	"github.com/parnurzeal/gorequest"
 	"golang.org/x/xerrors"
 
+	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
 	"github.com/future-architect/vuls/util"
@@ -47,7 +48,11 @@ func (ms Microsoft) DetectCVEs(r *models.ScanResult, _ bool) (nCVEs int, err err
 		var errs []error
 		var resp *http.Response
 		f := func() error {
-			resp, body, errs = gorequest.New().Timeout(10 * time.Second).Post(u).SendStruct(content).Type("json").EndBytes()
+			req := gorequest.New().Post(u).SendStruct(content).Type("json")
+			if config.Conf.Gost.TimeoutSecPerRequest > 0 {
+				req = req.Timeout(time.Duration(config.Conf.Gost.TimeoutSecPerRequest) * time.Second)
+			}
+			resp, body, errs = req.EndBytes()
 			if 0 < len(errs) || resp == nil || resp.StatusCode != 200 {
 				return xerrors.Errorf("HTTP POST error. url: %s, resp: %v, err: %+v", u, resp, errs)
 			}
@@ -88,7 +93,11 @@ func (ms Microsoft) DetectCVEs(r *models.ScanResult, _ bool) (nCVEs int, err err
 		var errs []error
 		var resp *http.Response
 		f := func() error {
-			resp, body, errs = gorequest.New().Timeout(10 * time.Second).Post(u).SendStruct(content).Type("json").EndBytes()
+			req := gorequest.New().Post(u).SendStruct(content).Type("json")
+			if config.Conf.Gost.TimeoutSecPerRequest > 0 {
+				req = req.Timeout(time.Duration(config.Conf.Gost.TimeoutSecPerRequest) * time.Second)
+			}
+			resp, body, errs = req.EndBytes()
 			if 0 < len(errs) || resp == nil || resp.StatusCode != 200 {
 				return xerrors.Errorf("HTTP POST error. url: %s, resp: %v, err: %+v", u, resp, errs)
 			}
@@ -151,7 +160,11 @@ func (ms Microsoft) DetectCVEs(r *models.ScanResult, _ bool) (nCVEs int, err err
 		var errs []error
 		var resp *http.Response
 		f := func() error {
-			resp, body, errs = gorequest.New().Timeout(10 * time.Second).Post(u).SendStruct(content).Type("json").EndBytes()
+			req := gorequest.New().Post(u).SendStruct(content).Type("json")
+			if config.Conf.Gost.TimeoutSecPerRequest > 0 {
+				req = req.Timeout(time.Duration(config.Conf.Gost.TimeoutSecPerRequest) * time.Second)
+			}
+			resp, body, errs = req.EndBytes()
 			if 0 < len(errs) || resp == nil || resp.StatusCode != 200 {
 				return xerrors.Errorf("HTTP POST error. url: %s, resp: %v, err: %+v", u, resp, errs)
 			}

--- a/gost/util.go
+++ b/gost/util.go
@@ -170,7 +170,7 @@ func httpGet(url string, req request, resChan chan<- response, errChan chan<- er
 		return nil
 	}
 	notify := func(err error, t time.Duration) {
-		logging.Log.Warnf("Failed to HTTP GET. retrying in %s seconds. err: %+v", t, err)
+		logging.Log.Warnf("Failed to HTTP GET. retrying in %f seconds. err: %+v", t.Seconds(), err)
 	}
 	err := backoff.RetryNotify(f, backoff.NewExponentialBackOff(), notify)
 	if err != nil {

--- a/oval/oval.go
+++ b/oval/oval.go
@@ -84,7 +84,12 @@ func (b Base) CheckIfOvalFetched(osFamily, release string) (bool, error) {
 		if err != nil {
 			return false, xerrors.Errorf("Failed to join URLPath. err: %w", err)
 		}
-		resp, body, errs := gorequest.New().Timeout(10 * time.Second).Get(url).End()
+
+		req := gorequest.New().Get(url)
+		if config.Conf.OvalDict.TimeoutSecPerRequest > 0 {
+			req = req.Timeout(time.Duration(config.Conf.OvalDict.TimeoutSecPerRequest) * time.Second)
+		}
+		resp, body, errs := req.End()
 		if 0 < len(errs) || resp == nil || resp.StatusCode != 200 {
 			return false, xerrors.Errorf("HTTP GET error, url: %s, resp: %v, err: %+v", url, resp, errs)
 		}
@@ -143,7 +148,11 @@ func (b Base) CheckIfOvalFresh(osFamily, release string) (ok bool, err error) {
 		if err != nil {
 			return false, xerrors.Errorf("Failed to join URLPath. err: %w", err)
 		}
-		resp, body, errs := gorequest.New().Timeout(10 * time.Second).Get(url).End()
+		req := gorequest.New().Get(url)
+		if config.Conf.OvalDict.TimeoutSecPerRequest > 0 {
+			req = req.Timeout(time.Duration(config.Conf.OvalDict.TimeoutSecPerRequest) * time.Second)
+		}
+		resp, body, errs := req.End()
 		if 0 < len(errs) || resp == nil || resp.StatusCode != 200 {
 			return false, xerrors.Errorf("HTTP GET error, url: %s, resp: %v, err: %+v", url, resp, errs)
 		}

--- a/oval/util.go
+++ b/oval/util.go
@@ -277,7 +277,7 @@ func httpGet(url string, req request, resChan chan<- response, errChan chan<- er
 		return nil
 	}
 	notify := func(err error, t time.Duration) {
-		logging.Log.Warnf("Failed to HTTP GET. retrying in %s seconds. err: %+v", t, err)
+		logging.Log.Warnf("Failed to HTTP GET. retrying in %f seconds. err: %+v", t.Seconds(), err)
 	}
 	err := backoff.RetryNotify(f, backoff.NewExponentialBackOff(), notify)
 	if err != nil {

--- a/oval/util.go
+++ b/oval/util.go
@@ -206,7 +206,10 @@ func getDefsByPackNameViaHTTP(r *models.ScanResult, url string) (relatedDefs ova
 		}
 	}
 
-	timeout := time.After(2 * 60 * time.Second)
+	var timeout <-chan time.Time
+	if config.Conf.OvalDict.TimeoutSec > 0 {
+		timeout = time.After(time.Duration(config.Conf.OvalDict.TimeoutSec) * time.Second)
+	}
 	var errs []error
 	for i := 0; i < nReq; i++ {
 		select {
@@ -259,7 +262,11 @@ func httpGet(url string, req request, resChan chan<- response, errChan chan<- er
 	var resp *http.Response
 	count, retryMax := 0, 3
 	f := func() (err error) {
-		resp, body, errs = gorequest.New().Timeout(10 * time.Second).Get(url).End()
+		req := gorequest.New().Get(url)
+		if config.Conf.OvalDict.TimeoutSecPerRequest > 0 {
+			req = req.Timeout(time.Duration(config.Conf.OvalDict.TimeoutSecPerRequest) * time.Second)
+		}
+		resp, body, errs = req.End()
 		if 0 < len(errs) || resp == nil || resp.StatusCode != 200 {
 			count++
 			if count == retryMax {

--- a/subcmds/discover.go
+++ b/subcmds/discover.go
@@ -82,36 +82,57 @@ func printConfigToml(ips []string) (err error) {
 #type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
 #sqlite3Path = "/path/to/cve.sqlite3"
 #url        = ""
+#debugSQL = false
+#timeoutSec = 0
+#timeoutSecPerRequest = 0
 
 [ovalDict]
 #type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
 #sqlite3Path = "/path/to/oval.sqlite3"
 #url        = ""
+#debugSQL = false
+#timeoutSec = 0
+#timeoutSecPerRequest = 0
 
 [gost]
 #type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
 #sqlite3Path = "/path/to/gost.sqlite3"
 #url        = ""
+#debugSQL = false
+#timeoutSec = 0
+#timeoutSecPerRequest = 0
 
 [exploit]
 #type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
 #sqlite3Path = "/path/to/go-exploitdb.sqlite3"
 #url        = ""
+#debugSQL = false
+#timeoutSec = 0
+#timeoutSecPerRequest = 0
 
 [metasploit]
 #type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
 #sqlite3Path = "/path/to/go-msfdb.sqlite3"
 #url        = ""
+#debugSQL = false
+#timeoutSec = 0
+#timeoutSecPerRequest = 0
 
 [kevuln]
 #type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
 #sqlite3Path = "/path/to/go-kev.sqlite3"
 #url        = ""
+#debugSQL = false
+#timeoutSec = 0
+#timeoutSecPerRequest = 0
 
 [cti]
 #type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
 #sqlite3Path = "/path/to/go-cti.sqlite3"
 #url        = ""
+#debugSQL = false
+#timeoutSec = 0
+#timeoutSecPerRequest = 0
 
 [vuls2]
 #Path = "/path/to/vuls.db"


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

It is now possible to set the timeout for the entire request for each DB and for a single request.

Fixes #1695 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
## before
```console
$ vuls report --refresh-cve
[Apr 30 09:42:22]  INFO [localhost] vuls-0.30.0-358cbf59b8480330cebed319dee1bfc4c5704c7e-2025-03-18T06:42:29Z
...
[Apr 30 09:42:22]  INFO [localhost] Skip OVAL and Scan with gost alone.
[Apr 30 09:42:22]  INFO [localhost] localhost: 0 CVEs are detected with OVAL
[Apr 30 09:42:33]  WARN [localhost] Failed to HTTP GET. retrying in 349.858873ms seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/thunderbird/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/thunderbird/fixed-cves": read tcp 127.0.0.1:60838->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:162
[Apr 30 09:42:34]  WARN [localhost] Failed to HTTP GET. retrying in 733.697151ms seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/fixed-cves": read tcp 127.0.0.1:35692->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:162
[Apr 30 09:42:37]  WARN [localhost] Failed to HTTP GET. retrying in 362.707582ms seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/fixed-cves": read tcp 127.0.0.1:57228->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:162
[Apr 30 09:42:53]  WARN [localhost] Failed to HTTP GET. retrying in 523.661391ms seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/unfixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/unfixed-cves": read tcp 127.0.0.1:41338->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:162
[Apr 30 09:42:55]  WARN [localhost] Failed to HTTP GET. retrying in 291.867323ms seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/thunderbird/unfixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/thunderbird/unfixed-cves": read tcp 127.0.0.1:44874->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:162
[Apr 30 09:42:57]  WARN [localhost] Failed to HTTP GET. retrying in 710.885385ms seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/firefox/unfixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/firefox/unfixed-cves": read tcp 127.0.0.1:35386->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:162
[Apr 30 09:43:02]  WARN [localhost] Failed to HTTP GET. retrying in 679.438469ms seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/unfixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/unfixed-cves": read tcp 127.0.0.1:39344->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:162
[Apr 30 09:43:04]  WARN [localhost] Failed to HTTP GET. retrying in 592.415271ms seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/unfixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/unfixed-cves": read tcp 127.0.0.1:40358->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:162
[Apr 30 09:43:07]  INFO [localhost] localhost: 1412 CVEs are detected with gost
...
```

## after
### no timeout
```console
$ cat config.toml
...
[gost]
type = "http"
url = "http://127.0.0.1:1325"
...

$ vuls report --refresh-cve
[Apr 30 10:09:08]  INFO [localhost] vuls-v0.30.0-build-20250430_100859_60d3afc
...
[Apr 30 10:09:08]  INFO [localhost] Skip OVAL and Scan with gost alone.
[Apr 30 10:09:08]  INFO [localhost] localhost: 0 CVEs are detected with OVAL
[Apr 30 10:09:33]  INFO [localhost] localhost: 1412 CVEs are detected with gost
...
```

### TimeoutSec = 3
```console
$ cat config.toml
...
[gost]
type = "http"
url = "http://127.0.0.1:1325"
timeoutSec = 3
...

$ vuls report --refresh-cve
[Apr 30 10:13:53]  INFO [localhost] vuls-v0.30.0-build-20250430_101344_60d3afc
...
[Apr 30 10:13:53]  INFO [localhost] Skip OVAL and Scan with gost alone.
[Apr 30 10:13:53]  INFO [localhost] localhost: 0 CVEs are detected with OVAL
[Apr 30 10:14:03] ERROR [localhost] Failed to detect Pkg CVE:
    github.com/future-architect/vuls/detector.Detect
        github.com/future-architect/vuls/detector/detector.go:54
  - Failed to detect CVE with gost:
    github.com/future-architect/vuls/detector.DetectPkgCves
        github.com/future-architect/vuls/detector/detector.go:341
  - Failed to detect CVEs with gost:
    github.com/future-architect/vuls/detector.detectPkgsCvesWithGost
        github.com/future-architect/vuls/detector/detector.go:593
  - Failed to detect CVEs. err:
    github.com/future-architect/vuls/gost.Ubuntu.DetectCVEs
        github.com/future-architect/vuls/gost/ubuntu.go:91
  - Failed to get fixed CVEs via HTTP. err:
    github.com/future-architect/vuls/gost.Ubuntu.detectCVEs
        github.com/future-architect/vuls/gost/ubuntu.go:110
  - Timeout Fetching Gost:
    github.com/future-architect/vuls/gost.getCvesWithFixStateViaHTTP
        github.com/future-architect/vuls/gost/util.go:143
...
```

### TimeoutSecPerRequest = 1
```console
$ cat config.toml
...
[gost]
type = "http"
url = "http://127.0.0.1:1325"
timeoutSecPerRequest = 1
...

$ vuls report --refresh-cve
[Apr 30 15:50:45]  INFO [localhost] vuls-v0.30.0-build-20250430_154216_d2347cb
...
[Apr 30 15:50:45]  INFO [localhost] Skip OVAL and Scan with gost alone.
[Apr 30 15:50:45]  INFO [localhost] localhost: 0 CVEs are detected with OVAL
[Apr 30 15:50:46]  WARN [localhost] Failed to HTTP GET. retrying in 0.263985 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/mysql-8.0/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/mysql-8.0/fixed-cves": read tcp 127.0.0.1:39478->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:46]  WARN [localhost] Failed to HTTP GET. retrying in 0.510949 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/qemu/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/qemu/fixed-cves": read tcp 127.0.0.1:39832->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:47]  WARN [localhost] Failed to HTTP GET. retrying in 0.353559 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/ffmpeg/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/ffmpeg/fixed-cves": read tcp 127.0.0.1:40242->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:47]  WARN [localhost] Failed to HTTP GET. retrying in 0.533346 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/vim/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/vim/fixed-cves": read tcp 127.0.0.1:40646->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:48]  WARN [localhost] Failed to HTTP GET. retrying in 0.501117 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/mysql-8.0/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/mysql-8.0/fixed-cves": read tcp 127.0.0.1:36746->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:48]  WARN [localhost] Failed to HTTP GET. retrying in 0.687424 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/ghostscript/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/ghostscript/fixed-cves": read tcp 127.0.0.1:36820->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:48]  WARN [localhost] Failed to HTTP GET. retrying in 0.350745 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/imagemagick/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/imagemagick/fixed-cves": read tcp 127.0.0.1:37056->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:48]  WARN [localhost] Failed to HTTP GET. retrying in 0.586388 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/ffmpeg/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/ffmpeg/fixed-cves": read tcp 127.0.0.1:37110->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:48]  WARN [localhost] Failed to HTTP GET. retrying in 0.468247 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/qemu/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/qemu/fixed-cves": read tcp 127.0.0.1:37126->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:48]  WARN [localhost] Failed to HTTP GET. retrying in 0.634093 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/vim/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/vim/fixed-cves": read tcp 127.0.0.1:37330->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:49]  WARN [localhost] Failed to HTTP GET. retrying in 0.706379 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/thunderbird/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/thunderbird/fixed-cves": read tcp 127.0.0.1:38156->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:49]  WARN [localhost] Failed to HTTP GET. retrying in 0.535043 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/imagemagick/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/imagemagick/fixed-cves": read tcp 127.0.0.1:38194->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:49]  WARN [localhost] Failed to HTTP GET. retrying in 1.029654 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/ghostscript/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/ghostscript/fixed-cves": read tcp 127.0.0.1:38252->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:50]  WARN [localhost] Failed to HTTP GET. retrying in 0.373260 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/webkit2gtk/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/webkit2gtk/fixed-cves": read tcp 127.0.0.1:39446->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:50]  WARN [localhost] Failed to HTTP GET. retrying in 0.652793 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/binutils/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/binutils/fixed-cves": read tcp 127.0.0.1:39452->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:50]  WARN [localhost] Failed to HTTP GET. retrying in 0.677239 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/openssl/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/openssl/fixed-cves": read tcp 127.0.0.1:39488->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:51]  WARN [localhost] Failed to HTTP GET. retrying in 0.714202 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/wireshark/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/wireshark/fixed-cves": read tcp 127.0.0.1:39558->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:51]  WARN [localhost] Failed to HTTP GET. retrying in 0.767817 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/thunderbird/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/thunderbird/fixed-cves": read tcp 127.0.0.1:39570->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:51]  WARN [localhost] Failed to HTTP GET. retrying in 0.361295 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/firefox/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/firefox/fixed-cves": read tcp 127.0.0.1:40248->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:52]  WARN [localhost] Failed to HTTP GET. retrying in 0.965213 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/webkit2gtk/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/webkit2gtk/fixed-cves": read tcp 127.0.0.1:40494->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:52]  WARN [localhost] Failed to HTTP GET. retrying in 0.746926 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/binutils/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/binutils/fixed-cves": read tcp 127.0.0.1:40710->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:52]  WARN [localhost] Failed to HTTP GET. retrying in 0.711244 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/exiv2/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/exiv2/fixed-cves": read tcp 127.0.0.1:40734->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:52]  WARN [localhost] Failed to HTTP GET. retrying in 0.924650 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/openssl/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/openssl/fixed-cves": read tcp 127.0.0.1:40746->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:52]  WARN [localhost] Failed to HTTP GET. retrying in 0.446524 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/wireshark/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/wireshark/fixed-cves": read tcp 127.0.0.1:40796->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:53]  WARN [localhost] Failed to HTTP GET. retrying in 0.483182 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/firefox/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/firefox/fixed-cves": read tcp 127.0.0.1:40856->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:54]  WARN [localhost] Failed to HTTP GET. retrying in 0.819730 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/exiv2/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/exiv2/fixed-cves": read tcp 127.0.0.1:41430->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:55]  WARN [localhost] Failed to HTTP GET. retrying in 0.494745 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/tiff/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/tiff/fixed-cves": read tcp 127.0.0.1:42114->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:55]  WARN [localhost] Failed to HTTP GET. retrying in 0.684500 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/mozjs91/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/mozjs91/fixed-cves": read tcp 127.0.0.1:42406->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:56]  WARN [localhost] Failed to HTTP GET. retrying in 0.532269 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/bind9/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/bind9/fixed-cves": read tcp 127.0.0.1:43478->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:56]  WARN [localhost] Failed to HTTP GET. retrying in 1.038578 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/tiff/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/tiff/fixed-cves": read tcp 127.0.0.1:43672->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:56]  WARN [localhost] Failed to HTTP GET. retrying in 0.395437 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/fixed-cves": read tcp 127.0.0.1:43960->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:57]  WARN [localhost] Failed to HTTP GET. retrying in 1.116910 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/mozjs91/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/mozjs91/fixed-cves": read tcp 127.0.0.1:44152->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:57]  WARN [localhost] Failed to HTTP GET. retrying in 0.366740 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/glibc/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/glibc/fixed-cves": read tcp 127.0.0.1:44156->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:57]  WARN [localhost] Failed to HTTP GET. retrying in 0.317072 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/xorg-server/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/xorg-server/fixed-cves": read tcp 127.0.0.1:44474->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:57]  WARN [localhost] Failed to HTTP GET. retrying in 0.323855 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/fixed-cves": read tcp 127.0.0.1:44554->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:57]  WARN [localhost] Failed to HTTP GET. retrying in 0.342929 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/krb5/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/krb5/fixed-cves": read tcp 127.0.0.1:44624->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:58]  WARN [localhost] Failed to HTTP GET. retrying in 0.687875 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/bind9/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/bind9/fixed-cves": read tcp 127.0.0.1:37230->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:58]  WARN [localhost] Failed to HTTP GET. retrying in 1.057722 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/fixed-cves": read tcp 127.0.0.1:37234->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:58]  WARN [localhost] Failed to HTTP GET. retrying in 0.583585 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/glibc/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/glibc/fixed-cves": read tcp 127.0.0.1:37272->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:58]  WARN [localhost] Failed to HTTP GET. retrying in 0.833720 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/xorg-server/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/xorg-server/fixed-cves": read tcp 127.0.0.1:37408->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:58]  WARN [localhost] Failed to HTTP GET. retrying in 0.550009 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/linux-hwe-6.8/fixed-cves": read tcp 127.0.0.1:37416->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:59]  WARN [localhost] Failed to HTTP GET. retrying in 0.593574 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/tcpdump/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/tcpdump/fixed-cves": read tcp 127.0.0.1:37808->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:50:59]  WARN [localhost] Failed to HTTP GET. retrying in 0.646464 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/radare2/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/radare2/fixed-cves": read tcp 127.0.0.1:37872->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:51:00]  WARN [localhost] Failed to HTTP GET. retrying in 1.009003 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/tcpdump/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/tcpdump/fixed-cves": read tcp 127.0.0.1:38702->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:51:01]  WARN [localhost] Failed to HTTP GET. retrying in 0.400232 seconds. err: HTTP GET error, url: http://127.0.0.1:1325/ubuntu/2204/pkgs/poppler/fixed-cves, resp: <nil>, err: [Get "http://127.0.0.1:1325/ubuntu/2204/pkgs/poppler/fixed-cves": read tcp 127.0.0.1:38770->127.0.0.1:1325: i/o timeout]:
    github.com/future-architect/vuls/gost.httpGet.func1
        github.com/future-architect/vuls/gost/util.go:168
[Apr 30 15:51:02] ERROR [localhost] Failed to detect Pkg CVE:
    github.com/future-architect/vuls/detector.Detect
        github.com/future-architect/vuls/detector/detector.go:54
  - Failed to detect CVE with gost:
    github.com/future-architect/vuls/detector.DetectPkgCves
        github.com/future-architect/vuls/detector/detector.go:341
  - Failed to detect CVEs with gost:
    github.com/future-architect/vuls/detector.detectPkgsCvesWithGost
        github.com/future-architect/vuls/detector/detector.go:593
  - Failed to detect CVEs. err:
    github.com/future-architect/vuls/gost.Ubuntu.DetectCVEs
        github.com/future-architect/vuls/gost/ubuntu.go:91
  - Failed to get fixed CVEs via HTTP. err:
    github.com/future-architect/vuls/gost.Ubuntu.detectCVEs
        github.com/future-architect/vuls/gost/ubuntu.go:110
  - Failed to fetch Gost. err: %!w([]error=[0xc002933bc0 0xc0021acde0 0xc0017f94d0 0xc001bba3f0 0xc00139c810 0xc0014b2de0 0xc0015caa20 0xc0018ca990 0xc0018cb380 0xc0018cb890 0xc001919ce0 0xc001aa3a70 0xc002554f30 0xc002c03f20 0xc0017f8570 0xc0015ca300 0xc001aa2d50 0xc00241cf30 0xc0022ce2a0]):
    github.com/future-architect/vuls/gost.getCvesWithFixStateViaHTTP
        github.com/future-architect/vuls/gost/util.go:147
```

### TimeoutSec = 120, TimeoutSecPerRequest = 30
```console
$ cat config.toml
...
[gost]
type = "http"
url = "http://127.0.0.1:1325"
timeoutSec = 120
timeoutSecPerRequest = 30
...

$ vuls report --refresh-cve
[Apr 30 10:19:49]  INFO [localhost] vuls-v0.30.0-build-20250430_101344_60d3afc
...
[Apr 30 10:19:49]  INFO [localhost] Skip OVAL and Scan with gost alone.
[Apr 30 10:19:49]  INFO [localhost] localhost: 0 CVEs are detected with OVAL
[Apr 30 10:20:20]  INFO [localhost] localhost: 1412 CVEs are detected with gost
...
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference
