### PR TITLE
fix(scanner): scan lockfiles

### DIFF
--- a/scanner/base.go
+++ b/scanner/base.go
@@ -15,6 +15,9 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/semaphore"
+	"golang.org/x/xerrors"
+
 	fanal "github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	tlog "github.com/aquasecurity/trivy/pkg/log"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
@@ -23,9 +26,8 @@ import (
 	"github.com/future-architect/vuls/constant"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
+	ufilepath "github.com/future-architect/vuls/scanner/utils/filepath/unix"
 	"github.com/future-architect/vuls/util"
-	"golang.org/x/sync/semaphore"
-	"golang.org/x/xerrors"
 
 	// Import library scanner
 	_ "github.com/aquasecurity/trivy/pkg/fanal/analyzer/language/c/conan"
@@ -625,7 +627,7 @@ func (l *base) parseSystemctlStatus(stdout string) string {
 var trivyLoggerInit = sync.OnceFunc(func() { tlog.InitLogger(config.Conf.Debug, config.Conf.Quiet) })
 
 func (l *base) scanLibraries() (err error) {
-	if len(l.LibraryScanners) != 0 {
+	if len(l.LibraryScanners) > 0 {
 		return nil
 	}
 
@@ -638,7 +640,6 @@ func (l *base) scanLibraries() (err error) {
 
 	trivyLoggerInit()
 
-	found := map[string]bool{}
 	detectFiles := l.ServerInfo.Lockfiles
 
 	priv := noSudo
@@ -648,87 +649,110 @@ func (l *base) scanLibraries() (err error) {
 
 	// auto detect lockfile
 	if l.ServerInfo.FindLock {
-		findopt := ""
-		for _, filename := range models.FindLockFiles {
-			findopt += fmt.Sprintf("-name %q -o ", filename)
-		}
+		dir := func() string {
+			if len(l.ServerInfo.FindLockDirs) == 0 {
+				l.log.Infof("It's recommended to specify FindLockDirs in config.toml. If FindLockDirs is not specified, all directories under / will be searched, which may increase CPU load")
+				return "/"
+			}
+			return strings.Join(l.ServerInfo.FindLockDirs, " ")
+		}()
 
-		dir := "/"
-		if len(l.ServerInfo.FindLockDirs) != 0 {
-			dir = strings.Join(l.ServerInfo.FindLockDirs, " ")
-		} else {
-			l.log.Infof("It's recommended to specify FindLockDirs in config.toml. If FindLockDirs is not specified, all directories under / will be searched, which may increase CPU load")
-		}
+		findopt := func() string {
+			ss := make([]string, 0, len(models.FindLockFiles))
+			for _, filename := range models.FindLockFiles {
+				ss = append(ss, fmt.Sprintf("-name %q", filename))
+			}
+			return strings.Join(ss, " -o ")
+		}()
+
 		l.log.Infof("Finding files under %s", dir)
 
-		// delete last "-o "
 		// find / -type f -and \( -name "package-lock.json" -o -name "yarn.lock" ... \) 2>&1 | grep -v "find: "
-		cmd := fmt.Sprintf(`find %s -type f -and \( `+findopt[:len(findopt)-3]+` \) 2>&1 | grep -v "find: "`, dir)
-		r := exec(l.ServerInfo, cmd, priv)
+		r := l.exec(fmt.Sprintf(`find %s -type f -and \( %s \) 2>&1 | grep -v "find: "`, dir, findopt), priv)
 		if r.ExitStatus != 0 && r.ExitStatus != 1 {
-			return xerrors.Errorf("Failed to find lock files")
+			return xerrors.Errorf("Failed to find lock files: %s", r)
 		}
-		detectFiles = append(detectFiles, strings.Split(r.Stdout, "\n")...)
+
+		scanner := bufio.NewScanner(strings.NewReader(r.Stdout))
+		for scanner.Scan() {
+			detectFiles = append(detectFiles, scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			return xerrors.Errorf("Failed to reading find results. err: %w", err)
+		}
 	}
 
+	found := make(map[string]bool)
 	for _, path := range detectFiles {
 		if path == "" {
 			continue
 		}
 
-		if path, err = filepath.Abs(path); err != nil {
-			return xerrors.Errorf("Failed to abs the lockfile. err: %w, filepath: %s", err, path)
+		abspath, err := func() (string, error) {
+			if ufilepath.IsAbs(path) {
+				return ufilepath.Clean(path), nil
+			}
+
+			r := l.exec("pwd", noSudo)
+			if !r.isSuccess() {
+				return "", xerrors.Errorf("Failed to get current directory. err: %w", r.Error)
+			}
+
+			return ufilepath.Join(strings.TrimSuffix(r.Stdout, "\n"), path), nil
+		}()
+		if err != nil {
+			return xerrors.Errorf("Failed to abs the lockfile. filepath: %s, err: %w", path, err)
 		}
 
-		// skip already exist
-		if _, ok := found[path]; ok {
+		if _, ok := found[abspath]; ok {
+			continue
+		}
+		found[abspath] = true
+
+		l.log.Debugf("Analyzing file: %s", abspath)
+		filemode, contents, err := func() (os.FileMode, []byte, error) {
+			if isLocalExec(l.getServerInfo().Port, l.getServerInfo().Host) {
+				fileinfo, err := os.Stat(abspath)
+				if err != nil {
+					return os.FileMode(0000), nil, xerrors.Errorf("Failed to get target file info. filepath: %s, err: %w", abspath, err)
+				}
+				filemode := fileinfo.Mode().Perm()
+
+				contents, err := os.ReadFile(abspath)
+				if err != nil {
+					return os.FileMode(0000), nil, xerrors.Errorf("Failed to read target file contents. filepath: %s, err: %w", abspath, err)
+				}
+
+				return filemode, contents, nil
+			}
+
+			r := l.exec(fmt.Sprintf(`stat -c "%%a" %s`, abspath), priv)
+			if !r.isSuccess() {
+				return os.FileMode(0000), nil, xerrors.Errorf("Failed to get target file permission. filepath: %s, err: %w", abspath, err)
+			}
+			permStr := fmt.Sprintf("0%s", strings.TrimSuffix(r.Stdout, "\n"))
+			perm, err := strconv.ParseUint(permStr, 8, 32)
+			if err != nil {
+				return os.FileMode(0000), nil, xerrors.Errorf("Failed to parse permission string. , permission string: %s, err: %s", permStr, err)
+			}
+			filemode := os.FileMode(perm)
+
+			r = l.exec(fmt.Sprintf("cat %s", abspath), priv)
+			if !r.isSuccess() {
+				return os.FileMode(0000), nil, xerrors.Errorf("Failed to read target file contents. filepath: %s, err: %w", abspath, err)
+			}
+			contents := []byte(r.Stdout)
+
+			return filemode, contents, nil
+		}()
+		if err != nil {
+			l.log.Warn(err)
 			continue
 		}
 
-		var contents []byte
-		var filemode os.FileMode
-
-		switch l.Distro.Family {
-		case constant.ServerTypePseudo:
-			fileinfo, err := os.Stat(path)
-			if err != nil {
-				l.log.Warnf("Failed to get target file info. err: %s, filepath: %s", err, path)
-				continue
-			}
-			filemode = fileinfo.Mode().Perm()
-			contents, err = os.ReadFile(path)
-			if err != nil {
-				l.log.Warnf("Failed to read target file contents. err: %s, filepath: %s", err, path)
-				continue
-			}
-		default:
-			l.log.Debugf("Analyzing file: %s", path)
-			cmd := fmt.Sprintf(`stat -c "%%a" %s`, path)
-			r := exec(l.ServerInfo, cmd, priv, logging.NewIODiscardLogger())
-			if !r.isSuccess() {
-				l.log.Warnf("Failed to get target file permission: %s, filepath: %s", r, path)
-				continue
-			}
-			permStr := fmt.Sprintf("0%s", strings.ReplaceAll(r.Stdout, "\n", ""))
-			perm, err := strconv.ParseUint(permStr, 8, 32)
-			if err != nil {
-				l.log.Warnf("Failed to parse permission string. err: %s, permission string: %s", err, permStr)
-				continue
-			}
-			filemode = os.FileMode(perm)
-
-			cmd = fmt.Sprintf("cat %s", path)
-			r = exec(l.ServerInfo, cmd, priv, logging.NewIODiscardLogger())
-			if !r.isSuccess() {
-				l.log.Warnf("Failed to get target file contents: %s, filepath: %s", r, path)
-				continue
-			}
-			contents = []byte(r.Stdout)
-		}
-		found[path] = true
-		var libraryScanners []models.LibraryScanner
-		if libraryScanners, err = AnalyzeLibrary(context.Background(), path, contents, filemode, l.ServerInfo.Mode.IsOffline()); err != nil {
-			return err
+		libraryScanners, err := AnalyzeLibrary(context.Background(), abspath, contents, filemode, l.ServerInfo.Mode.IsOffline())
+		if err != nil {
+			return xerrors.Errorf("Failed to analyze library. err: %w, filepath: %s", err, abspath)
 		}
 		l.LibraryScanners = append(l.LibraryScanners, libraryScanners...)
 	}
@@ -748,7 +772,7 @@ func AnalyzeLibrary(ctx context.Context, path string, contents []byte, filemode 
 	var wg sync.WaitGroup
 	result := new(fanal.AnalysisResult)
 
-	info := &DummyFileInfo{name: filepath.Base(path), size: int64(len(contents)), filemode: filemode}
+	info := &DummyFileInfo{name: ufilepath.Base(path), size: int64(len(contents)), filemode: filemode}
 	opts := fanal.AnalysisOptions{Offline: isOffline}
 	if err := ag.AnalyzeFile(
 		ctx,

--- a/scanner/pseudo.go
+++ b/scanner/pseudo.go
@@ -1,6 +1,14 @@
 package scanner
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/xerrors"
+
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/constant"
 	"github.com/future-architect/vuls/logging"
@@ -65,4 +73,87 @@ func (o *pseudo) parseInstalledPackages(string) (models.Packages, models.SrcPack
 
 func (o *pseudo) detectPlatform() {
 	o.setPlatform(models.Platform{Name: "other"})
+}
+
+func (o *pseudo) scanLibraries() (err error) {
+	if len(o.LibraryScanners) > 0 {
+		return nil
+	}
+
+	// library scan for servers need lockfiles
+	if len(o.getServerInfo().Lockfiles) == 0 && !o.getServerInfo().FindLock {
+		return nil
+	}
+
+	o.log.Info("Scanning Language-specific Packages...")
+
+	trivyLoggerInit()
+
+	detectFiles := o.getServerInfo().Lockfiles
+
+	if o.getServerInfo().FindLock {
+		return xerrors.New("FindLock is not supported in pseudo")
+	}
+
+	found := make(map[string]bool)
+	for _, path := range detectFiles {
+		if path == "" {
+			continue
+		}
+
+		abspath, err := filepath.Abs(path)
+		if err != nil {
+			return xerrors.Errorf("Failed to abs the lockfile. filepath: %s, err: %w", path, err)
+		}
+
+		if _, ok := found[abspath]; ok {
+			continue
+		}
+		found[abspath] = true
+
+		filemode, contents, err := func() (os.FileMode, []byte, error) {
+			fileinfo, err := os.Stat(abspath)
+			if err != nil {
+				return os.FileMode(0000), nil, xerrors.Errorf("Failed to get target file info. filepath: %s, err: %w", abspath, err)
+			}
+			filemode := fileinfo.Mode().Perm()
+
+			contents, err := os.ReadFile(abspath)
+			if err != nil {
+				return os.FileMode(0000), nil, xerrors.Errorf("Failed to read target file contents. filepath: %s, err: %w", abspath, err)
+			}
+
+			return filemode, contents, nil
+		}()
+		if err != nil {
+			o.log.Warn(err)
+			continue
+		}
+
+		trivypath := o.cleanPath(abspath)
+		libraryScanners, err := AnalyzeLibrary(context.Background(), trivypath, contents, filemode, o.getServerInfo().Mode.IsOffline())
+		if err != nil {
+			return xerrors.Errorf("Failed to analyze library. err: %w, filepath: %s", err, trivypath)
+		}
+		for _, libscanner := range libraryScanners {
+			libscanner.LockfilePath = abspath
+			o.LibraryScanners = append(o.LibraryScanners, libscanner)
+		}
+	}
+
+	return nil
+}
+
+// https://github.com/aquasecurity/trivy/blob/35e88890c3c201b3eb11f95376172e57bf44df4b/pkg/mapfs/fs.go#L272-L283
+func (o *pseudo) cleanPath(path string) string {
+	// Convert the volume name like 'C:' into dir like 'C\'
+	if vol := filepath.VolumeName(path); vol != "" {
+		newVol := strings.TrimSuffix(vol, ":")
+		newVol = fmt.Sprintf("%s%c", newVol, filepath.Separator)
+		path = strings.Replace(path, vol, newVol, 1)
+	}
+	path = filepath.Clean(path)
+	path = filepath.ToSlash(path)
+	path = strings.TrimLeft(path, "/") // Remove the leading slash
+	return path
 }

--- a/scanner/utils/filepath/unix/unix.go
+++ b/scanner/utils/filepath/unix/unix.go
@@ -1,0 +1,304 @@
+package unix
+
+import (
+	"strings"
+)
+
+// https://cs.opensource.google/go/go/+/refs/tags/go1.24.3:src/internal/filepathlite/path.go
+// https://cs.opensource.google/go/go/+/refs/tags/go1.24.3:src/internal/filepathlite/path_unix.go
+// https://cs.opensource.google/go/go/+/refs/tags/go1.24.3:src/internal/filepathlite/path_nonwindows.go
+// https://cs.opensource.google/go/go/+/refs/tags/go1.24.3:src/path/filepath/path_unix.go
+
+// Separator is OS-specific path separator
+const Separator = '/'
+
+type lazybuf struct {
+	path       string
+	buf        []byte
+	w          int
+	volAndPath string
+	volLen     int
+}
+
+func (b *lazybuf) index(i int) byte {
+	if b.buf != nil {
+		return b.buf[i]
+	}
+	return b.path[i]
+}
+
+func (b *lazybuf) append(c byte) {
+	if b.buf == nil {
+		if b.w < len(b.path) && b.path[b.w] == c {
+			b.w++
+			return
+		}
+		b.buf = make([]byte, len(b.path))
+		copy(b.buf, b.path[:b.w])
+	}
+	b.buf[b.w] = c
+	b.w++
+}
+
+func (b *lazybuf) string() string {
+	if b.buf == nil {
+		return b.volAndPath[:b.volLen+b.w]
+	}
+	return b.volAndPath[:b.volLen] + string(b.buf[:b.w])
+}
+
+// Clean returns the shortest path name equivalent to path
+// by purely lexical processing. It applies the following rules
+// iteratively until no further processing can be done:
+//
+//  1. Replace multiple [Separator] elements with a single one.
+//  2. Eliminate each . path name element (the current directory).
+//  3. Eliminate each inner .. path name element (the parent directory)
+//     along with the non-.. element that precedes it.
+//  4. Eliminate .. elements that begin a rooted path:
+//     that is, replace "/.." by "/" at the beginning of a path,
+//     assuming Separator is '/'.
+//
+// The returned path ends in a slash only if it represents a root directory,
+// such as "/" on Unix or `C:\` on Windows.
+//
+// Finally, any occurrences of slash are replaced by Separator.
+//
+// If the result of this process is an empty string, Clean
+// returns the string ".".
+//
+// On Windows, Clean does not modify the volume name other than to replace
+// occurrences of "/" with `\`.
+// For example, Clean("//host/share/../x") returns `\\host\share\x`.
+//
+// See also Rob Pike, “Lexical File Names in Plan 9 or
+// Getting Dot-Dot Right,”
+// https://9p.io/sys/doc/lexnames.html
+func Clean(path string) string {
+	originalPath := path
+	volLen := volumeNameLen(path)
+	path = path[volLen:]
+	if path == "" {
+		if volLen > 1 && isPathSeparator(originalPath[0]) && isPathSeparator(originalPath[1]) {
+			// should be UNC
+			return FromSlash(originalPath)
+		}
+		return originalPath + "."
+	}
+	rooted := isPathSeparator(path[0])
+
+	// Invariants:
+	//	reading from path; r is index of next byte to process.
+	//	writing to buf; w is index of next byte to write.
+	//	dotdot is index in buf where .. must stop, either because
+	//		it is the leading slash or it is a leading ../../.. prefix.
+	n := len(path)
+	out := lazybuf{path: path, volAndPath: originalPath, volLen: volLen}
+	r, dotdot := 0, 0
+	if rooted {
+		out.append(Separator)
+		r, dotdot = 1, 1
+	}
+
+	for r < n {
+		switch {
+		case isPathSeparator(path[r]):
+			// empty path element
+			r++
+		case path[r] == '.' && (r+1 == n || isPathSeparator(path[r+1])):
+			// . element
+			r++
+		case path[r] == '.' && path[r+1] == '.' && (r+2 == n || isPathSeparator(path[r+2])):
+			// .. element: remove to last separator
+			r += 2
+			switch {
+			case out.w > dotdot:
+				// can backtrack
+				out.w--
+				for out.w > dotdot && !isPathSeparator(out.index(out.w)) {
+					out.w--
+				}
+			case !rooted:
+				// cannot backtrack, but not rooted, so append .. element.
+				if out.w > 0 {
+					out.append(Separator)
+				}
+				out.append('.')
+				out.append('.')
+				dotdot = out.w
+			}
+		default:
+			// real path element.
+			// add slash if needed
+			if rooted && out.w != 1 || !rooted && out.w != 0 {
+				out.append(Separator)
+			}
+			// copy element
+			for ; r < n && !isPathSeparator(path[r]); r++ {
+				out.append(path[r])
+			}
+		}
+	}
+
+	// Turn empty string into "."
+	if out.w == 0 {
+		out.append('.')
+	}
+
+	postClean(&out) // avoid creating absolute paths on Windows
+	return FromSlash(out.string())
+}
+
+func postClean(_ *lazybuf) {}
+
+// ToSlash returns the result of replacing each separator character
+// in path with a slash ('/') character. Multiple separators are
+// replaced by multiple slashes.
+func ToSlash(path string) string {
+	if Separator == '/' {
+		return path
+	}
+	return replaceStringByte(path, Separator, '/')
+}
+
+// FromSlash returns the result of replacing each slash ('/') character
+// in path with a separator character. Multiple slashes are replaced
+// by multiple separators.
+//
+// See also the Localize function, which converts a slash-separated path
+// as used by the io/fs package to an operating system path.
+func FromSlash(path string) string {
+	if Separator == '/' {
+		return path
+	}
+	return replaceStringByte(path, '/', Separator)
+}
+
+func replaceStringByte(s string, before, after byte) string {
+	if strings.IndexByte(s, before) == -1 {
+		return s
+	}
+	n := []byte(s)
+	for i := range n {
+		if n[i] == before {
+			n[i] = after
+		}
+	}
+	return string(n)
+}
+
+// Split splits path immediately following the final [Separator],
+// separating it into a directory and file name component.
+// If there is no Separator in path, Split returns an empty dir
+// and file set to path.
+// The returned values have the property that path = dir+file.
+func Split(path string) (dir, file string) {
+	vol := VolumeName(path)
+	i := len(path) - 1
+	for i >= len(vol) && !isPathSeparator(path[i]) {
+		i--
+	}
+	return path[:i+1], path[i+1:]
+}
+
+// Ext returns the file name extension used by path.
+// The extension is the suffix beginning at the final dot
+// in the final element of path; it is empty if there is
+// no dot.
+func Ext(path string) string {
+	for i := len(path) - 1; i >= 0 && !isPathSeparator(path[i]); i-- {
+		if path[i] == '.' {
+			return path[i:]
+		}
+	}
+	return ""
+}
+
+// Base returns the last element of path.
+// Trailing path separators are removed before extracting the last element.
+// If the path is empty, Base returns ".".
+// If the path consists entirely of separators, Base returns a single separator.
+func Base(path string) string {
+	if path == "" {
+		return "."
+	}
+	// Strip trailing slashes.
+	for len(path) > 0 && isPathSeparator(path[len(path)-1]) {
+		path = path[0 : len(path)-1]
+	}
+	// Throw away volume name
+	path = path[len(VolumeName(path)):]
+	// Find the last element
+	i := len(path) - 1
+	for i >= 0 && !isPathSeparator(path[i]) {
+		i--
+	}
+	if i >= 0 {
+		path = path[i+1:]
+	}
+	// If empty now, it had only slashes.
+	if path == "" {
+		return string(Separator)
+	}
+	return path
+}
+
+// Dir returns all but the last element of path, typically the path's directory.
+// After dropping the final element, Dir calls [Clean] on the path and trailing
+// slashes are removed.
+// If the path is empty, Dir returns ".".
+// If the path consists entirely of separators, Dir returns a single separator.
+// The returned path does not end in a separator unless it is the root directory.
+func Dir(path string) string {
+	vol := VolumeName(path)
+	i := len(path) - 1
+	for i >= len(vol) && !isPathSeparator(path[i]) {
+		i--
+	}
+	dir := Clean(path[len(vol) : i+1])
+	if dir == "." && len(vol) > 2 {
+		// must be UNC
+		return vol
+	}
+	return vol + dir
+}
+
+// VolumeName returns leading volume name.
+// Given "C:\foo\bar" it returns "C:" on Windows.
+// Given "\\host\share\foo" it returns "\\host\share".
+// On other platforms it returns "".
+func VolumeName(path string) string {
+	return FromSlash(path[:volumeNameLen(path)])
+}
+
+// volumeNameLen returns the length of the leading volume name on Windows.
+// It returns 0 elsewhere.
+func volumeNameLen(_ string) int {
+	return 0
+}
+
+func isPathSeparator(c uint8) bool {
+	return Separator == c
+}
+
+// Join joins any number of path elements into a single path,
+// separating them with an OS specific [Separator]. Empty elements
+// are ignored. The result is Cleaned. However, if the argument
+// list is empty or all its elements are empty, Join returns
+// an empty string.
+// On Windows, the result will only be a UNC path if the first
+// non-empty element is a UNC path.
+func Join(elem ...string) string {
+	// If there's a bug here, fix the logic in ./path_plan9.go too.
+	for i, e := range elem {
+		if e != "" {
+			return Clean(strings.Join(elem[i:], string(Separator)))
+		}
+	}
+	return ""
+}
+
+// IsAbs reports whether the path is absolute.
+func IsAbs(path string) bool {
+	return strings.HasPrefix(path, string(Separator))
+}

--- a/scanner/utils/filepath/windows/windows.go
+++ b/scanner/utils/filepath/windows/windows.go
@@ -1,0 +1,485 @@
+package windows
+
+import (
+	"slices"
+	"strings"
+)
+
+// https://cs.opensource.google/go/go/+/refs/tags/go1.24.3:src/internal/filepathlite/path.go
+// https://cs.opensource.google/go/go/+/refs/tags/go1.24.3:src/internal/filepathlite/path_windows.go
+// https://cs.opensource.google/go/go/+/refs/tags/go1.24.3:src/path/filepath/path_windows.go
+
+// Separator is OS-specific path separator
+const Separator = '\\' // OS-specific path separator
+
+type lazybuf struct {
+	path       string
+	buf        []byte
+	w          int
+	volAndPath string
+	volLen     int
+}
+
+func (b *lazybuf) index(i int) byte {
+	if b.buf != nil {
+		return b.buf[i]
+	}
+	return b.path[i]
+}
+
+func (b *lazybuf) append(c byte) {
+	if b.buf == nil {
+		if b.w < len(b.path) && b.path[b.w] == c {
+			b.w++
+			return
+		}
+		b.buf = make([]byte, len(b.path))
+		copy(b.buf, b.path[:b.w])
+	}
+	b.buf[b.w] = c
+	b.w++
+}
+
+func (b *lazybuf) prepend(prefix ...byte) {
+	b.buf = slices.Insert(b.buf, 0, prefix...)
+	b.w += len(prefix)
+}
+
+func (b *lazybuf) string() string {
+	if b.buf == nil {
+		return b.volAndPath[:b.volLen+b.w]
+	}
+	return b.volAndPath[:b.volLen] + string(b.buf[:b.w])
+}
+
+// Clean returns the shortest path name equivalent to path
+// by purely lexical processing. It applies the following rules
+// iteratively until no further processing can be done:
+//
+//  1. Replace multiple [Separator] elements with a single one.
+//  2. Eliminate each . path name element (the current directory).
+//  3. Eliminate each inner .. path name element (the parent directory)
+//     along with the non-.. element that precedes it.
+//  4. Eliminate .. elements that begin a rooted path:
+//     that is, replace "/.." by "/" at the beginning of a path,
+//     assuming Separator is '/'.
+//
+// The returned path ends in a slash only if it represents a root directory,
+// such as "/" on Unix or `C:\` on Windows.
+//
+// Finally, any occurrences of slash are replaced by Separator.
+//
+// If the result of this process is an empty string, Clean
+// returns the string ".".
+//
+// On Windows, Clean does not modify the volume name other than to replace
+// occurrences of "/" with `\`.
+// For example, Clean("//host/share/../x") returns `\\host\share\x`.
+//
+// See also Rob Pike, “Lexical File Names in Plan 9 or
+// Getting Dot-Dot Right,”
+// https://9p.io/sys/doc/lexnames.html
+func Clean(path string) string {
+	originalPath := path
+	volLen := volumeNameLen(path)
+	path = path[volLen:]
+	if path == "" {
+		if volLen > 1 && isPathSeparator(originalPath[0]) && isPathSeparator(originalPath[1]) {
+			// should be UNC
+			return FromSlash(originalPath)
+		}
+		return originalPath + "."
+	}
+	rooted := isPathSeparator(path[0])
+
+	// Invariants:
+	//	reading from path; r is index of next byte to process.
+	//	writing to buf; w is index of next byte to write.
+	//	dotdot is index in buf where .. must stop, either because
+	//		it is the leading slash or it is a leading ../../.. prefix.
+	n := len(path)
+	out := lazybuf{path: path, volAndPath: originalPath, volLen: volLen}
+	r, dotdot := 0, 0
+	if rooted {
+		out.append(Separator)
+		r, dotdot = 1, 1
+	}
+
+	for r < n {
+		switch {
+		case isPathSeparator(path[r]):
+			// empty path element
+			r++
+		case path[r] == '.' && (r+1 == n || isPathSeparator(path[r+1])):
+			// . element
+			r++
+		case path[r] == '.' && path[r+1] == '.' && (r+2 == n || isPathSeparator(path[r+2])):
+			// .. element: remove to last separator
+			r += 2
+			switch {
+			case out.w > dotdot:
+				// can backtrack
+				out.w--
+				for out.w > dotdot && !isPathSeparator(out.index(out.w)) {
+					out.w--
+				}
+			case !rooted:
+				// cannot backtrack, but not rooted, so append .. element.
+				if out.w > 0 {
+					out.append(Separator)
+				}
+				out.append('.')
+				out.append('.')
+				dotdot = out.w
+			}
+		default:
+			// real path element.
+			// add slash if needed
+			if rooted && out.w != 1 || !rooted && out.w != 0 {
+				out.append(Separator)
+			}
+			// copy element
+			for ; r < n && !isPathSeparator(path[r]); r++ {
+				out.append(path[r])
+			}
+		}
+	}
+
+	// Turn empty string into "."
+	if out.w == 0 {
+		out.append('.')
+	}
+
+	postClean(&out) // avoid creating absolute paths on Windows
+	return FromSlash(out.string())
+}
+
+// postClean adjusts the results of Clean to avoid turning a relative path
+// into an absolute or rooted one.
+func postClean(out *lazybuf) {
+	if out.volLen != 0 || out.buf == nil {
+		return
+	}
+	// If a ':' appears in the path element at the start of a path,
+	// insert a .\ at the beginning to avoid converting relative paths
+	// like a/../c: into c:.
+	for _, c := range out.buf {
+		if isPathSeparator(c) {
+			break
+		}
+		if c == ':' {
+			out.prepend('.', Separator)
+			return
+		}
+	}
+	// If a path begins with \??\, insert a \. at the beginning
+	// to avoid converting paths like \a\..\??\c:\x into \??\c:\x
+	// (equivalent to c:\x).
+	if len(out.buf) >= 3 && isPathSeparator(out.buf[0]) && out.buf[1] == '?' && out.buf[2] == '?' {
+		out.prepend(Separator, '.')
+	}
+}
+
+// ToSlash returns the result of replacing each separator character
+// in path with a slash ('/') character. Multiple separators are
+// replaced by multiple slashes.
+func ToSlash(path string) string {
+	if Separator == '/' {
+		return path
+	}
+	return replaceStringByte(path, Separator, '/')
+}
+
+// FromSlash returns the result of replacing each slash ('/') character
+// in path with a separator character. Multiple slashes are replaced
+// by multiple separators.
+//
+// See also the Localize function, which converts a slash-separated path
+// as used by the io/fs package to an operating system path.
+func FromSlash(path string) string {
+	if Separator == '/' {
+		return path
+	}
+	return replaceStringByte(path, '/', Separator)
+}
+
+func replaceStringByte(s string, before, after byte) string {
+	if strings.IndexByte(s, before) == -1 {
+		return s
+	}
+	n := []byte(s)
+	for i := range n {
+		if n[i] == before {
+			n[i] = after
+		}
+	}
+	return string(n)
+}
+
+// Split splits path immediately following the final [Separator],
+// separating it into a directory and file name component.
+// If there is no Separator in path, Split returns an empty dir
+// and file set to path.
+// The returned values have the property that path = dir+file.
+func Split(path string) (dir, file string) {
+	vol := VolumeName(path)
+	i := len(path) - 1
+	for i >= len(vol) && !isPathSeparator(path[i]) {
+		i--
+	}
+	return path[:i+1], path[i+1:]
+}
+
+// Ext returns the file name extension used by path.
+// The extension is the suffix beginning at the final dot
+// in the final element of path; it is empty if there is
+// no dot.
+func Ext(path string) string {
+	for i := len(path) - 1; i >= 0 && !isPathSeparator(path[i]); i-- {
+		if path[i] == '.' {
+			return path[i:]
+		}
+	}
+	return ""
+}
+
+// Base returns the last element of path.
+// Trailing path separators are removed before extracting the last element.
+// If the path is empty, Base returns ".".
+// If the path consists entirely of separators, Base returns a single separator.
+func Base(path string) string {
+	if path == "" {
+		return "."
+	}
+	// Strip trailing slashes.
+	for len(path) > 0 && isPathSeparator(path[len(path)-1]) {
+		path = path[0 : len(path)-1]
+	}
+	// Throw away volume name
+	path = path[len(VolumeName(path)):]
+	// Find the last element
+	i := len(path) - 1
+	for i >= 0 && !isPathSeparator(path[i]) {
+		i--
+	}
+	if i >= 0 {
+		path = path[i+1:]
+	}
+	// If empty now, it had only slashes.
+	if path == "" {
+		return string(Separator)
+	}
+	return path
+}
+
+// Dir returns all but the last element of path, typically the path's directory.
+// After dropping the final element, Dir calls [Clean] on the path and trailing
+// slashes are removed.
+// If the path is empty, Dir returns ".".
+// If the path consists entirely of separators, Dir returns a single separator.
+// The returned path does not end in a separator unless it is the root directory.
+func Dir(path string) string {
+	vol := VolumeName(path)
+	i := len(path) - 1
+	for i >= len(vol) && !isPathSeparator(path[i]) {
+		i--
+	}
+	dir := Clean(path[len(vol) : i+1])
+	if dir == "." && len(vol) > 2 {
+		// must be UNC
+		return vol
+	}
+	return vol + dir
+}
+
+// VolumeName returns leading volume name.
+// Given "C:\foo\bar" it returns "C:" on Windows.
+// Given "\\host\share\foo" it returns "\\host\share".
+// On other platforms it returns "".
+func VolumeName(path string) string {
+	return FromSlash(path[:volumeNameLen(path)])
+}
+
+// volumeNameLen returns length of the leading volume name on Windows.
+// It returns 0 elsewhere.
+//
+// See:
+// https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+// https://googleprojectzero.blogspot.com/2016/02/the-definitive-guide-on-win32-to-nt.html
+func volumeNameLen(path string) int {
+	switch {
+	case len(path) >= 2 && path[1] == ':':
+		// Path starts with a drive letter.
+		//
+		// Not all Windows functions necessarily enforce the requirement that
+		// drive letters be in the set A-Z, and we don't try to here.
+		//
+		// We don't handle the case of a path starting with a non-ASCII character,
+		// in which case the "drive letter" might be multiple bytes long.
+		return 2
+
+	case len(path) == 0 || !isPathSeparator(path[0]):
+		// Path does not have a volume component.
+		return 0
+
+	case pathHasPrefixFold(path, `\\.\UNC`):
+		// We're going to treat the UNC host and share as part of the volume
+		// prefix for historical reasons, but this isn't really principled;
+		// Windows's own GetFullPathName will happily remove the first
+		// component of the path in this space, converting
+		// \\.\unc\a\b\..\c into \\.\unc\a\c.
+		return uncLen(path, len(`\\.\UNC\`))
+
+	case pathHasPrefixFold(path, `\\.`) ||
+		pathHasPrefixFold(path, `\\?`) || pathHasPrefixFold(path, `\??`):
+		// Path starts with \\.\, and is a Local Device path; or
+		// path starts with \\?\ or \??\ and is a Root Local Device path.
+		//
+		// We treat the next component after the \\.\ prefix as
+		// part of the volume name, which means Clean(`\\?\c:\`)
+		// won't remove the trailing \. (See #64028.)
+		if len(path) == 3 {
+			return 3 // exactly \\.
+		}
+		_, rest, ok := cutPath(path[4:])
+		if !ok {
+			return len(path)
+		}
+		return len(path) - len(rest) - 1
+
+	case len(path) >= 2 && isPathSeparator(path[1]):
+		// Path starts with \\, and is a UNC path.
+		return uncLen(path, 2)
+	}
+	return 0
+}
+
+// pathHasPrefixFold tests whether the path s begins with prefix,
+// ignoring case and treating all path separators as equivalent.
+// If s is longer than prefix, then s[len(prefix)] must be a path separator.
+func pathHasPrefixFold(s, prefix string) bool {
+	if len(s) < len(prefix) {
+		return false
+	}
+	for i := 0; i < len(prefix); i++ {
+		if isPathSeparator(prefix[i]) {
+			if !isPathSeparator(s[i]) {
+				return false
+			}
+		} else if toUpper(prefix[i]) != toUpper(s[i]) {
+			return false
+		}
+	}
+	if len(s) > len(prefix) && !isPathSeparator(s[len(prefix)]) {
+		return false
+	}
+	return true
+}
+
+func toUpper(c byte) byte {
+	if 'a' <= c && c <= 'z' {
+		return c - ('a' - 'A')
+	}
+	return c
+}
+
+// uncLen returns the length of the volume prefix of a UNC path.
+// prefixLen is the prefix prior to the start of the UNC host;
+// for example, for "//host/share", the prefixLen is len("//")==2.
+func uncLen(path string, prefixLen int) int {
+	count := 0
+	for i := prefixLen; i < len(path); i++ {
+		if isPathSeparator(path[i]) {
+			count++
+			if count == 2 {
+				return i
+			}
+		}
+	}
+	return len(path)
+}
+
+// cutPath slices path around the first path separator.
+func cutPath(path string) (before, after string, found bool) {
+	for i := range path {
+		if isPathSeparator(path[i]) {
+			return path[:i], path[i+1:], true
+		}
+	}
+	return path, "", false
+}
+
+func isPathSeparator(c uint8) bool {
+	return c == '\\' || c == '/'
+}
+
+// Join joins any number of path elements into a single path,
+// separating them with an OS specific [Separator]. Empty elements
+// are ignored. The result is Cleaned. However, if the argument
+// list is empty or all its elements are empty, Join returns
+// an empty string.
+// On Windows, the result will only be a UNC path if the first
+// non-empty element is a UNC path.
+func Join(elem ...string) string {
+	var b strings.Builder
+	var lastChar byte
+	for _, e := range elem {
+		switch {
+		case b.Len() == 0:
+			// Add the first non-empty path element unchanged.
+		case isPathSeparator(lastChar):
+			// If the path ends in a slash, strip any leading slashes from the next
+			// path element to avoid creating a UNC path (any path starting with "\\")
+			// from non-UNC elements.
+			//
+			// The correct behavior for Join when the first element is an incomplete UNC
+			// path (for example, "\\") is underspecified. We currently join subsequent
+			// elements so Join("\\", "host", "share") produces "\\host\share".
+			for len(e) > 0 && isPathSeparator(e[0]) {
+				e = e[1:]
+			}
+			// If the path is \ and the next path element is ??,
+			// add an extra .\ to create \.\?? rather than \??\
+			// (a Root Local Device path).
+			if b.Len() == 1 && strings.HasPrefix(e, "??") && (len(e) == len("??") || isPathSeparator(e[2])) {
+				b.WriteString(`.\`)
+			}
+		case lastChar == ':':
+			// If the path ends in a colon, keep the path relative to the current directory
+			// on a drive and don't add a separator. Preserve leading slashes in the next
+			// path element, which may make the path absolute.
+			//
+			// 	Join(`C:`, `f`) = `C:f`
+			//	Join(`C:`, `\f`) = `C:\f`
+		default:
+			// In all other cases, add a separator between elements.
+			b.WriteByte('\\')
+			lastChar = '\\'
+		}
+		if len(e) > 0 {
+			b.WriteString(e)
+			lastChar = e[len(e)-1]
+		}
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return Clean(b.String())
+}
+
+// IsAbs reports whether the path is absolute.
+func IsAbs(path string) bool {
+	l := volumeNameLen(path)
+	if l == 0 {
+		return false
+	}
+	// If the volume name starts with a double slash, this is an absolute path.
+	if isPathSeparator(path[0]) && isPathSeparator(path[1]) {
+		return true
+	}
+	path = path[l:]
+	if path == "" {
+		return false
+	}
+	return isPathSeparator(path[0])
+}


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Fixes #2207 #2208 #2209 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## local scan (pseudo on linux)
### setup
```console
$ curl -sL --create-dirs --output Downloads/package-lock.json https://raw.githubusercontent.com/vulsio/integration/refs/heads/main/data/lockfile/npm-v3/package-lock.json
```

### abspath
```console
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.lockfile]
type = "pseudo"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["/home/vagrant/Downloads/package-lock.json"]
EOS

$ ./vuls scan
[May 18 21:12:59]  INFO [localhost] vuls-v0.32.0-build-20250519_061016_916f9da
[May 18 21:12:59]  INFO [localhost] Start scanning
[May 18 21:12:59]  INFO [localhost] config: /home/vagrant/config.toml
[May 18 21:12:59]  INFO [localhost] Validating config...
[May 18 21:12:59]  INFO [localhost] Detecting Server/Container OS... 
[May 18 21:12:59]  INFO [localhost] Detecting OS of servers... 
[May 18 21:12:59]  INFO [localhost] (1/1) Detected: lockfile: pseudo 
[May 18 21:12:59]  INFO [localhost] Detecting OS of containers... 
[May 18 21:12:59]  INFO [localhost] Checking Scan Modes... 
[May 18 21:12:59]  INFO [localhost] Detecting Platforms... 
[May 18 21:12:59]  INFO [localhost] (1/1) lockfile is running on other
[May 18 21:12:59]  INFO [lockfile] Scanning Language-specific Packages...
2025-05-18T21:12:59Z	INFO	[npm] To collect the license information of packages, "npm install" needs to be performed beforehand	dir="home/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile	pseudo	0 installed, 0 updatable	250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### relpath
```console
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.lockfile]
type = "pseudo"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["Downloads/package-lock.json"]
EOS

$ ./vuls scan
[May 18 21:13:17]  INFO [localhost] vuls-v0.32.0-build-20250519_061016_916f9da
[May 18 21:13:17]  INFO [localhost] Start scanning
[May 18 21:13:17]  INFO [localhost] config: /home/vagrant/config.toml
[May 18 21:13:17]  INFO [localhost] Validating config...
[May 18 21:13:17]  INFO [localhost] Detecting Server/Container OS... 
[May 18 21:13:17]  INFO [localhost] Detecting OS of servers... 
[May 18 21:13:17]  INFO [localhost] (1/1) Detected: lockfile: pseudo 
[May 18 21:13:17]  INFO [localhost] Detecting OS of containers... 
[May 18 21:13:17]  INFO [localhost] Checking Scan Modes... 
[May 18 21:13:17]  INFO [localhost] Detecting Platforms... 
[May 18 21:13:17]  INFO [localhost] (1/1) lockfile is running on other
[May 18 21:13:17]  INFO [lockfile] Scanning Language-specific Packages...
2025-05-18T21:13:17Z	INFO	[npm] To collect the license information of packages, "npm install" needs to be performed beforehand	dir="home/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile	pseudo	0 installed, 0 updatable	250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### findlock
```console
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.lockfile]
type = "pseudo"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
findLock = true
findLockDirs = ["/home/vagrant/Downloads"]
EOS

$ ./vuls scan
[May 18 21:13:37]  INFO [localhost] vuls-v0.32.0-build-20250519_061016_916f9da
[May 18 21:13:37]  INFO [localhost] Start scanning
[May 18 21:13:37]  INFO [localhost] config: /home/vagrant/config.toml
[May 18 21:13:37]  INFO [localhost] Validating config...
[May 18 21:13:37]  INFO [localhost] Detecting Server/Container OS... 
[May 18 21:13:37]  INFO [localhost] Detecting OS of servers... 
[May 18 21:13:37]  INFO [localhost] (1/1) Detected: lockfile: pseudo 
[May 18 21:13:37]  INFO [localhost] Detecting OS of containers... 
[May 18 21:13:37]  INFO [localhost] Checking Scan Modes... 
[May 18 21:13:37]  INFO [localhost] Detecting Platforms... 
[May 18 21:13:37]  INFO [localhost] (1/1) lockfile is running on other
[May 18 21:13:37]  INFO [lockfile] Scanning Language-specific Packages...
[May 18 21:13:37] ERROR [localhost] Error on lockfile, err: [Failed to scan Library:
    github.com/future-architect/vuls/scanner.Scanner.getScanResults.func1
        github.com/future-architect/vuls/scanner/scanner.go:981
  - FindLock is not supported in pseudo:
    github.com/future-architect/vuls/scanner.(*pseudo).scanLibraries
        github.com/future-architect/vuls/scanner/pseudo.go:95]


Scan Summary
================
lockfile	Error		Use configtest subcommand or scan with --debug to view the details


[May 18 21:13:37] ERROR [localhost] Failed to scan: Failed to scan. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        github.com/future-architect/vuls/scanner/scanner.go:111
  - An error occurred on [lockfile]
```

## local scan (pseudo on windows)
### setup
```console
PS C:\Users\vagrant> curl.exe -sL --create-dirs --output Downloads\package-lock.json https://raw.githubusercontent.com/vulsio/integration/refs/heads/main/data/lockfile/npm-v3/package-lock.json
```

### abspath
```powershell
PS C:\Users\vagrant> @"
version = "v2"

[default]

[servers]

[servers.lockfile]
type = "pseudo"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["C:\\Users\\vagrant\\Downloads\\package-lock.json"]
"@ | Set-Content config.toml

PS C:\Users\vagrant> .\vuls.exe scan
time="May 18 21:19:26" level=info msg="vuls-v0.32.0-build-20250519_061025_916f9da" 
time="May 18 21:19:26" level=info msg="Start scanning" 
time="May 18 21:19:26" level=info msg="config: C:\\Users\\vagrant\\config.toml" 
time="May 18 21:19:26" level=info msg="Validating config..." 
time="May 18 21:19:26" level=info msg="Detecting Server/Container OS... " 
time="May 18 21:19:26" level=info msg="Detecting OS of servers... " 
time="May 18 21:19:26" level=info msg="(1/1) Detected: lockfile: pseudo " 
time="May 18 21:19:26" level=info msg="Detecting OS of containers... " 
time="May 18 21:19:26" level=info msg="Checking Scan Modes... " 
time="May 18 21:19:26" level=info msg="Detecting Platforms... " 
time="May 18 21:19:26" level=info msg="(1/1) lockfile is running on other" 
time="May 18 21:19:26" level=info msg="Scanning Language-specific Packages..." 
2025-05-18T21:19:26Z    INFO    [npm] To collect the license information of packages, "npm install" needs to be performed beforehand    dir="C/Users/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile        pseudo  0 installed, 0 updatable        250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

```

### relpath
```powershell
PS C:\Users\vagrant> @"
version = "v2"

[default]

[servers]

[servers.lockfile]
type = "pseudo"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["Downloads\\package-lock.json"]
"@ | Set-Content config.toml

PS C:\Users\vagrant> .\vuls.exe scan
time="May 18 21:19:42" level=info msg="vuls-v0.32.0-build-20250519_061025_916f9da" 
time="May 18 21:19:42" level=info msg="Start scanning" 
time="May 18 21:19:42" level=info msg="config: C:\\Users\\vagrant\\config.toml" 
time="May 18 21:19:42" level=info msg="Validating config..." 
time="May 18 21:19:42" level=info msg="Detecting Server/Container OS... " 
time="May 18 21:19:42" level=info msg="Detecting OS of servers... " 
time="May 18 21:19:42" level=info msg="(1/1) Detected: lockfile: pseudo " 
time="May 18 21:19:42" level=info msg="Detecting OS of containers... " 
time="May 18 21:19:42" level=info msg="Checking Scan Modes... " 
time="May 18 21:19:42" level=info msg="Detecting Platforms... " 
time="May 18 21:19:42" level=info msg="(1/1) lockfile is running on other" 
time="May 18 21:19:42" level=info msg="Scanning Language-specific Packages..." 
2025-05-18T21:19:42Z    INFO    [npm] To collect the license information of packages, "npm install" needs to be performed beforehand    dir="C/Users/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile        pseudo  0 installed, 0 updatable        250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### findlock
```powershell
PS C:\Users\vagrant> @"
version = "v2"

[default]

[servers]

[servers.lockfile]
type = "pseudo"
findLock = true
scanMode           = ["fast"]
scanModules        = ["lockfile"]
findLockDirs = ["C:\\Users\\vagrant\\Downloads"]
"@ | Set-Content config.toml

PS C:\Users\vagrant> .\vuls.exe scan
time="May 18 21:20:01" level=info msg="vuls-v0.32.0-build-20250519_061025_916f9da" 
time="May 18 21:20:01" level=info msg="Start scanning" 
time="May 18 21:20:01" level=info msg="config: C:\\Users\\vagrant\\config.toml"
time="May 18 21:20:01" level=info msg="Validating config..."
time="May 18 21:20:01" level=info msg="Detecting Server/Container OS... "
time="May 18 21:20:01" level=info msg="Detecting OS of servers... "
time="May 18 21:20:01" level=info msg="(1/1) Detected: lockfile: pseudo "
time="May 18 21:20:01" level=info msg="Detecting OS of containers... "
time="May 18 21:20:01" level=info msg="Checking Scan Modes... "
time="May 18 21:20:01" level=info msg="Detecting Platforms... "
time="May 18 21:20:01" level=info msg="(1/1) lockfile is running on other"
time="May 18 21:20:01" level=info msg="Scanning Language-specific Packages..."
time="May 18 21:20:01" level=error msg="Error on lockfile, err: [Failed to scan Library:\n    github.com/future-architect/vuls/scanner.Scanner.getScanResults.func1\n        github.com/future-architect/vuls/scanner/scanner.go:981\n  - FindLock is not supported in pseudo:\n    github.com/future-architect/vuls/scanner.(*pseudo).scanLibraries\n        github.com/future-architect/vuls/scanner/pseudo.go:95]"


Scan Summary
================
lockfile        Error           Use configtest subcommand or scan with --debug to view the details


time="May 18 21:20:01" level=error msg="Failed to scan: Failed to scan. err:\n    github.com/future-architect/vuls/scanner.Scanner.Scan\n        github.com/future-architect/vuls/scanner/scanner.go:111\n  - An error occurred on [lockfile]"
```

## local scan (linux)
### setup
```console
$ curl -sL --create-dirs --output Downloads/package-lock.json https://raw.githubusercontent.com/vulsio/integration/refs/heads/main/data/lockfile/npm-v3/package-lock.json
```

### abspath
```powershell
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "localhost"
port = "local"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["/home/vagrant/Downloads/package-lock.json"]
EOS

$ ./vuls scan
[May 18 21:14:20]  INFO [localhost] vuls-v0.32.0-build-20250519_061016_916f9da
[May 18 21:14:20]  INFO [localhost] Start scanning
[May 18 21:14:20]  INFO [localhost] config: /home/vagrant/config.toml
[May 18 21:14:20]  INFO [localhost] Validating config...
[May 18 21:14:20]  INFO [localhost] Detecting Server/Container OS... 
[May 18 21:14:20]  INFO [localhost] Detecting OS of servers... 
[May 18 21:14:20]  INFO [localhost] (1/1) Detected: lockfile: ubuntu 24.04
[May 18 21:14:20]  INFO [localhost] Detecting OS of containers... 
[May 18 21:14:20]  INFO [localhost] Checking Scan Modes... 
[May 18 21:14:20]  INFO [localhost] Detecting Platforms... 
[May 18 21:14:22]  INFO [localhost] (1/1) lockfile is running on other
[May 18 21:14:22]  INFO [lockfile] Scanning Language-specific Packages...
2025-05-18T21:14:22Z	INFO	[npm] To collect the license information of packages, "npm install" needs to be performed beforehand	dir="home/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile	ubuntu24.04	0 installed	250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### relpath
```powershell
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "localhost"
port = "local"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["Downloads/package-lock.json"]
EOS

$ ./vuls scan
[May 18 21:14:47]  INFO [localhost] vuls-v0.32.0-build-20250519_061016_916f9da
[May 18 21:14:47]  INFO [localhost] Start scanning
[May 18 21:14:47]  INFO [localhost] config: /home/vagrant/config.toml
[May 18 21:14:47]  INFO [localhost] Validating config...
[May 18 21:14:47]  INFO [localhost] Detecting Server/Container OS... 
[May 18 21:14:47]  INFO [localhost] Detecting OS of servers... 
[May 18 21:14:47]  INFO [localhost] (1/1) Detected: lockfile: ubuntu 24.04
[May 18 21:14:47]  INFO [localhost] Detecting OS of containers... 
[May 18 21:14:47]  INFO [localhost] Checking Scan Modes... 
[May 18 21:14:47]  INFO [localhost] Detecting Platforms... 
[May 18 21:14:49]  INFO [localhost] (1/1) lockfile is running on other
[May 18 21:14:49]  INFO [lockfile] Scanning Language-specific Packages...
2025-05-18T21:14:49Z	INFO	[npm] To collect the license information of packages, "npm install" needs to be performed beforehand	dir="home/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile	ubuntu24.04	0 installed	250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### findlock
```powershell
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "localhost"
port = "local"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
findLock = true
findLockDirs = ["/home/vagrant/Downloads"]
EOS

$ ./vuls scan
[May 18 21:15:07]  INFO [localhost] vuls-v0.32.0-build-20250519_061016_916f9da
[May 18 21:15:07]  INFO [localhost] Start scanning
[May 18 21:15:07]  INFO [localhost] config: /home/vagrant/config.toml
[May 18 21:15:07]  INFO [localhost] Validating config...
[May 18 21:15:07]  INFO [localhost] Detecting Server/Container OS... 
[May 18 21:15:07]  INFO [localhost] Detecting OS of servers... 
[May 18 21:15:07]  INFO [localhost] (1/1) Detected: lockfile: ubuntu 24.04
[May 18 21:15:07]  INFO [localhost] Detecting OS of containers... 
[May 18 21:15:07]  INFO [localhost] Checking Scan Modes... 
[May 18 21:15:07]  INFO [localhost] Detecting Platforms... 
[May 18 21:15:09]  INFO [localhost] (1/1) lockfile is running on other
[May 18 21:15:09]  INFO [lockfile] Scanning Language-specific Packages...
[May 18 21:15:09]  INFO [lockfile] Finding files under /home/vagrant/Downloads
2025-05-18T21:15:09Z	INFO	[npm] To collect the license information of packages, "npm install" needs to be performed beforehand	dir="home/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile	ubuntu24.04	0 installed	250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

## local scan (windows)
### setup
```console
PS C:\Users\vagrant> curl.exe -sL --create-dirs --output Downloads\package-lock.json https://raw.githubusercontent.com/vulsio/integration/refs/heads/main/data/lockfile/npm-v3/package-lock.json
```

### abspath
```powershell
PS C:\Users\vagrant> @"
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "localhost"
port = "local"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["C:\\Users\\vagrant\\Downloads\\package-lock.json"]
"@ | Set-Content config.toml

PS C:\Users\vagrant> .\vuls.exe scan
time="May 18 21:20:22" level=info msg="vuls-v0.32.0-build-20250519_061025_916f9da" 
time="May 18 21:20:22" level=info msg="Start scanning" 
time="May 18 21:20:22" level=info msg="config: C:\\Users\\vagrant\\config.toml"
time="May 18 21:20:22" level=info msg="Validating config..."
time="May 18 21:20:22" level=info msg="Detecting Server/Container OS... "
time="May 18 21:20:22" level=info msg="Detecting OS of servers... "
time="May 18 21:20:27" level=info msg="(1/1) Detected: lockfile: windows Windows Server 2022" 
time="May 18 21:20:27" level=info msg="Detecting OS of containers... " 
time="May 18 21:20:27" level=info msg="Checking Scan Modes... "
time="May 18 21:20:27" level=info msg="Detecting Platforms... "
time="May 18 21:20:40" level=info msg="(1/1) lockfile is running on other" 
time="May 18 21:20:40" level=info msg="Scanning Language-specific Packages..." 
2025-05-18T21:20:40Z    INFO    [npm] To collect the license information of packages, "npm install" needs to be performed beforehand    dir="C/Users/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile        windowsWindows Server 2022      0 installed, 0 updatable        250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### relpath
```powershell
PS C:\Users\vagrant> @"
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "localhost"
port = "local"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["Downloads\\package-lock.json"]
"@ | Set-Content config.toml

PS C:\Users\vagrant> .\vuls.exe scan
time="May 18 21:22:13" level=info msg="vuls-v0.32.0-build-20250519_061025_916f9da" 
time="May 18 21:22:13" level=info msg="Start scanning" 
time="May 18 21:22:13" level=info msg="config: C:\\Users\\vagrant\\config.toml"
time="May 18 21:22:13" level=info msg="Validating config..."
time="May 18 21:22:13" level=info msg="Detecting Server/Container OS... "
time="May 18 21:22:13" level=info msg="Detecting OS of servers... "
time="May 18 21:22:17" level=info msg="(1/1) Detected: lockfile: windows Windows Server 2022" 
time="May 18 21:22:17" level=info msg="Detecting OS of containers... " 
time="May 18 21:22:17" level=info msg="Checking Scan Modes... "
time="May 18 21:22:17" level=info msg="Detecting Platforms... "
time="May 18 21:22:29" level=info msg="(1/1) lockfile is running on other" 
time="May 18 21:22:29" level=info msg="Scanning Language-specific Packages..." 
2025-05-18T21:22:31Z    INFO    [npm] To collect the license information of packages, "npm install" needs to be performed beforehand    dir="C/Users/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile        windowsWindows Server 2022      0 installed, 0 updatable        250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### findlock
```powershell
PS C:\Users\vagrant> @"
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "localhost"
port = "local"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
findLock = true
findLockDirs = ["C:\\Users\\vagrant\\Downloads\\"]
"@ | Set-Content config.toml

PS C:\Users\vagrant> .\vuls.exe scan
time="May 18 21:20:59" level=info msg="vuls-v0.32.0-build-20250519_061025_916f9da" 
time="May 18 21:20:59" level=info msg="Start scanning" 
time="May 18 21:20:59" level=info msg="config: C:\\Users\\vagrant\\config.toml"
time="May 18 21:20:59" level=info msg="Validating config..."
time="May 18 21:20:59" level=info msg="Detecting Server/Container OS... "
time="May 18 21:20:59" level=info msg="Detecting OS of servers... "
time="May 18 21:21:04" level=info msg="(1/1) Detected: lockfile: windows Windows Server 2022" 
time="May 18 21:21:04" level=info msg="Detecting OS of containers... " 
time="May 18 21:21:04" level=info msg="Checking Scan Modes... "
time="May 18 21:21:04" level=info msg="Detecting Platforms... "
time="May 18 21:21:15" level=info msg="(1/1) lockfile is running on other" 
time="May 18 21:21:15" level=info msg="Scanning Language-specific Packages..." 
time="May 18 21:21:15" level=info msg="Finding files under \"C:\\Users\\vagrant\\Downloads\\\""
2025-05-18T21:21:17Z    INFO    [npm] To collect the license information of packages, "npm install" needs to be performed beforehand    dir="C/Users/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile        windowsWindows Server 2022      0 installed, 0 updatable        250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

## remote scan (linux to linux)
### setup
```console
$ curl -sL --create-dirs --output Downloads/package-lock.json https://raw.githubusercontent.com/vulsio/integration/refs/heads/main/data/lockfile/npm-v3/package-lock.json
```

### abspath
```console
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "127.0.0.1"
port = "2222"
user = "vagrant"
keyPath = "/home/vuls/.ssh/id_rsa"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["/home/vagrant/Downloads/package-lock.json"]
EOS

$ ./vuls scan
[May 19 06:16:25]  INFO [localhost] vuls-v0.32.0-build-20250519_061016_916f9da
[May 19 06:16:25]  INFO [localhost] Start scanning
[May 19 06:16:25]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[May 19 06:16:25]  INFO [localhost] Validating config...
[May 19 06:16:25]  INFO [localhost] Detecting Server/Container OS... 
[May 19 06:16:25]  INFO [localhost] Detecting OS of servers... 
[May 19 06:16:25]  INFO [localhost] (1/1) Detected: lockfile: ubuntu 24.04
[May 19 06:16:25]  INFO [localhost] Detecting OS of containers... 
[May 19 06:16:25]  INFO [localhost] Checking Scan Modes... 
[May 19 06:16:25]  INFO [localhost] Detecting Platforms... 
[May 19 06:16:27]  INFO [localhost] (1/1) lockfile is running on other
[May 19 06:16:27]  INFO [lockfile] Scanning Language-specific Packages...
2025-05-19T06:16:27+09:00	INFO	[npm] To collect the license information of packages, "npm install" needs to be performed beforehand	dir="home/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile	ubuntu24.04	0 installed	250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### relpath
```console
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "127.0.0.1"
port = "2222"
user = "vagrant"
keyPath = "/home/vuls/.ssh/id_rsa"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["Downloads/package-lock.json"]
EOS

$ ./vuls scan
[May 19 06:16:46]  INFO [localhost] vuls-v0.32.0-build-20250519_061016_916f9da
[May 19 06:16:46]  INFO [localhost] Start scanning
[May 19 06:16:46]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[May 19 06:16:46]  INFO [localhost] Validating config...
[May 19 06:16:46]  INFO [localhost] Detecting Server/Container OS... 
[May 19 06:16:46]  INFO [localhost] Detecting OS of servers... 
[May 19 06:16:46]  INFO [localhost] (1/1) Detected: lockfile: ubuntu 24.04
[May 19 06:16:46]  INFO [localhost] Detecting OS of containers... 
[May 19 06:16:46]  INFO [localhost] Checking Scan Modes... 
[May 19 06:16:46]  INFO [localhost] Detecting Platforms... 
[May 19 06:16:48]  INFO [localhost] (1/1) lockfile is running on other
[May 19 06:16:48]  INFO [lockfile] Scanning Language-specific Packages...
2025-05-19T06:16:48+09:00	INFO	[npm] To collect the license information of packages, "npm install" needs to be performed beforehand	dir="home/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile	ubuntu24.04	0 installed	250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### findlock
```console
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "127.0.0.1"
port = "2222"
user = "vagrant"
keyPath = "/home/vuls/.ssh/id_rsa"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
findLock = true
findLockDirs = ["/home/vagrant/Downloads"]
EOS

$ ./vuls scan
[May 19 06:17:18]  INFO [localhost] vuls-v0.32.0-build-20250519_061016_916f9da
[May 19 06:17:18]  INFO [localhost] Start scanning
[May 19 06:17:18]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[May 19 06:17:18]  INFO [localhost] Validating config...
[May 19 06:17:18]  INFO [localhost] Detecting Server/Container OS... 
[May 19 06:17:18]  INFO [localhost] Detecting OS of servers... 
[May 19 06:17:18]  INFO [localhost] (1/1) Detected: lockfile: ubuntu 24.04
[May 19 06:17:18]  INFO [localhost] Detecting OS of containers... 
[May 19 06:17:18]  INFO [localhost] Checking Scan Modes... 
[May 19 06:17:18]  INFO [localhost] Detecting Platforms... 
[May 19 06:17:20]  INFO [localhost] (1/1) lockfile is running on other
[May 19 06:17:20]  INFO [lockfile] Scanning Language-specific Packages...
[May 19 06:17:20]  INFO [lockfile] Finding files under /home/vagrant/Downloads
2025-05-19T06:17:21+09:00	INFO	[npm] To collect the license information of packages, "npm install" needs to be performed beforehand	dir="home/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile	ubuntu24.04	0 installed	250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

## remote scan (linux to windows)
### setup
```console
PS C:\Users\vagrant> curl.exe -sL --create-dirs --output Downloads\package-lock.json https://raw.githubusercontent.com/vulsio/integration/refs/heads/main/data/lockfile/npm-v3/package-lock.json
```

### abspath
```console
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "127.0.0.1"
port = "2222"
user = "vagrant"
keyPath = "/home/vuls/.ssh/id_rsa"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["C:\\Users\\vagrant\\Downloads\\package-lock.json"]
EOS

$ ./vuls scan
[May 19 06:23:03]  INFO [localhost] vuls-v0.32.0-build-20250519_061016_916f9da
[May 19 06:23:03]  INFO [localhost] Start scanning
[May 19 06:23:03]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[May 19 06:23:03]  INFO [localhost] Validating config...
[May 19 06:23:03]  INFO [localhost] Detecting Server/Container OS... 
[May 19 06:23:03]  INFO [localhost] Detecting OS of servers... 
[May 19 06:23:07]  INFO [localhost] (1/1) Detected: lockfile: windows Windows Server 2022
[May 19 06:23:07]  INFO [localhost] Detecting OS of containers... 
[May 19 06:23:07]  INFO [localhost] Checking Scan Modes... 
[May 19 06:23:07]  INFO [localhost] Detecting Platforms... 
[May 19 06:23:14]  INFO [localhost] (1/1) lockfile is running on other
[May 19 06:23:14]  INFO [lockfile] Scanning Language-specific Packages...
2025-05-19T06:23:17+09:00	INFO	[npm] To collect the license information of packages, "npm install" needs to be performed beforehand	dir="C/Users/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile	windowsWindows Server 2022	0 installed, 0 updatable	250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### relpath
```console
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "127.0.0.1"
port = "2222"
user = "vagrant"
keyPath = "/home/vuls/.ssh/id_rsa"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["Downloads\\package-lock.json"]
EOS

$ ./vuls scan
[May 19 06:23:34]  INFO [localhost] vuls-v0.32.0-build-20250519_061016_916f9da
[May 19 06:23:34]  INFO [localhost] Start scanning
[May 19 06:23:34]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[May 19 06:23:34]  INFO [localhost] Validating config...
[May 19 06:23:34]  INFO [localhost] Detecting Server/Container OS... 
[May 19 06:23:34]  INFO [localhost] Detecting OS of servers... 
[May 19 06:23:37]  INFO [localhost] (1/1) Detected: lockfile: windows Windows Server 2022
[May 19 06:23:37]  INFO [localhost] Detecting OS of containers... 
[May 19 06:23:37]  INFO [localhost] Checking Scan Modes... 
[May 19 06:23:37]  INFO [localhost] Detecting Platforms... 
[May 19 06:23:44]  INFO [localhost] (1/1) lockfile is running on other
[May 19 06:23:44]  INFO [lockfile] Scanning Language-specific Packages...
2025-05-19T06:23:49+09:00	INFO	[npm] To collect the license information of packages, "npm install" needs to be performed beforehand	dir="C/Users/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile	windowsWindows Server 2022	0 installed, 0 updatable	250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### findlock
```console
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "127.0.0.1"
port = "2222"
user = "vagrant"
keyPath = "/home/vuls/.ssh/id_rsa"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
findLock = true
findLockDirs = ["C:\\Users\\vagrant\\Downloads"]
EOS

$ ./vuls scan
[May 19 06:24:34]  INFO [localhost] vuls-v0.32.0-build-20250519_061016_916f9da
[May 19 06:24:34]  INFO [localhost] Start scanning
[May 19 06:24:34]  INFO [localhost] config: /home/mainek00n/github/github.com/MaineK00n/vuls/config.toml
[May 19 06:24:34]  INFO [localhost] Validating config...
[May 19 06:24:34]  INFO [localhost] Detecting Server/Container OS... 
[May 19 06:24:34]  INFO [localhost] Detecting OS of servers... 
[May 19 06:24:37]  INFO [localhost] (1/1) Detected: lockfile: windows Windows Server 2022
[May 19 06:24:37]  INFO [localhost] Detecting OS of containers... 
[May 19 06:24:37]  INFO [localhost] Checking Scan Modes... 
[May 19 06:24:37]  INFO [localhost] Detecting Platforms... 
[May 19 06:24:43]  INFO [localhost] (1/1) lockfile is running on other
[May 19 06:24:43]  INFO [lockfile] Scanning Language-specific Packages...
[May 19 06:24:43]  INFO [lockfile] Finding files under \"C:\Users\vagrant\Downloads\"
2025-05-19T06:24:48+09:00	INFO	[npm] To collect the license information of packages, "npm install" needs to be performed beforehand	dir="C/Users/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile	windowsWindows Server 2022	0 installed, 0 updatable	250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

## remote scan (windows to linux)
I don't have an environment where I can reproduce this.

## remote scan (windows to windows)
### setup
```console
PS C:\Users\vagrant> curl.exe -sL --create-dirs --output Downloads\package-lock.json https://raw.githubusercontent.com/vulsio/integration/refs/heads/main/data/lockfile/npm-v3/package-lock.json
```

### abspath
```powershell
PS C:\Users\vagrant> @"
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "127.0.0.1"
port = "22"
user = "vagrant"
keyPath = "C:\\Users\\vagrant\\.ssh\\id_rsa"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["C:\\Users\\vagrant\\Downloads\\package-lock.json"]
"@ | Set-Content config.toml

PS C:\Users\vagrant> .\vuls.exe scan
time="May 18 21:29:46" level=info msg="vuls-v0.32.0-build-20250519_061025_916f9da" 
time="May 18 21:29:46" level=info msg="Start scanning" 
time="May 18 21:29:46" level=info msg="config: C:\\Users\\vagrant\\config.toml" 
time="May 18 21:29:46" level=info msg="Validating config..." 
time="May 18 21:29:46" level=info msg="Detecting Server/Container OS... " 
time="May 18 21:29:46" level=info msg="Detecting OS of servers... " 
time="May 18 21:29:52" level=info msg="(1/1) Detected: lockfile: windows Windows Server 2022" 
time="May 18 21:29:52" level=info msg="Detecting OS of containers... " 
time="May 18 21:29:52" level=info msg="Checking Scan Modes... " 
time="May 18 21:29:52" level=info msg="Detecting Platforms... " 
time="May 18 21:30:01" level=info msg="(1/1) lockfile is running on other" 
time="May 18 21:30:01" level=info msg="Scanning Language-specific Packages..." 
2025-05-18T21:30:04Z    INFO    [npm] To collect the license information of packages, "npm install" needs to be performed beforehand    dir="C/Users/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile        windowsWindows Server 2022      0 installed, 0 updatable        250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### relpath
```powershell
PS C:\Users\vagrant> @"
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "127.0.0.1"
port = "22"
user = "vagrant"
keyPath = "C:\\Users\\vagrant\\.ssh\\id_rsa"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = ["Downloads\\package-lock.json"]
"@ | Set-Content config.toml

PS C:\Users\vagrant> .\vuls.exe scan
time="May 18 21:31:48" level=info msg="vuls-v0.32.0-build-20250519_061025_916f9da" 
time="May 18 21:31:48" level=info msg="Start scanning" 
time="May 18 21:31:48" level=info msg="config: C:\\Users\\vagrant\\config.toml" 
time="May 18 21:31:48" level=info msg="Validating config..." 
time="May 18 21:31:48" level=info msg="Detecting Server/Container OS... " 
time="May 18 21:31:48" level=info msg="Detecting OS of servers... " 
time="May 18 21:31:55" level=info msg="(1/1) Detected: lockfile: windows Windows Server 2022" 
time="May 18 21:31:55" level=info msg="Detecting OS of containers... " 
time="May 18 21:31:55" level=info msg="Checking Scan Modes... " 
time="May 18 21:31:55" level=info msg="Detecting Platforms... " 
time="May 18 21:32:04" level=info msg="(1/1) lockfile is running on other" 
time="May 18 21:32:04" level=info msg="Scanning Language-specific Packages..." 
2025-05-18T21:32:10Z    INFO    [npm] To collect the license information of packages, "npm install" needs to be performed beforehand    dir="C/Users/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile        windowsWindows Server 2022      0 installed, 0 updatable        250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

### findlock
```powershell
PS C:\Users\vagrant> @"
version = "v2"

[default]

[servers]

[servers.lockfile]
host = "127.0.0.1"
port = "22"
user = "vagrant"
keyPath = "C:\\Users\\vagrant\\.ssh\\id_rsa"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
findLock = true
findLockDirs = ["C:\\Users\\vagrant\\Downloads"]
"@ | Set-Content config.toml

PS C:\Users\vagrant> .\vuls.exe scan
time="May 18 21:32:26" level=info msg="vuls-v0.32.0-build-20250519_061025_916f9da" 
time="May 18 21:32:26" level=info msg="Start scanning" 
time="May 18 21:32:26" level=info msg="config: C:\\Users\\vagrant\\config.toml"
time="May 18 21:32:26" level=info msg="Validating config..."
time="May 18 21:32:26" level=info msg="Detecting Server/Container OS... "
time="May 18 21:32:26" level=info msg="Detecting OS of servers... "
time="May 18 21:32:35" level=info msg="(1/1) Detected: lockfile: windows Windows Server 2022" 
time="May 18 21:32:35" level=info msg="Detecting OS of containers... " 
time="May 18 21:32:35" level=info msg="Checking Scan Modes... "
time="May 18 21:32:35" level=info msg="Detecting Platforms... "
time="May 18 21:32:43" level=info msg="(1/1) lockfile is running on other" 
time="May 18 21:32:43" level=info msg="Scanning Language-specific Packages..." 
time="May 18 21:32:43" level=info msg="Finding files under \\\"C:\\Users\\vagrant\\Downloads\\\""
2025-05-18T21:32:50Z    INFO    [npm] To collect the license information of packages, "npm install" needs to be performed beforehand    dir="C/Users/vagrant/Downloads/node_modules"


Scan Summary
================
lockfile        windowsWindows Server 2022      0 installed, 0 updatable        250 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

