### PR TITLE
feat(server): open db before starting server

### DIFF
--- a/subcmds/report.go
+++ b/subcmds/report.go
@@ -204,6 +204,7 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 			&config.Conf.Exploit,
 			&config.Conf.Metasploit,
 			&config.Conf.KEVuln,
+			&config.Conf.Cti,
 		} {
 			cnf.Init()
 		}

--- a/subcmds/report_windows.go
+++ b/subcmds/report_windows.go
@@ -201,6 +201,7 @@ func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 			&config.Conf.Exploit,
 			&config.Conf.Metasploit,
 			&config.Conf.KEVuln,
+			&config.Conf.Cti,
 		} {
 			cnf.Init()
 		}

--- a/subcmds/server.go
+++ b/subcmds/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/subcommands"
 
 	"github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/detector"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/server"
 )
@@ -102,6 +103,7 @@ func (p *ServerCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interface{}
 			&config.Conf.Exploit,
 			&config.Conf.Metasploit,
 			&config.Conf.KEVuln,
+			&config.Conf.Cti,
 		} {
 			cnf.Init()
 		}
@@ -115,6 +117,12 @@ func (p *ServerCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interface{}
 	logging.Log.Info("Validating config...")
 	if !config.Conf.ValidateOnReport() {
 		return subcommands.ExitUsageError
+	}
+
+	logging.Log.Info("Validating DBs...")
+	if err := detector.ValidateDBs(config.Conf.CveDict, config.Conf.OvalDict, config.Conf.Gost, config.Conf.Exploit, config.Conf.Metasploit, config.Conf.KEVuln, config.Conf.Cti, config.Conf.LogOpts); err != nil {
+		logging.Log.Errorf("Failed to validate DBs. err: %+v", err)
+		return subcommands.ExitFailure
 	}
 
 	http.Handle("/vuls", server.VulsHandler{


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Fixes #2242 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- test.sh
```bash
#!/bin/bash

# Send concurrent requests to uninitialized databases
curl -X POST -H "Content-Type: application/json" -d @//home/vuls/integration/data/results/ubuntu_2204.json http://localhost:5515/vuls &
curl -X POST -H "Content-Type: application/json" -d @//home/vuls/integration/data/results/ubuntu_2204.json http://localhost:5515/vuls & 
wait
```

## before
```console
$ rm *.sqlite3

$ vuls server
[Jun 16 18:55:15]  INFO [localhost] vuls-0.32.0-6accfb855ea1523c5a70b79c30c5430fd3b7a1a5-2025-05-16T07:24:16Z
[Jun 16 18:55:15]  INFO [localhost] Validating config...
[Jun 16 18:55:15]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/home/vuls/cve.sqlite3
[Jun 16 18:55:15]  WARN [localhost] cveDict.SQLite3Path=/home/vuls/cve.sqlite3 file not found
[Jun 16 18:55:15]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/vuls/oval.sqlite3
[Jun 16 18:55:15]  WARN [localhost] ovalDict.SQLite3Path=/home/vuls/oval.sqlite3 file not found
[Jun 16 18:55:15]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/home/vuls/gost.sqlite3
[Jun 16 18:55:15]  WARN [localhost] gost.SQLite3Path=/home/vuls/gost.sqlite3 file not found
[Jun 16 18:55:15]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/home/vuls/go-exploitdb.sqlite3
[Jun 16 18:55:15]  WARN [localhost] exploit.SQLite3Path=/home/vuls/go-exploitdb.sqlite3 file not found
[Jun 16 18:55:15]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/home/vuls/go-msfdb.sqlite3
[Jun 16 18:55:15]  WARN [localhost] metasploit.SQLite3Path=/home/vuls/go-msfdb.sqlite3 file not found
[Jun 16 18:55:15]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/home/vuls/go-kev.sqlite3
[Jun 16 18:55:15]  WARN [localhost] kevuln.SQLite3Path=/home/vuls/go-kev.sqlite3 file not found
[Jun 16 18:55:15]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/home/vuls/go-cti.sqlite3
[Jun 16 18:55:15]  WARN [localhost] cti.SQLite3Path=/home/vuls/go-cti.sqlite3 file not found
[Jun 16 18:55:15]  INFO [localhost] Listening on localhost:5515

($ ls *.sqlite3)
ls: cannot access '*.sqlite3': No such file or directory

($ ./test.sh)
[Jun 16 18:55:20] ERROR [localhost] Failed to detect Pkg CVE: Failed to detect CVE with OVAL:
    github.com/future-architect/vuls/detector.DetectPkgCves
        github.com/future-architect/vuls/detector/detector.go:336
  - Failed to newOvalDB. err:
    github.com/future-architect/vuls/oval.NewOVALClient
        github.com/future-architect/vuls/oval/util.go:653
  - Failed to init OVAL DB. DB Path: /home/vuls/oval.sqlite3, err:
    github.com/future-architect/vuls/oval.newOvalDB
        github.com/future-architect/vuls/oval/oval.go:194
  - Failed to migrate db. err:
    github.com/vulsio/goval-dictionary/db.NewDB
        github.com/vulsio/goval-dictionary@v0.12.0/db/db.go:56
  - Failed to migrate. err:
    github.com/vulsio/goval-dictionary/db.(*RDBDriver).MigrateDB
        github.com/vulsio/goval-dictionary@v0.12.0/db/rdb.go:161
  - SQL logic error: table `fetch_meta` already exists (1)
[Jun 16 18:55:20]  INFO [localhost] Skip OVAL and Scan with gost alone.
[Jun 16 18:55:20]  INFO [localhost] ubuntu_2204: 0 CVEs are detected with OVAL
[Jun 16 18:55:21]  INFO [localhost] ubuntu_2204: 0 CVEs are detected with gost
[Jun 16 18:55:21]  INFO [localhost] Fill CVE detailed with gost
[Jun 16 18:55:21]  INFO [localhost] Fill CVE detailed with CVE-DB
[Jun 16 18:55:25]  INFO [localhost] ubuntu_2204: 0 PoC detected
[Jun 16 18:55:25]  INFO [localhost] ubuntu_2204: 0 exploits are detected
[Jun 16 18:55:25]  INFO [localhost] ubuntu_2204: Known Exploited Vulnerabilities are detected for 0 CVEs
[Jun 16 18:55:27]  INFO [localhost] ubuntu_2204: Cyber Threat Intelligences are detected for 0 CVEs
[Jun 16 18:55:27]  INFO [localhost] ubuntu_2204: total 0 CVEs detected
[Jun 16 18:55:27]  INFO [localhost] ubuntu_2204: 0 CVEs filtered by --confidence-over=80
```

## after
```console
$ rm *.sqlite3

$ vuls server
[Jun 16 18:56:36]  INFO [localhost] vuls-v0.32.0-build-20250616_182742_25ae497
[Jun 16 18:56:36]  INFO [localhost] Validating config...
[Jun 16 18:56:36]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/home/vuls/cve.sqlite3
[Jun 16 18:56:36]  WARN [localhost] cveDict.SQLite3Path=/home/vuls/cve.sqlite3 file not found
[Jun 16 18:56:36]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/vuls/oval.sqlite3
[Jun 16 18:56:36]  WARN [localhost] ovalDict.SQLite3Path=/home/vuls/oval.sqlite3 file not found
[Jun 16 18:56:36]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/home/vuls/gost.sqlite3
[Jun 16 18:56:36]  WARN [localhost] gost.SQLite3Path=/home/vuls/gost.sqlite3 file not found
[Jun 16 18:56:36]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/home/vuls/go-exploitdb.sqlite3
[Jun 16 18:56:36]  WARN [localhost] exploit.SQLite3Path=/home/vuls/go-exploitdb.sqlite3 file not found
[Jun 16 18:56:36]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/home/vuls/go-msfdb.sqlite3
[Jun 16 18:56:36]  WARN [localhost] metasploit.SQLite3Path=/home/vuls/go-msfdb.sqlite3 file not found
[Jun 16 18:56:36]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/home/vuls/go-kev.sqlite3
[Jun 16 18:56:36]  WARN [localhost] kevuln.SQLite3Path=/home/vuls/go-kev.sqlite3 file not found
[Jun 16 18:56:36]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/home/vuls/go-cti.sqlite3
[Jun 16 18:56:36]  WARN [localhost] cti.SQLite3Path=/home/vuls/go-cti.sqlite3 file not found
[Jun 16 18:56:36]  INFO [localhost] Validating DBs...
[Jun 16 18:56:44]  INFO [localhost] Listening on localhost:5515

($ ls *.sqlite3)
cve.sqlite3  go-cti.sqlite3  go-exploitdb.sqlite3  go-kev.sqlite3  go-msfdb.sqlite3  gost.sqlite3  oval.sqlite

($ ./test.sh)
[Jun 16 18:57:57]  INFO [localhost] Skip OVAL and Scan with gost alone.
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: 0 CVEs are detected with OVAL
[Jun 16 18:57:57]  INFO [localhost] Skip OVAL and Scan with gost alone.
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: 0 CVEs are detected with OVAL
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: 0 CVEs are detected with gost
[Jun 16 18:57:57]  INFO [localhost] Fill CVE detailed with gost
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: 0 CVEs are detected with gost
[Jun 16 18:57:57]  INFO [localhost] Fill CVE detailed with gost
[Jun 16 18:57:57]  INFO [localhost] Fill CVE detailed with CVE-DB
[Jun 16 18:57:57]  INFO [localhost] Fill CVE detailed with CVE-DB
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: 0 PoC detected
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: 0 exploits are detected
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: Known Exploited Vulnerabilities are detected for 0 CVEs
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: 0 PoC detected
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: 0 exploits are detected
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: Known Exploited Vulnerabilities are detected for 0 CVEs
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: Cyber Threat Intelligences are detected for 0 CVEs
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: total 0 CVEs detected
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: 0 CVEs filtered by --confidence-over=80
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: Cyber Threat Intelligences are detected for 0 CVEs
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: total 0 CVEs detected
[Jun 16 18:57:57]  INFO [localhost] ubuntu_2204: 0 CVEs filtered by --confidence-over=80
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES  

# Reference

