### PR TITLE
fix(ci): add contrib to dependabot's docker settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,9 @@ updates:
           - "*"
     target-branch: master
   - package-ecosystem: docker
-    directory: /
+    directories:
+      - /
+      - /contrib
     schedule:
       interval: "monthly"
     groups:


### PR DESCRIPTION
# What did you implement:

Publish Docker image action failed:
https://github.com/future-architect/vuls/actions/runs/16016441115/job/45183876489

Dockerfile at the root directory was updated in https://github.com/future-architect/vuls/pull/2235/files but contrib/Dockerfile was not.

This PR adds contrib/ to dependabot's settings for both to be updated.

`directories` setting item is described here: 
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference?learn=dependency_version_updates&learnProduct=code-security#directories-or-directory--

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Waiting dep-bot work 🤞 

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

