### PR TITLE
fix(scanner/windows): do not format arch in parseRegistry

### DIFF
--- a/scanner/windows.go
+++ b/scanner/windows.go
@@ -568,11 +568,7 @@ func parseRegistry(stdout string) (osInfo, error) {
 			if !found {
 				return osInfo{}, xerrors.Errorf(`Failed to detect PROCESSOR_ARCHITECTURE. expected: "PROCESSOR_ARCHITECTURE : <PROCESSOR_ARCHITECTURE>", line: "%s"`, line)
 			}
-			formatted, err := formatArch(strings.TrimSpace(rhs))
-			if err != nil {
-				return osInfo{}, xerrors.Errorf("Failed to format arch. arch: %s, err: %w", strings.TrimSpace(rhs), err)
-			}
-			o.arch = formatted
+			o.arch = strings.TrimSpace(rhs)
 		default:
 		}
 	}
@@ -620,7 +616,12 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 			default:
 				n = "Microsoft Windows XP"
 			}
-			switch osInfo.arch {
+			arch, err := formatArch(osInfo.arch)
+			if err != nil {
+				return "", xerrors.Errorf("Failed to format architecture: %w", err)
+			}
+
+			switch arch {
 			case "x64-based":
 				n = fmt.Sprintf("%s x64 Edition", n)
 			}
@@ -643,7 +644,11 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 			default:
 				n = "Microsoft Windows XP"
 			}
-			switch osInfo.arch {
+			arch, err := formatArch(osInfo.arch)
+			if err != nil {
+				return "", xerrors.Errorf("Failed to format architecture: %w", err)
+			}
+			switch arch {
 			case "x64-based":
 				n = fmt.Sprintf("%s x64 Edition", n)
 			}
@@ -656,7 +661,11 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 			if strings.Contains(osInfo.productName, "R2") {
 				n = "Microsoft Windows Server 2003 R2"
 			}
-			switch osInfo.arch {
+			arch, err := formatArch(osInfo.arch)
+			if err != nil {
+				return "", xerrors.Errorf("Failed to format architecture: %w", err)
+			}
+			switch arch {
 			case "x64-based":
 				n = fmt.Sprintf("%s x64 Edition", n)
 			case "Itanium-based":
@@ -675,7 +684,11 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 		switch osInfo.installationType {
 		case "Client":
 			var n string
-			switch osInfo.arch {
+			arch, err := formatArch(osInfo.arch)
+			if err != nil {
+				return "", xerrors.Errorf("Failed to format architecture: %w", err)
+			}
+			switch arch {
 			case "x64-based":
 				n = "Windows Vista x64 Editions"
 			default:
@@ -688,7 +701,7 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 		case "Server", "Domain Controller":
 			arch, err := formatArch(osInfo.arch)
 			if err != nil {
-				return "", err
+				return "", xerrors.Errorf("Failed to format architecture: %w", err)
 			}
 			if osInfo.servicePack != "" {
 				return fmt.Sprintf("Windows Server 2008 for %s Systems %s", arch, osInfo.servicePack), nil
@@ -697,7 +710,7 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 		case "Server Core":
 			arch, err := formatArch(osInfo.arch)
 			if err != nil {
-				return "", err
+				return "", xerrors.Errorf("Failed to format architecture: %w", err)
 			}
 			if osInfo.servicePack != "" {
 				return fmt.Sprintf("Windows Server 2008 for %s Systems %s (Server Core installation)", arch, osInfo.servicePack), nil
@@ -709,7 +722,7 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 		case "Client":
 			arch, err := formatArch(osInfo.arch)
 			if err != nil {
-				return "", err
+				return "", xerrors.Errorf("Failed to format architecture: %w", err)
 			}
 			if osInfo.servicePack != "" {
 				return fmt.Sprintf("Windows 7 for %s Systems %s", arch, osInfo.servicePack), nil
@@ -718,7 +731,7 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 		case "Server", "Domain Controller":
 			arch, err := formatArch(osInfo.arch)
 			if err != nil {
-				return "", err
+				return "", xerrors.Errorf("Failed to format architecture: %w", err)
 			}
 			if osInfo.servicePack != "" {
 				return fmt.Sprintf("Windows Server 2008 R2 for %s Systems %s", arch, osInfo.servicePack), nil
@@ -727,7 +740,7 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 		case "Server Core":
 			arch, err := formatArch(osInfo.arch)
 			if err != nil {
-				return "", err
+				return "", xerrors.Errorf("Failed to format architecture: %w", err)
 			}
 			if osInfo.servicePack != "" {
 				return fmt.Sprintf("Windows Server 2008 R2 for %s Systems %s (Server Core installation)", arch, osInfo.servicePack), nil
@@ -739,7 +752,7 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 		case "Client":
 			arch, err := formatArch(osInfo.arch)
 			if err != nil {
-				return "", err
+				return "", xerrors.Errorf("Failed to format architecture: %w", err)
 			}
 			return fmt.Sprintf("Windows 8 for %s Systems", arch), nil
 		case "Server", "Domain Controller":
@@ -752,7 +765,7 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 		case "Client":
 			arch, err := formatArch(osInfo.arch)
 			if err != nil {
-				return "", err
+				return "", xerrors.Errorf("Failed to format architecture: %w", err)
 			}
 			return fmt.Sprintf("Windows 8.1 for %s Systems", arch), nil
 		case "Server", "Domain Controller":
@@ -766,22 +779,22 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 			if strings.Contains(osInfo.productName, "Windows 11") {
 				arch, err := formatArch(osInfo.arch)
 				if err != nil {
-					return "", err
+					return "", xerrors.Errorf("Failed to format architecture: %w", err)
 				}
 				name, err := formatNamebyBuild("11", osInfo.build)
 				if err != nil {
-					return "", err
+					return "", xerrors.Errorf("Failed to format name by build: %w", err)
 				}
 				return fmt.Sprintf("%s for %s Systems", name, arch), nil
 			}
 
 			arch, err := formatArch(osInfo.arch)
 			if err != nil {
-				return "", err
+				return "", xerrors.Errorf("Failed to format architecture: %w", err)
 			}
 			name, err := formatNamebyBuild("10", osInfo.build)
 			if err != nil {
-				return "", err
+				return "", xerrors.Errorf("Failed to format name by build: %w", err)
 			}
 			return fmt.Sprintf("%s for %s Systems", name, arch), nil
 		case "Server", "Nano Server", "Domain Controller":
@@ -789,7 +802,7 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 		case "Server Core":
 			name, err := formatNamebyBuild("Server", osInfo.build)
 			if err != nil {
-				return "", err
+				return "", xerrors.Errorf("Failed to format name by build: %w", err)
 			}
 			return fmt.Sprintf("%s (Server Core installation)", name), nil
 		}
@@ -808,7 +821,7 @@ func formatArch(arch string) (string, error) {
 	case "x86", "X86-based":
 		return "32-bit", nil
 	default:
-		return "", xerrors.New("CPU Architecture not found")
+		return "", xerrors.Errorf("CPU Architecture not found. expected: %q, actual: %q", []string{"AMD64", "x64-based", "ARM64", "ARM64-based", "IA64", "Itanium-based", "x86", "X86-based"}, arch)
 	}
 }
 

--- a/scanner/windows_test.go
+++ b/scanner/windows_test.go
@@ -333,7 +333,7 @@ PROCESSOR_ARCHITECTURE : AMD64
 				revision:         "2364",
 				edition:          "Professional",
 				servicePack:      "",
-				arch:             "x64-based",
+				arch:             "AMD64",
 				installationType: "Client",
 			},
 		},
@@ -376,6 +376,20 @@ func Test_detectOSName(t *testing.T) {
 		{
 			name: "Windows 10 Version 21H2 for x64-based Systems",
 			args: osInfo{
+				productName:      "Windows 10 Pro",
+				version:          "10.0",
+				build:            "19044",
+				revision:         "2364",
+				edition:          "Professional",
+				servicePack:      "",
+				arch:             "AMD64",
+				installationType: "Client",
+			},
+			want: "Windows 10 Version 21H2 for x64-based Systems",
+		},
+		{
+			name: "Windows 10 Version 21H2 for x64-based Systems",
+			args: osInfo{
 				productName:      "Microsoft Windows 10 Pro",
 				version:          "10.0",
 				build:            "19044",
@@ -386,6 +400,20 @@ func Test_detectOSName(t *testing.T) {
 				installationType: "Client",
 			},
 			want: "Windows 10 Version 21H2 for x64-based Systems",
+		},
+		{
+			name: "Windows 10 Version 22H2 for 32-bit Systems",
+			args: osInfo{
+				productName:      "Windows 10 Pro",
+				version:          "10.0",
+				build:            "19045",
+				revision:         "6093",
+				edition:          "Professional",
+				servicePack:      "",
+				arch:             "x86",
+				installationType: "Client",
+			},
+			want: "Windows 10 Version 22H2 for 32-bit Systems",
 		},
 		{
 			name: "Windows 11 Version 21H2 for x64-based Systems",


### PR DESCRIPTION
During scanning an 32-bit windows machine, "Failed to detect os name." error occured. By investigation, it is found that formatArch function is called twice during scanning. When first time it is called, it converts the os arch string to "32-bit" , but when it is called second time, with input string 32-bit, it returns "unknown architecture" as there is no switch case to handle "32-bit" case. formatArch function is updated to match proper "x86" or "32-bit" switch case and make the scan to progress and successful.

time="Jul 17 10:34:40" level=info msg="Detecting OS of servers... "
time="Jul 17 10:34:52" level=error msg="(1/1) Failed: 127.0.0.1, err: [Failed to detect os name. err:\n github.com/future-architect/vuls/scanner.detectWindows\n C:/Users/Administrator/Desktop/asd/vuls/scanner/windows.go:87\n - Failed to detect OS Name from OSInfo: {productName:Windows 10 Pro version:10.0 build:19045 revision:6093 edition:Professional servicePack: arch:32-bit installationType:Client}, err:\n github.com/future-architect/vuls/scanner.detectOSName\n C:/Users/Administrator/Desktop/asd/vuls/scanner/windows.go:589\n - CPU Architecture not found:\n github.com/future-architect/vuls/scanner.formatArch\n C:/Users/Administrator/Desktop/asd/vuls/scanner/windows.go:811]"

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

by unit test

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** 
YES

