### PR TITLE
fix(scanner/windows): print debug log in detect

### DIFF
--- a/scanner/windows.go
+++ b/scanner/windows.go
@@ -81,7 +81,7 @@ func detectWindows(c config.ServerInfo) (bool, osTypeInterface) {
 			return true, w
 		}
 
-		w.log.Debugf("osInfo(Registry): %+v", osInfo)
+		logging.Log.Debugf("osInfo(Registry): %+v", osInfo)
 		release, err := detectOSName(osInfo)
 		if err != nil {
 			w.setErrs([]error{xerrors.Errorf("Failed to detect os name. err: %w", err)})
@@ -99,7 +99,7 @@ func detectWindows(c config.ServerInfo) (bool, osTypeInterface) {
 			return true, w
 		}
 
-		w.log.Debugf("osInfo(Get-ComputerInfo): %+v", osInfo)
+		logging.Log.Debugf("osInfo(Get-ComputerInfo): %+v", osInfo)
 		release, err := detectOSName(osInfo)
 		if err != nil {
 			w.setErrs([]error{xerrors.Errorf("Failed to detect os name. err: %w", err)})
@@ -117,7 +117,7 @@ func detectWindows(c config.ServerInfo) (bool, osTypeInterface) {
 			return true, w
 		}
 
-		w.log.Debugf("osInfo(Get-WmiObject): %+v", osInfo)
+		logging.Log.Debugf("osInfo(Get-WmiObject): %+v", osInfo)
 		release, err := detectOSName(osInfo)
 		if err != nil {
 			w.setErrs([]error{xerrors.Errorf("Failed to detect os name. err: %w", err)})
@@ -135,7 +135,7 @@ func detectWindows(c config.ServerInfo) (bool, osTypeInterface) {
 			return true, w
 		}
 
-		w.log.Debugf("osInfo(systeminfo.exe): %+v", osInfo)
+		logging.Log.Debugf("osInfo(systeminfo.exe): %+v", osInfo)
 		release, err := detectOSName(osInfo)
 		if err != nil {
 			w.setErrs([]error{xerrors.Errorf("Failed to detect os name. err: %w", err)})


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Fixes #2231 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## setup
```console
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[server.windows]
host = "127.0.0.1"
port = "2222"
user = "vagrant"
keyPath = "/home/vuls/vuls-targets-docker/.ssh/id_rsa"
scanMode           = ["fast"]
scanModules        = ["ospkg"]
EOS
```

## before
```console
$ vuls scan -debug 2>&1 | grep -A 2 "osInfo(Registry):"
(empty)
```

## after
```console
$ vuls scan -debug 2>&1 | grep -A 2 "osInfo(Registry):"
time="Jun  9 12:12:05" level=debug msg="osInfo(Registry): {productName:Windows Server 2022 Standard Evaluation version:10.0 build:20348 revision:2159 edition:ServerStandardEval servicePack: arch:x64-based installationType:Server}" 
time="Jun  9 12:12:05" level=debug msg="Windows. Host: 127.0.0.1:2222" 
time="Jun  9 12:12:05" level=info msg="(1/1) Detected: vagrant: windows Windows Server 2022"
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

