### PR TITLE
feat(reporter): add row separator for --format-list

### DIFF
--- a/reporter/util.go
+++ b/reporter/util.go
@@ -308,7 +308,8 @@ No CVE-IDs are found in updatable packages.
 	b := bytes.Buffer{}
 	table := tablewriter.NewTable(&b,
 		tablewriter.WithRenderer(renderer.NewBlueprint(tw.Rendition{
-			Symbols: tw.NewSymbols(tw.StyleASCII),
+			Symbols:  tw.NewSymbols(tw.StyleASCII),
+			Settings: tw.Settings{Separators: tw.Separators{BetweenRows: tw.On}},
 		})),
 		tablewriter.WithMaxWidth(terminalWidth()),
 		tablewriter.WithHeaderAutoFormat(tw.Off),


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

add row separator for --format-list

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
## v0.32.0
```console
$ vuls report
[Jun 13 08:10:19]  INFO [localhost] vuls-0.32.0-6accfb855ea1523c5a70b79c30c5430fd3b7a1a5-2025-05-16T07:24:16Z
...
rhel_90 (redhat9.0)
===================
Total: 3715 (Critical:4 High:524 Medium:3058 Low:116 ?:13)
1983/3715 Fixed, 0 poc, 0 exploits, 0 kevs, uscert: 0, jpcert: 0 alerts
496 installed

+------------------+------+--------+-----+-----+-----------+---------+-------------------------------------+
|      CVE-ID      | CVSS | ATTACK | POC | KEV |   ALERT   |  FIXED  |              PACKAGES               |
+------------------+------+--------+-----+-----+-----------+---------+-------------------------------------+
| CVE-2022-32207   |  9.8 |  AV:N  |     |     |           |   fixed | curl, libcurl                       |
+------------------+------+--------+-----+-----+-----------+---------+-------------------------------------+
| CVE-2023-38408   |  9.8 |  AV:N  |     |     |           |   fixed | openssh, openssh-clients,           |
|                  |      |        |     |     |           |         | openssh-server                      |
+------------------+------+--------+-----+-----+-----------+---------+-------------------------------------+
| CVE-2023-37920   |  9.1 |  AV:N  |     |     |           |   fixed | ca-certificates                     |
+------------------+------+--------+-----+-----+-----------+---------+-------------------------------------+
| CVE-2024-3596    |  9.0 |  AV:N  |     |     |           |   fixed | krb5-libs                           |
+------------------+------+--------+-----+-----+-----------+---------+-------------------------------------+
| CVE-2022-1271    |  8.8 |  AV:N  |     |     |           |   fixed | gzip, xz, xz-libs                   |
+------------------+------+--------+-----+-----+-----------+---------+-------------------------------------+
| CVE-2022-42898   |  8.8 |  AV:N  |     |     |           |   fixed | krb5-libs                           |
+------------------+------+--------+-----+-----+-----------+---------+-------------------------------------+
| CVE-2023-0767    |  8.8 |  AV:N  |     |     |           |   fixed | nspr, nss, nss-softokn,             |
|                  |      |        |     |     |           |         | nss-softokn-freebl,                 |
|                  |      |        |     |     |           |         | nss-sysinit, nss-util               |
+------------------+------+--------+-----+-----+-----------+---------+-------------------------------------+
| CVE-2023-30079   |  8.8 |  AV:N  |     |     |           |   fixed | libeconf                            |
+------------------+------+--------+-----+-----+-----------+---------+-------------------------------------+
| CVE-2023-39975   |  8.8 |  AV:N  |     |     |           |   fixed | krb5-libs                           |
+------------------+------+--------+-----+-----+-----------+---------+-------------------------------------+
| CVE-2023-44466   |  8.8 |  AV:N  |     |     |           |   fixed | kernel, kernel-core,                |
...
```

## master
```console
$ vuls report
[Jun 13 08:08:11]  INFO [localhost] vuls-v0.32.0-build-20250613_080635_55cabca
...
rhel_90 (redhat9.0)
===================
Total: 3715 (Critical:4 High:524 Medium:3058 Low:116 ?:13)
1983/3715 Fixed, 0 poc, 0 exploits, 0 kevs, uscert: 0, jpcert: 0 alerts
496 installed

+------------------+------+--------+-----+-----+-------+---------+-------------------------------------+
|      CVE-ID      | CVSS | Attack | PoC | KEV | Alert |  Fixed  |              Packages               |
+------------------+------+--------+-----+-----+-------+---------+-------------------------------------+
| CVE-2022-32207   | 9.8  | AV:N   |     |     |       | fixed   | curl, libcurl                       |
| CVE-2023-38408   | 9.8  | AV:N   |     |     |       | fixed   | openssh,                            |
|                  |      |        |     |     |       |         | openssh-clients,                    |
|                  |      |        |     |     |       |         | openssh-server                      |
| CVE-2023-37920   | 9.1  | AV:N   |     |     |       | fixed   | ca-certificates                     |
| CVE-2024-3596    | 9.0  | AV:N   |     |     |       | fixed   | krb5-libs                           |
| CVE-2022-1271    | 8.8  | AV:N   |     |     |       | fixed   | gzip, xz, xz-libs                   |
| CVE-2022-42898   | 8.8  | AV:N   |     |     |       | fixed   | krb5-libs                           |
| CVE-2023-0767    | 8.8  | AV:N   |     |     |       | fixed   | nspr, nss, nss-softokn,             |
|                  |      |        |     |     |       |         | nss-softokn-freebl,                 |
|                  |      |        |     |     |       |         | nss-sysinit, nss-util               |
| CVE-2023-30079   | 8.8  | AV:N   |     |     |       | fixed   | libeconf                            |
| CVE-2023-39975   | 8.8  | AV:N   |     |     |       | fixed   | krb5-libs                           |
| CVE-2023-44466   | 8.8  | AV:N   |     |     |       | fixed   | kernel, kernel-core,                |
...
```

## pr
```console
$ vuls report
...
rhel_90 (redhat9.0)
===================
Total: 3715 (Critical:4 High:524 Medium:3058 Low:116 ?:13)
1983/3715 Fixed, 0 poc, 0 exploits, 0 kevs, uscert: 0, jpcert: 0 alerts
496 installed

+------------------+------+--------+-----+-----+-------+---------+-------------------------------------+
|      CVE-ID      | CVSS | Attack | PoC | KEV | Alert |  Fixed  |              Packages               |
+------------------+------+--------+-----+-----+-------+---------+-------------------------------------+
| CVE-2022-32207   | 9.8  | AV:N   |     |     |       | fixed   | curl, libcurl                       |
+------------------+------+--------+-----+-----+-------+---------+-------------------------------------+
| CVE-2023-38408   | 9.8  | AV:N   |     |     |       | fixed   | openssh,                            |
|                  |      |        |     |     |       |         | openssh-clients,                    |
|                  |      |        |     |     |       |         | openssh-server                      |
+------------------+------+--------+-----+-----+-------+---------+-------------------------------------+
| CVE-2023-37920   | 9.1  | AV:N   |     |     |       | fixed   | ca-certificates                     |
+------------------+------+--------+-----+-----+-------+---------+-------------------------------------+
| CVE-2024-3596    | 9.0  | AV:N   |     |     |       | fixed   | krb5-libs                           |
+------------------+------+--------+-----+-----+-------+---------+-------------------------------------+
| CVE-2022-1271    | 8.8  | AV:N   |     |     |       | fixed   | gzip, xz, xz-libs                   |
+------------------+------+--------+-----+-----+-------+---------+-------------------------------------+
| CVE-2022-42898   | 8.8  | AV:N   |     |     |       | fixed   | krb5-libs                           |
+------------------+------+--------+-----+-----+-------+---------+-------------------------------------+
| CVE-2023-0767    | 8.8  | AV:N   |     |     |       | fixed   | nspr, nss, nss-softokn,             |
|                  |      |        |     |     |       |         | nss-softokn-freebl,                 |
|                  |      |        |     |     |       |         | nss-sysinit, nss-util               |
+------------------+------+--------+-----+-----+-------+---------+-------------------------------------+
| CVE-2023-30079   | 8.8  | AV:N   |     |     |       | fixed   | libeconf                            |
+------------------+------+--------+-----+-----+-------+---------+-------------------------------------+
| CVE-2023-39975   | 8.8  | AV:N   |     |     |       | fixed   | krb5-libs                           |
+------------------+------+--------+-----+-----+-------+---------+-------------------------------------+
| CVE-2023-44466   | 8.8  | AV:N   |     |     |       | fixed   | kernel, kernel-core,                |
...
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
