### PR TITLE
fix(detector/vuls2): fix cvss v3.1 vector check

### DIFF
--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -603,7 +603,7 @@ func toCvss(v vulnerabilityTypes.Vulnerability) (v2.CVSSv2, v31.CVSSv31, v40.CVS
 				}
 			}
 		case severityTypes.SeverityTypeCVSSv31:
-			if !strings.HasPrefix(s.CVSSv31.Vector, "CVSS:3.1/") && s.CVSSv31 != nil {
+			if !strings.HasPrefix(cvss3.Vector, "CVSS:3.1/") && s.CVSSv31 != nil {
 				cvss3 = *s.CVSSv31
 			}
 		case severityTypes.SeverityTypeCVSSv40:


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

When cvss3.1 was provided, the check was incorrect and it was always not set.
This PR fixes this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## setup
```console
$ curl -s --create-dirs --output results/2025-05-04T13-30-00+0900/rhel_90.json https://raw.githubusercontent.com/vulsio/integration/refs/heads/main/data/results/rhel_90.json
```

## before
```console
$ vuls report --refresh-cve 2025-05-04T13-30-00+0900
$ jq -r '.scannedCves."CVE-2007-4559".cveContents' results/2025-05-04T13-30-00+0900/rhel_90.json
{
  "redhat": [
    {
      "type": "redhat",
      "cveID": "CVE-2007-4559",
      "title": "python: tarfile module directory traversal",
      "summary": "A flaw was found in the Python tarfile module. Extracting a crafted TAR archive with the tarfile.extract or tarfile.extractall functions could lead to a directory traversal vulnerability, resulting in overwrite of arbitrary files.",
      "cvss2Score": 0,
      "cvss2Vector": "",
      "cvss2Severity": "",
      "cvss3Score": 0,
      "cvss3Vector": "",
      "cvss3Severity": "",
      "cvss40Score": 0,
      "cvss40Vector": "",
      "cvss40Severity": "",
      "sourceLink": "https://access.redhat.com/security/cve/CVE-2007-4559",
      "references": [
        {
          "link": "https://access.redhat.com/errata/RHSA-2023:6324",
          "source": "RHSA",
          "refID": "RHSA-2023:6324"
        }
      ],
      "cweIDs": [
        "CWE-22"
      ],
      "published": "2023-11-07T08:43:07Z",
      "lastModified": "2025-01-07T07:24:17Z",
      "optional": {
        "redhat-rootid": "CVE-2007-4559",
        "redhat-sourceid": "redhat-vex"
      }
    }
  ]
}
```

## after
```console
$ vuls report --refresh-cve 2025-05-04T13-30-00+0900
$ jq -r '.scannedCves."CVE-2007-4559".cveContents' results/2025-05-04T13-30-00+0900/rhel_90.json
{
  "redhat": [
    {
      "type": "redhat",
      "cveID": "CVE-2007-4559",
      "title": "python: tarfile module directory traversal",
      "summary": "A flaw was found in the Python tarfile module. Extracting a crafted TAR archive with the tarfile.extract or tarfile.extractall functions could lead to a directory traversal vulnerability, resulting in overwrite of arbitrary files.",
      "cvss2Score": 0,
      "cvss2Vector": "",
      "cvss2Severity": "",
      "cvss3Score": 5.5,
      "cvss3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
      "cvss3Severity": "MEDIUM",
      "cvss40Score": 0,
      "cvss40Vector": "",
      "cvss40Severity": "",
      "sourceLink": "https://access.redhat.com/security/cve/CVE-2007-4559",
      "references": [
        {
          "link": "https://access.redhat.com/errata/RHSA-2023:6324",
          "source": "RHSA",
          "refID": "RHSA-2023:6324"
        }
      ],
      "cweIDs": [
        "CWE-22"
      ],
      "published": "2023-11-07T08:43:07Z",
      "lastModified": "2025-01-07T07:24:17Z",
      "optional": {
        "redhat-rootid": "CVE-2007-4559",
        "redhat-sourceid": "redhat-vex"
      }
    }
  ]
}
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

