### PR TITLE
chore(deps): bump github.com/MaineK00n/vuls2

### DIFF
--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -3,6 +3,7 @@ package vuls2
 import (
 	"maps"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -149,7 +150,7 @@ func detect(dbc db.DB, sr scanTypes.ScanResult) (detectTypes.DetectResult, error
 	detected := make(map[dataTypes.RootID]detectTypes.VulnerabilityData)
 
 	if len(sr.OSPackages) > 0 {
-		m, err := ospkg.Detect(dbc, sr)
+		m, err := ospkg.Detect(dbc, sr, runtime.NumCPU())
 		if err != nil {
 			return detectTypes.DetectResult{}, xerrors.Errorf("Failed to detect os packages. err: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/CycloneDX/cyclonedx-go v0.9.2
 	github.com/MaineK00n/vuls-data-update v0.0.0-20241224035812-2450d4a4763f
-	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20250418035303-727e0a682b7a
+	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20250508062930-5ba469b2c6ca
 	github.com/Ullaakut/nmap/v2 v2.2.2
 	github.com/aquasecurity/trivy v0.61.0
 	github.com/aquasecurity/trivy-db v0.0.0-20250311120810-59fdabb63644
@@ -289,7 +289,7 @@ require (
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
-	github.com/redis/rueidis v1.0.56 // indirect
+	github.com/redis/rueidis v1.0.59 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rubenv/sql-migrate v1.7.1 // indirect
@@ -358,7 +358,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/mysql v1.5.7 // indirect
 	gorm.io/driver/postgres v1.5.11 // indirect
-	gorm.io/gorm v1.25.12 // indirect
+	gorm.io/gorm v1.26.0 // indirect
 	gotest.tools/v3 v3.5.0 // indirect
 	helm.sh/helm/v3 v3.17.3 // indirect
 	k8s.io/api v0.32.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -682,8 +682,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/MaineK00n/vuls-data-update v0.0.0-20241224035812-2450d4a4763f h1:mGsE8hE7Yb1db2XhLQIL9ueYAqwhkTJkChcS1mUZOMU=
 github.com/MaineK00n/vuls-data-update v0.0.0-20241224035812-2450d4a4763f/go.mod h1:X15skWJjHS02lyFsbyU0gXlfrLyOMBrhj7X7cJ876h8=
-github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20250418035303-727e0a682b7a h1:eUcm08LzE5NT16Qxyh3iak+oaw8ClJYKEKAh0O78rVw=
-github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20250418035303-727e0a682b7a/go.mod h1:nol+/GQ7O5ECHaohnNoW1qPSiKGHxiWmgl2PH8kPAR8=
+github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20250508062930-5ba469b2c6ca h1:RH99T4ulOVwmUGDmJH+8M+SZPltRwHKQCbikP6dUSoY=
+github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20250508062930-5ba469b2c6ca/go.mod h1:SsK0pcQmkag1EsUilD+dOOF7zK7Xux3T8rE4re3mcx4=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
@@ -1581,8 +1581,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5X
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
 github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
-github.com/redis/rueidis v1.0.56 h1:DwPjFIgas1OMU/uCqBELOonu9TKMYt3MFPq6GtwEWNY=
-github.com/redis/rueidis v1.0.56/go.mod h1:g660/008FMYmAF46HG4lmcpcgFNj+jCjCAZUUM+wEbs=
+github.com/redis/rueidis v1.0.59 h1:r4SpgqrKnKwO2omN+BB5+24OCu+K15zmf/2b/zP7NKw=
+github.com/redis/rueidis v1.0.59/go.mod h1:Lkhr2QTgcoYBhxARU7kJRO8SyVlgUuEkcJO1Y8MCluA=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
@@ -2546,8 +2546,8 @@ gorm.io/driver/mysql v1.5.7/go.mod h1:sEtPWMiqiN1N1cMXoXmBbd8C6/l+TESwriotuRRpkD
 gorm.io/driver/postgres v1.5.11 h1:ubBVAfbKEUld/twyKZ0IYn9rSQh448EdelLYk9Mv314=
 gorm.io/driver/postgres v1.5.11/go.mod h1:DX3GReXH+3FPWGrrgffdvCk3DQ1dwDPdmbenSkweRGI=
 gorm.io/gorm v1.25.7/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
-gorm.io/gorm v1.25.12 h1:I0u8i2hWQItBq1WfE0o2+WuL9+8L21K9e2HHSTE/0f8=
-gorm.io/gorm v1.25.12/go.mod h1:xh7N7RHfYlNc5EmcI/El95gXusucDrQnHXe0+CgWcLQ=
+gorm.io/gorm v1.26.0 h1:9lqQVPG5aNNS6AyHdRiwScAVnXHg/L/Srzx55G5fOgs=
+gorm.io/gorm v1.26.0/go.mod h1:8Z33v652h4//uMA76KjeDH8mJXPm1QNCYrMeatR0DOE=
 gotest.tools/v3 v3.5.0 h1:Ljk6PdHdOhAb5aDMWXjDLMMhph+BpztA4v1QdqEW2eY=
 gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 helm.sh/helm/v3 v3.17.3 h1:3n5rW3D0ArjFl0p4/oWO8IbY/HKaNNwJtOQFdH2AZHg=


### PR DESCRIPTION
# What did you implement:

Fixes #2196 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## setup
```console
$ rm vuls.db
$ cat config.toml
...
[vuls2]
Repository = "ghcr.io/vulsio/vuls-nightly-db@sha256:788456a519e7f205eb0395410f296535927c8510948937badd190bff3c2156d7"
...

$ curl -sL --create-dirs --output results/2025-05-03T09-00-00+0900/redhat.json https://github.com/user-attachments/files/20011464/redhat.json
```

## v0.30.0
```console
$ /usr/bin/time -v ./vuls report --refresh-cve 2025-05-03T09-00-00+0900 > /dev/null
[May  3 08:57:51]  INFO [localhost] vuls-0.30.0-358cbf59b8480330cebed319dee1bfc4c5704c7e-2025-03-18T06:42:29Z
...
[May  3 08:57:51]  INFO [localhost] Loaded: /home/vuls/results/2025-05-03T09-00-00+0900
[May  3 08:57:59]  INFO [localhost] : 1155 CVEs are detected with vuls2
[May  3 08:57:59]  INFO [localhost] : 0 unfixed CVEs are detected with gost
[May  3 08:57:59]  INFO [localhost] : 0 CVEs are detected with CPE
[May  3 08:57:59]  INFO [localhost] : 0 PoC are detected
[May  3 08:57:59]  INFO [localhost] : 0 exploits are detected
[May  3 08:57:59]  INFO [localhost] : Known Exploited Vulnerabilities are detected for 0 CVEs
[May  3 08:57:59]  INFO [localhost] : Cyber Threat Intelligences are detected for 0 CVEs
[May  3 08:57:59]  INFO [localhost] : total 1155 CVEs detected
[May  3 08:57:59]  INFO [localhost] : 0 CVEs filtered by --confidence-over=80
	Command being timed: "./vuls report --refresh-cve 2025-05-03T09-00-00+0900"
	User time (seconds): 10.01
	System time (seconds): 0.76
	Percent of CPU this job got: 123%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:08.70
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 1963840
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 2
	Minor (reclaiming a frame) page faults: 571691
	Voluntary context switches: 7087
	Involuntary context switches: 500
	Swaps: 0
	File system inputs: 336
	File system outputs: 13408
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

## HEAD(c5be2653b31daea0dc5fd82ee1dacfd7441595f4)
```console
$ /usr/bin/time -v ./vuls report --refresh-cve 2025-05-03T09-00-00+0900 > /dev/null
[May  3 08:59:46]  INFO [localhost] vuls-v0.30.0-build-20250503_085925_c5be265
...
[May  3 08:59:46]  INFO [localhost] Loaded: /home/vuls/results/2025-05-03T09-00-00+0900
[May  3 08:59:55]  INFO [localhost] : 1155 CVEs are detected with vuls2
[May  3 08:59:55]  INFO [localhost] : 0 unfixed CVEs are detected with gost
[May  3 08:59:55]  INFO [localhost] : 0 CVEs are detected with CPE
[May  3 08:59:56]  INFO [localhost] : 0 PoC are detected
[May  3 08:59:56]  INFO [localhost] : 0 exploits are detected
[May  3 08:59:56]  INFO [localhost] : Known Exploited Vulnerabilities are detected for 0 CVEs
[May  3 08:59:56]  INFO [localhost] : Cyber Threat Intelligences are detected for 0 CVEs
[May  3 08:59:56]  INFO [localhost] : total 1155 CVEs detected
[May  3 08:59:56]  INFO [localhost] : 0 CVEs filtered by --confidence-over=80
	Command being timed: "./vuls report --refresh-cve 2025-05-03T09-00-00+0900"
	User time (seconds): 12.14
	System time (seconds): 0.49
	Percent of CPU this job got: 123%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:10.24
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 341700
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 181759
	Voluntary context switches: 12178
	Involuntary context switches: 1421
	Swaps: 0
	File system inputs: 0
	File system outputs: 13328
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

## PR
```console
$ /usr/bin/time -v ./vuls report --refresh-cve 2025-05-03T09-00-00+0900 > /dev/null
[May  8 15:35:43]  INFO [localhost] vuls-v0.30.0-build-20250508_153408_dd614b8
...
[May  8 15:35:43]  INFO [localhost] Loaded: /home/vuls/results/2025-05-03T09-00-00+0900
[May  8 15:35:43]  INFO [localhost] : 1155 CVEs are detected with vuls2
[May  8 15:35:43]  INFO [localhost] : 0 unfixed CVEs are detected with gost
[May  8 15:35:43]  INFO [localhost] : 0 CVEs are detected with CPE
[May  8 15:35:44]  INFO [localhost] : 0 PoC are detected
[May  8 15:35:44]  INFO [localhost] : 0 exploits are detected
[May  8 15:35:44]  INFO [localhost] : Known Exploited Vulnerabilities are detected for 0 CVEs
[May  8 15:35:44]  INFO [localhost] : Cyber Threat Intelligences are detected for 0 CVEs
[May  8 15:35:44]  INFO [localhost] : total 1155 CVEs detected
[May  8 15:35:44]  INFO [localhost] : 0 CVEs filtered by --confidence-over=80
	Command being timed: "./vuls report --refresh-cve 2025-05-03T09-00-00+0900"
	User time (seconds): 2.44
	System time (seconds): 0.19
	Percent of CPU this job got: 187%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:01.40
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 339568
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 56681
	Voluntary context switches: 2313
	Involuntary context switches: 616
	Swaps: 0
	File system inputs: 0
	File system outputs: 13328
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

