### PR TITLE
fix(subcmds/saas): remove timestamped directory in results-dir 

### DIFF
--- a/subcmds/saas.go
+++ b/subcmds/saas.go
@@ -82,6 +82,15 @@ func (p *SaaSCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 		return subcommands.ExitFailure
 	}
 
+	defer func() {
+		if config.Conf.Debug {
+			return
+		}
+		if err := os.RemoveAll(dir); err != nil {
+			logging.Log.Warnf("Failed to remove %q. err: %+v", dir, err)
+		}
+	}()
+
 	logging.Log.Info("Validating config...")
 	if !config.Conf.ValidateOnSaaS() {
 		return subcommands.ExitUsageError
@@ -132,12 +141,6 @@ func (p *SaaSCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) 
 
 	if hasError {
 		return subcommands.ExitFailure
-	}
-
-	if !config.Conf.Debug {
-		if err := os.RemoveAll(dir); err != nil {
-			logging.Log.Warnf("Failed to remove %s. err: %+v", dir, err)
-		}
 	}
 
 	return subcommands.ExitSuccess


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:
- WHY
  - In the previous implementation, the results directory was not deleted when an upload failed. This could cause stale files from the failed run to be included in subsequent processes, potentially leading to inaccurate results.

- WHAT
  - Updated the logic to purge the results directory after each upload attempt, regardless of whether the upload succeeds or fails.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## Before

```
./vuls -v
vuls v0.29.0 build-4e3ee6a
```
```
ls
2025-06-19T11-36-43+0900  2025-06-20T14-58-57+0900
```
```
./vuls saas
[Jun 20 15:06:29]  INFO [localhost] vuls-v0.29.0-build-4e3ee6a
[Jun 20 15:06:29]  INFO [localhost] Validating config...
[Jun 20 15:06:29]  INFO [localhost] Loaded: /XXX/XXXX/results/2025-06-20T14-58-57+0900
[Jun 20 15:06:35]  INFO [localhost] Uploading... NOTE12794
[Jun 20 15:06:39] ERROR [localhost] Failed to upload. err: Failed to upload data to vuls-results-tmp-prd/1/11118/fa797b8e-2447-ecd4-1e0d-e452ff2472f9.json, err:
    github.com/future-architect/vuls/saas.Writer.Write
        /home/runner/work/futurevuls-backend/futurevuls-backend/scanner-src/saas/saas.go:135
  - operation error S3: PutObject, https response error StatusCode: 0, RequestID: , HostID: , canceled, context deadline exceeded
```
```
ls
2025-06-19T11-36-43+0900  2025-06-20T14-58-57+0900
```

## After

```
./vuls -v
vuls  build-20250619_115602_55cabca
```
```
ls
2025-06-19T11-36-43+0900  2025-06-20T14-58-57+0900
```
```
./vuls saas
[Jun 20 15:25:42]  INFO [localhost] vuls--build-20250619_115602_55cabca
[Jun 20 15:25:42]  INFO [localhost] Validating config...
[Jun 20 15:25:42]  INFO [localhost] Loaded: /XXX/XXXX/results/2025-06-20T14-58-57+0900
[Jun 20 15:25:47]  INFO [localhost] Uploading... NOTE12794
[Jun 20 15:25:52] ERROR [localhost] Failed to upload. err: Failed to upload data to vuls-results-tmp-prd/1/11118/fa797b8e-2447-ecd4-1e0d-e452ff2472f9.json, err:
    github.com/future-architect/vuls/saas.Writer.Write
        github.com/future-architect/vuls/saas/saas.go:138
  - operation error S3: PutObject, https response error StatusCode: 0, RequestID: , HostID: , canceled, context deadline exceeded
```
```
ls
2025-06-19T11-36-43+0900
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES 

# Reference


