### PR TITLE
fix(detector/vuls2): get metadata after opening db

### DIFF
--- a/detector/vuls2/db.go
+++ b/detector/vuls2/db.go
@@ -50,6 +50,11 @@ func newDBConnection(vuls2Conf config.Vuls2Conf, noProgress bool) (db.DB, error)
 		return nil, xerrors.Errorf("Failed to new vuls2 db connection. path: %s, err: %w", vuls2Conf.Path, err)
 	}
 
+	if err := dbc.Open(); err != nil {
+		return nil, xerrors.Errorf("Failed to open vuls2 db. path: %s, err: %w", vuls2Conf.Path, err)
+	}
+	defer dbc.Close()
+
 	metadata, err := dbc.GetMetadata()
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to get vuls2 db metadata. path: %s, err: %w", vuls2Conf.Path, err)


### PR DESCRIPTION
# What did you implement:

get metadata after opening db

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## setup
```console
$ curl -s --create-dirs --output results/2025-05-22T00-00-00+0900/rhel_90.json https://raw.githubusercontent.com/vulsio/integration/refs/heads/main/data/results/rhel_90.json
```

## before
```console
$ vuls report --refresh-cve 2025-05-22T00-00-00+0900
[May 22 02:30:50]  INFO [localhost] vuls-v0.32.0-build-20250522_022918_e52fa8d
[May 22 02:30:50]  INFO [localhost] Validating config...
[May 22 02:30:50]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/home/vuls/cve.sqlite3
[May 22 02:30:50]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/vuls/oval.sqlite3
[May 22 02:30:50]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/home/vuls/gost.sqlite3
[May 22 02:30:50]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/home/vuls/go-exploitdb.sqlite3
[May 22 02:30:50]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/home/vuls/go-msfdb.sqlite3
[May 22 02:30:50]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/home/vuls/go-kev.sqlite3
[May 22 02:30:50]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/home/vuls/go-cti.sqlite3
[May 22 02:30:50]  INFO [localhost] Loaded: /home/vuls/results/2025-05-22T00-00-00+0900
[May 22 02:30:50]  INFO [localhost] Fetching vuls2 db. repository: ghcr.io/vulsio/vuls-nightly-db:0
⠼ fetching (353 MB, 143 MB/s) [2s] 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x1d0 pc=0xb3eb6d]

goroutine 1 [running]:
go.etcd.io/bbolt.(*DB).beginTx(0x0)
	go.etcd.io/bbolt@v1.4.0/db.go:772 +0x2d
go.etcd.io/bbolt.(*DB).Begin(0x0, 0x0)
	go.etcd.io/bbolt@v1.4.0/db.go:758 +0x1cc
go.etcd.io/bbolt.(*DB).View(0x4a54a20?, 0xc00101f650)
	go.etcd.io/bbolt@v1.4.0/db.go:923 +0x30
github.com/MaineK00n/vuls2/pkg/db/common/boltdb.(*Connection).GetMetadata(0xc000b9e3f0)
	github.com/MaineK00n/vuls2@v0.0.1-alpha.0.20250508062930-5ba469b2c6ca/pkg/db/common/boltdb/boltdb.go:76 +0x4e
github.com/future-architect/vuls/detector/vuls2.newDBConnection({{0xc000965d60, 0x20}, {0xc000d9bb00, 0x38}, 0x0}, 0x0)
	github.com/future-architect/vuls/detector/vuls2/db.go:53 +0x3ab
github.com/future-architect/vuls/detector/vuls2.Detect(0xc000eef808, {{0xc000965d60, 0x20}, {0xc000d9bb00, 0x38}, 0x0}, 0x0?)
	github.com/future-architect/vuls/detector/vuls2/vuls2.go:59 +0x166
github.com/future-architect/vuls/detector.DetectPkgCves(0xc000eef808, {{{0x4b9d96c, 0x8}, {0xc000de00f2, 0x7}, {0x0, 0x0}, {0xc000dd2740, 0x3d}, 0x0, ...}}, ...)
	github.com/future-architect/vuls/detector/detector.go:330 +0x125
github.com/future-architect/vuls/detector.Detect({0xc000eee008, 0x1, 0x1}, {0xc000e0c5a0, 0x51})
	github.com/future-architect/vuls/detector/detector.go:53 +0x40f
github.com/future-architect/vuls/subcmds.(*ReportCmd).Execute(0xc000dc22d0, {0xc0001b4d40?, 0xc000b0fd90?}, 0xc0007b6380, {0x1?, 0x415dbe0?, 0xc000b0fd01?})
	github.com/future-architect/vuls/subcmds/report.go:282 +0xa6d
github.com/google/subcommands.(*Commander).Execute(0xc0001b2700, {0x5d6edb0, 0x896f520}, {0x0, 0x0, 0x0})
	github.com/google/subcommands@v1.2.0/subcommands.go:209 +0x37a
github.com/google/subcommands.Execute(...)
	github.com/google/subcommands@v1.2.0/subcommands.go:492
main.main()
	github.com/future-architect/vuls/cmd/vuls/main.go:37 +0x1794
```

## after
```console
$ vuls report --refresh-cve 2025-05-22T00-00-00+0900
[May 22 02:33:12]  INFO [localhost] vuls-v0.32.0-build-20250522_023226_532bc01
[May 22 02:33:12]  INFO [localhost] Validating config...
[May 22 02:33:12]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/cve.sqlite3
[May 22 02:33:12]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/oval.sqlite3
[May 22 02:33:12]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/gost.sqlite3
[May 22 02:33:12]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/go-exploitdb.sqlite3
[May 22 02:33:12]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/go-msfdb.sqlite3
[May 22 02:33:12]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/go-kev.sqlite3
[May 22 02:33:12]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/go-cti.sqlite3
[May 22 02:33:12]  INFO [localhost] Loaded: /home/mainek00n/github/github.com/MaineK00n/vuls/results/2025-05-22T00-00-00+0900
[May 22 02:33:12]  INFO [localhost] Fetching vuls2 db. repository: ghcr.io/vulsio/vuls-nightly-db:0
⠴ fetching (353 MB, 141 MB/s) [2s] 
[May 22 02:33:20]  INFO [localhost] rhel_90: 3715 CVEs are detected with vuls2
...
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

