### PR TITLE
fix(scanner/lockfile): view lockfiles according to permissions in local scan

### DIFF
--- a/scanner/base.go
+++ b/scanner/base.go
@@ -712,21 +712,6 @@ func (l *base) scanLibraries() (err error) {
 
 		l.log.Debugf("Analyzing file: %s", abspath)
 		filemode, contents, err := func() (os.FileMode, []byte, error) {
-			if isLocalExec(l.getServerInfo().Port, l.getServerInfo().Host) {
-				fileinfo, err := os.Stat(abspath)
-				if err != nil {
-					return os.FileMode(0000), nil, xerrors.Errorf("Failed to get target file info. filepath: %s, err: %w", abspath, err)
-				}
-				filemode := fileinfo.Mode().Perm()
-
-				contents, err := os.ReadFile(abspath)
-				if err != nil {
-					return os.FileMode(0000), nil, xerrors.Errorf("Failed to read target file contents. filepath: %s, err: %w", abspath, err)
-				}
-
-				return filemode, contents, nil
-			}
-
 			r := l.exec(fmt.Sprintf(`stat -c "%%a" %s`, abspath), priv)
 			if !r.isSuccess() {
 				return os.FileMode(0000), nil, xerrors.Errorf("Failed to get target file permission. filepath: %s, err: %w", abspath, err)

--- a/scanner/windows.go
+++ b/scanner/windows.go
@@ -5041,21 +5041,7 @@ func (w *windows) scanLibraries() (err error) {
 
 		w.log.Debugf("Analyzing file: %s", abspath)
 		filemode, contents, err := func() (os.FileMode, []byte, error) {
-			if isLocalExec(w.getServerInfo().Port, w.getServerInfo().Host) {
-				fileinfo, err := os.Stat(abspath)
-				if err != nil {
-					return os.FileMode(0000), nil, xerrors.Errorf("Failed to get target file info. filepath: %s, err: %w", abspath, err)
-				}
-				filemode := fileinfo.Mode().Perm()
-
-				contents, err := os.ReadFile(abspath)
-				if err != nil {
-					return os.FileMode(0000), nil, xerrors.Errorf("Failed to read target file contents. filepath: %s, err: %w", abspath, err)
-				}
-
-				return filemode, contents, nil
-			}
-
+			// set dummy filemode because Windows file permission is complex and converting them to unix permission is difficult
 			filemode := os.FileMode(0666)
 
 			r := w.exec(w.translateCmd(fmt.Sprintf("Get-Content %s", abspath)), priv)


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Fixes #2289 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## setup
```console
$ mkdir -p data/lockfile
$ curl -sL --output data/lockfile/log4j-core-2.13.0.jar https://github.com/vulsio/integration/raw/refs/heads/main/data/lockfile/log4j-core-2.13.0.jar
$ chmod 744 data/lockfile
$ sudo chown -R root:root data

// log4j-core-2.13.0.jar is not visible because there is no permission to search the lockfile directory.
$ tree data
data
└── lockfile

1 directory, 0 files

// log4j-core-2.13.0.jar is visible
$ sudo tree data
data
└── lockfile
    └── log4j-core-2.13.0.jar

1 directory, 1 file

$ cat config.toml
[servers]

[servers.localhost]
host = "localhost"
port = "local"
scanMode           = ["fast-root"]
scanModules        = ["lockfile"]
```

## before
```console
$ vuls scan
[Aug 15 20:32:14]  INFO [localhost] vuls-0.33.2-d79cf40de3422117f8ff428d53665abdb08f7afc-2025-07-02T04:55:24Z
[Aug 15 20:32:14]  INFO [localhost] Start scanning
[Aug 15 20:32:14]  INFO [localhost] config: /home/vuls/config.toml
[Aug 15 20:32:14]  INFO [localhost] Validating config...
[Aug 15 20:32:14]  INFO [localhost] Detecting Server/Container OS... 
[Aug 15 20:32:14]  INFO [localhost] Detecting OS of servers... 
[Aug 15 20:32:14]  INFO [localhost] (1/1) Detected: localhost: ubuntu 22.04
[Aug 15 20:32:14]  INFO [localhost] Detecting OS of containers... 
[Aug 15 20:32:14]  INFO [localhost] Checking Scan Modes... 
[Aug 15 20:32:14]  INFO [localhost] Detecting Platforms... 
[Aug 15 20:32:16]  INFO [localhost] (1/1) localhost is running on other
[Aug 15 20:32:16]  INFO [localhost] Scanning Language-specific Packages...
[Aug 15 20:32:16]  WARN [localhost] Failed to get target file info. filepath: /home/vuls/data/lockfile/log4j-core-2.13.0.jar, err: stat /home/vuls/data/lockfile/log4j-core-2.13.0.jar: permission denied


Scan Summary
================
localhost	ubuntu22.04	0 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

## after
```console
[Aug 15 20:32:44]  INFO [localhost] vuls-v0.33.2-build-20250815_202028_6a694ab
[Aug 15 20:32:44]  INFO [localhost] Start scanning
[Aug 15 20:32:44]  INFO [localhost] config: /home/vuls/config.toml
[Aug 15 20:32:44]  INFO [localhost] Validating config...
[Aug 15 20:32:44]  INFO [localhost] Detecting Server/Container OS... 
[Aug 15 20:32:44]  INFO [localhost] Detecting OS of servers... 
[Aug 15 20:32:44]  INFO [localhost] (1/1) Detected: localhost: ubuntu 22.04
[Aug 15 20:32:44]  INFO [localhost] Detecting OS of containers... 
[Aug 15 20:32:44]  INFO [localhost] Checking Scan Modes... 
[Aug 15 20:32:44]  INFO [localhost] Detecting Platforms... 
[Aug 15 20:32:46]  INFO [localhost] (1/1) localhost is running on other
[Aug 15 20:32:46]  INFO [localhost] Scanning Language-specific Packages...


Scan Summary
================
localhost	ubuntu22.04	0 installed, 0 updatable	1 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

