### PR TITLE
feat(detector/vuls2): should download db when the schema versions are different

### DIFF
--- a/detector/vuls2/db_test.go
+++ b/detector/vuls2/db_test.go
@@ -98,6 +98,34 @@ func Test_shouldDownload(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "schema version mismatch",
+			args: args{
+				vuls2Conf: config.Vuls2Conf{},
+				now:       *parse("2024-01-02T00:00:00Z"),
+			},
+			metadata: &types.Metadata{
+				LastModified:  *parse("2024-01-02T00:00:00Z"),
+				Downloaded:    parse("2024-01-02T00:00:00Z"),
+				SchemaVersion: common.SchemaVersion + 1,
+			},
+			want: true,
+		},
+		{
+			name: "schema version mismatch, but skip update",
+			args: args{
+				vuls2Conf: config.Vuls2Conf{
+					SkipUpdate: true,
+				},
+				now: *parse("2024-01-02T00:00:00Z"),
+			},
+			metadata: &types.Metadata{
+				LastModified:  *parse("2024-01-02T00:00:00Z"),
+				Downloaded:    parse("2024-01-02T00:00:00Z"),
+				SchemaVersion: common.SchemaVersion + 1,
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# What did you implement:

should download db when the schema versions are different

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

by unit test

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

