### PR TITLE
fix(oval): add pseudo server type in NewOVALClient

### DIFF
--- a/oval/util.go
+++ b/oval/util.go
@@ -529,6 +529,8 @@ func NewOVALClient(family string, cnf config.GovalDictConf, o logging.LogOpts) (
 		return NewSUSE(driver, cnf.GetURL(), constant.SUSEEnterpriseServer), nil
 	case constant.SUSEEnterpriseDesktop:
 		return NewSUSE(driver, cnf.GetURL(), constant.SUSEEnterpriseDesktop), nil
+	case constant.ServerTypePseudo:
+		return NewPseudo(family), nil
 	default:
 		if family == "" {
 			return nil, xerrors.New("Probably an error occurred during scanning. Check the error message")


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Fixes #2253 

In this commit, ServerTypePseudo was removed from NewOVALClient:
https://github.com/future-architect/vuls/commit/9c8fd04a0428107b136a3dba4a83cebd75758752#diff-c38ba8400657a4caf68a8813319549c02e254e9ccb12099f6d3dba39bbf81ddeL688-L689

As a result, an error occurred when opening the database before starting the server, because the family used at that time was ServerTypePseudo:
https://github.com/future-architect/vuls/commit/28e3ff59f4c479c726fbf3f3c486b0d4f119a90b#diff-ba4491525d7251d0ed3fa7f42df81f3150fa73551b7b4923bd45b14bd283e299R274

Therefore, this PR adds ServerTypePseudo back to NewOVALClient.

Note that this error does not occur during reporting because pseudo servers skip OVAL processing:
https://github.com/future-architect/vuls/blob/c40e7e8eb0049076bdded96a5d8b045428ef04cb/detector/detector.go#L380-L382

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## before
```console
$ vuls server
[Jul  1 10:55:41]  INFO [localhost] vuls-0.33.1-c40e7e8eb0049076bdded96a5d8b045428ef04cb-2025-06-25T04:33:59Z
[Jul  1 10:55:41]  INFO [localhost] Validating config...
[Jul  1 10:55:41]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/cve.sqlite3
[Jul  1 10:55:41]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/goval-dictionary/oval.sqlite3
[Jul  1 10:55:41]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/gost.sqlite3
[Jul  1 10:55:41]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/go-exploitdb.sqlite3
[Jul  1 10:55:41]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/go-msfdb.sqlite3
[Jul  1 10:55:41]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/go-kev.sqlite3
[Jul  1 10:55:41]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/go-cti.sqlite3
[Jul  1 10:55:41]  INFO [localhost] Validating DBs...
[Jul  1 10:55:41] ERROR [localhost] Failed to validate DBs. err: Failed to new OVAL client. err:
    github.com/future-architect/vuls/detector.ValidateDBs
        github.com/future-architect/vuls/detector/util.go:276
  - OVAL for pseudo is not implemented yet:
    github.com/future-architect/vuls/oval.NewOVALClient
        github.com/future-architect/vuls/oval/util.go:536
```

## after
```console
$ vuls server
[Jul  1 10:56:24]  INFO [localhost] vuls-v0.33.1-build-20250701_105326_64dffcf
[Jul  1 10:56:24]  INFO [localhost] Validating config...
[Jul  1 10:56:24]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/cve.sqlite3
[Jul  1 10:56:24]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/goval-dictionary/oval.sqlite3
[Jul  1 10:56:24]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/gost.sqlite3
[Jul  1 10:56:24]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/go-exploitdb.sqlite3
[Jul  1 10:56:24]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/go-msfdb.sqlite3
[Jul  1 10:56:24]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/go-kev.sqlite3
[Jul  1 10:56:24]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/home/mainek00n/github/github.com/MaineK00n/vuls/go-cti.sqlite3
[Jul  1 10:56:24]  INFO [localhost] Validating DBs...
[Jul  1 10:56:24]  INFO [localhost] Listening on localhost:5515

$ curl -s http://localhost:5515/health
ok
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

