### PR TITLE
fix(cmd/discover): fix ping options for windows

### DIFF
--- a/contrib/future-vuls/pkg/discover/discover.go
+++ b/contrib/future-vuls/pkg/discover/discover.go
@@ -6,20 +6,27 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/future-architect/vuls/contrib/future-vuls/pkg/config"
 	"github.com/kotakanbe/go-pingscanner"
+
+	"github.com/future-architect/vuls/contrib/future-vuls/pkg/config"
 )
 
 // ActiveHosts ...
 func ActiveHosts(cidr string, outputFile string, snmpVersion string, community string) error {
 	scanner := pingscanner.PingScanner{
 		CIDR: cidr,
-		PingOptions: []string{
-			"-c1",
-		},
+		PingOptions: func() []string {
+			switch runtime.GOOS {
+			case "windows":
+				return []string{"-n", "1"}
+			default:
+				return []string{"-c", "1"}
+			}
+		}(),
 		NumOfConcurrency: 100,
 	}
 	fmt.Printf("Discovering %s...\n", cidr)


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

fix vuls discover on windows

- cmd.exe
```console
vagrant@WIN-NI76NHOHQTA C:\Users\vagrant>ping -c1 127.0.0.2
Bad value for option -c1.

vagrant@WIN-NI76NHOHQTA C:\Users\vagrant>ping -n 1 127.0.0.2 

Pinging 127.0.0.2 with 32 bytes of data:
Reply from 127.0.0.2: bytes=32 time<1ms TTL=128

Ping statistics for 127.0.0.2:
    Packets: Sent = 1, Received = 1, Lost = 0 (0% loss),
Approximate round trip times in milli-seconds:
    Minimum = 0ms, Maximum = 0ms, Average = 0ms
```

- powershell
```powershell
PS C:\Users\vagrant> ping -c1 127.0.0.2 
Bad value for option -c1.

PS C:\Users\vagrant> ping -n 1 127.0.0.2

Pinging 127.0.0.2 with 32 bytes of data:
Reply from 127.0.0.2: bytes=32 time<1ms TTL=128

Ping statistics for 127.0.0.2:
    Packets: Sent = 1, Received = 1, Lost = 0 (0% loss),
Approximate round trip times in milli-seconds:
    Minimum = 0ms, Maximum = 0ms, Average = 0ms
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```powershell
PS C:\Users\vagrant> .\vuls.exe discover 127.0.0.1/32
time="May 18 22:42:45" level=info msg="vuls-0.32.0-6accfb855ea1523c5a70b79c30c5430fd3b7a1a5-2025-05-16T07:24:16Z" 
time="May 18 22:42:45" level=error msg="Active hosts not found in 127.0.0.1/32"
```

## after
```powershell
PS C:\Users\vagrant> .\vuls.exe discover 127.0.0.1/32
time="May 18 22:39:34" level=info msg="vuls-v0.32.0-build-20250519_073913_f53a805" 
# Create config.toml using below and then ./vuls -config=/path/to/config.toml


# https://vuls.io/docs/en/config.toml.html#database-section
[cveDict]
#type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
#sqlite3Path = "/path/to/cve.sqlite3"
#url        = ""
#debugSQL = false
#timeoutSec = 0
#timeoutSecPerRequest = 0

[ovalDict]
#type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
#sqlite3Path = "/path/to/oval.sqlite3"
#url        = ""
#debugSQL = false
#timeoutSec = 0
#timeoutSecPerRequest = 0

[gost]
#type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
#sqlite3Path = "/path/to/gost.sqlite3"
#url        = ""
#debugSQL = false
#timeoutSec = 0
#timeoutSecPerRequest = 0

[exploit]
#type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
#sqlite3Path = "/path/to/go-exploitdb.sqlite3"
#url        = ""
#debugSQL = false
#timeoutSec = 0
#timeoutSecPerRequest = 0

[metasploit]
#type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
#sqlite3Path = "/path/to/go-msfdb.sqlite3"
#url        = ""
#debugSQL = false
#timeoutSec = 0
#timeoutSecPerRequest = 0

[kevuln]
#type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
#sqlite3Path = "/path/to/go-kev.sqlite3"
#url        = ""
#debugSQL = false
#timeoutSec = 0
#timeoutSecPerRequest = 0

[cti]
#type = ["sqlite3", "mysql", "postgres", "redis", "http" ]
#sqlite3Path = "/path/to/go-cti.sqlite3"
#url        = ""
#debugSQL = false
#timeoutSec = 0
#timeoutSecPerRequest = 0

[vuls2]
#Path = "/path/to/vuls.db"
#Repository = "ghcr.io/vulsio/vuls-nightly-db:<schema-version>"
#SkipUpdate = false

# https://vuls.io/docs/en/config.toml.html#slack-section
#[slack]
#hookURL      = "https://hooks.slack.com/services/abc123/defghijklmnopqrstuvwxyz"
##legacyToken = "xoxp-11111111111-222222222222-3333333333"
#channel      = "#channel-name"
##channel     = "${servername}"
#iconEmoji    = ":ghost:"
#authUser     = "username"
#notifyUsers  = ["@username"]

# https://vuls.io/docs/en/config.toml.html#email-section
#[email]
#smtpAddr              = "smtp.example.com"
#smtpPort              = "587"
#tlsMode               = "STARTTLS"
#tlsInsecureSkipVerify = false
#user                  = "username"
#password              = "password"
#from                  = "from@example.com"
#to                    = ["to@example.com"]
#cc                    = ["cc@example.com"]
#subjectPrefix         = "[vuls]"

# https://vuls.io/docs/en/config.toml.html#http-section
#[http]
#url = "http://localhost:11234"

# https://vuls.io/docs/en/config.toml.html#syslog-section
#[syslog]
#protocol    = "tcp"
#host        = "localhost"
#port        = "514"
#tag         = "vuls"
#facility    = "local0"
#severity    = "alert"
#verbose     = false

# https://vuls.io/docs/en/usage-report.html#example-put-results-in-s3-bucket
#[aws]
#s3Endpoint             = "http://localhost:9000"
#region                 = "ap-northeast-1"
#profile                = "default"
#credentialProvider     = "anonymous"
#s3Bucket               = "vuls"
#s3ResultsDir           = "/path/to/result"
#s3ServerSideEncryption = "AES256"
#s3UsePathStyle         = false

# https://vuls.io/docs/en/usage-report.html#example-put-results-in-azure-blob-storage
#[azure]
#endpoint      = "https://default.blob.core.windows.net/"
#accountName   = "default"
#accountKey    = "xxxxxxxxxxxxxx"
#containerName = "vuls"

# https://vuls.io/docs/en/config.toml.html#chatwork-section
#[chatwork]
#room     = "xxxxxxxxxxx"
#apiToken = "xxxxxxxxxxxxxxxxxx"

# https://vuls.io/docs/en/config.toml.html#googlechat-section
#[googlechat]
#webHookURL = "https://chat.googleapis.com/v1/spaces/xxxxxxxxxx/messages?key=yyyyyyyyyy&token=zzzzzzzzzz%3D"
#skipIfNoCve = false
#serverNameRegexp = "^(\\[Reboot Required\\] )?((spam|ham).*|.*(egg)$)" # include spamonigiri, hamburger, boiledegg
#serverNameRegexp = "^(\\[Reboot Required\\] )?(?:(spam|ham).*|.*(?:egg)$)" # exclude spamonigiri, hamburger, boiledegg

# https://vuls.io/docs/en/config.toml.html#telegram-section
#[telegram]
#chatID     = "xxxxxxxxxxx"
#token = "xxxxxxxxxxxxxxxxxx"

#[wpscan]
#token = "xxxxxxxxxxx"
#detectInactive = false

# https://vuls.io/docs/en/config.toml.html#default-section
[default]
#port               = "22"
#user               = "username"
#keyPath            = "/home/username/.ssh/id_rsa"
#scanMode           = ["fast", "fast-root", "deep", "offline"]
#scanModules        = ["ospkg", "wordpress", "lockfile", "port"]
#lockfiles = ["/path/to/package-lock.json"]
#cpeNames = [
#  "cpe:/a:rubyonrails:ruby_on_rails:4.2.1",
#]
#owaspDCXMLPath     = "/tmp/dependency-check-report.xml"
#ignoreCves         = ["CVE-2014-6271"]
#containerType      = "docker" #or "lxd" or "lxc" default: docker
#containersIncluded = ["${running}"]
#containersExcluded = ["container_name_a"]

# https://vuls.io/docs/en/config.toml.html#servers-section
[servers]

[servers.127-0-0-1]
host                = "127.0.0.1"
#ignoreIPAddresses  = ["127.0.0.1"]
#port               = "22"
#user               = "root"
#sshConfigPath          = "/home/username/.ssh/config"
#keyPath            = "/home/username/.ssh/id_rsa"
#scanMode           = ["fast", "fast-root", "deep", "offline"]
#scanModules        = ["ospkg", "wordpress", "lockfile", "port"]
#type               = "pseudo"
#memo               = "DB Server"
#findLock = true
#findLockDirs = [ "/path/to/prject/lib" ]
#lockfiles = ["/path/to/package-lock.json"]
#cpeNames           = [ "cpe:/a:rubyonrails:ruby_on_rails:4.2.1" ]
#owaspDCXMLPath     = "/path/to/dependency-check-report.xml"
#ignoreCves         = ["CVE-2014-0160"]
#containersOnly     = false
#containerType      = "docker" #or "lxd" or "lxc" default: docker
#containersIncluded = ["${running}"]
#containersExcluded = ["container_name_a"]
#confidenceScoreOver = 80

#[servers.127-0-0-1.containers.container_name_a]
#cpeNames       = [ "cpe:/a:rubyonrails:ruby_on_rails:4.2.1" ]
#owaspDCXMLPath = "/path/to/dependency-check-report.xml"
#ignoreCves     = ["CVE-2014-0160"]

#[servers.127-0-0-1.githubs."owner/repo"]
#token  = "yourToken"
#ignoreGitHubDismissed  = false

#[servers.127-0-0-1.wordpress]
#cmdPath = "/usr/local/bin/wp"
#osUser = "wordpress"
#docRoot = "/path/to/DocumentRoot/"
#noSudo = false

#[servers.127-0-0-1.portscan]
#scannerBinPath = "/usr/bin/nmap"
#hasPrivileged = true
#scanTechniques = ["sS"]
#sourcePort = "65535"

#[servers.127-0-0-1.windows]
#serverSelection = 3
#cabPath = "/path/to/wsusscn2.cab"

#[servers.127-0-0-1.optional]
#key = "value1"




```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

