### PR TITLE
chore(deps): Force go-getter v1.7.9 to fix CVE-2025-8959

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -247,7 +247,6 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -383,3 +382,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.5.0 // indirect
 )
+
+// To fix CVE-2025-8959, force v1.7.9. Once trivy's fix update is released, we can remove this.
+replace github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.7.9

--- a/go.sum
+++ b/go.sum
@@ -1251,8 +1251,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-getter v1.7.8 h1:mshVHx1Fto0/MydBekWan5zUipGq7jO0novchgMmSiY=
-github.com/hashicorp/go-getter v1.7.8/go.mod h1:2c6CboOEb9jG6YvmC9xdD+tyAFsrUaJPedwXDGr0TM4=
+github.com/hashicorp/go-getter v1.7.9 h1:G9gcjrDixz7glqJ+ll5IWvggSBR+R0B54DSRt4qfdC4=
+github.com/hashicorp/go-getter v1.7.9/go.mod h1:dyFCmT1AQkDfOIt9NH8pw9XBDqNrIKJT5ylbpi7zPNE=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
@@ -1417,8 +1417,6 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
-github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

To fix https://github.com/future-architect/vuls/security/dependabot/212 , force v1.7.9 of go-getter.
The dependency chain is:
```
% go mod why -m github.com/hashicorp/go-getter
# github.com/hashicorp/go-getter
github.com/future-architect/vuls/detector/javadb
github.com/aquasecurity/trivy/pkg/oci
github.com/aquasecurity/trivy/pkg/downloader
github.com/hashicorp/go-getter
```

Once Trivy incorporate the change, we can remove replace line of go.mod.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The library is used in downloading javadb.
Confirmed by scanning `war` server and reporting the result:

```
% ./vuls scan war
[Aug 19 15:53:18]  INFO [localhost] vuls-v0.33.2-build-20250819_155100_9fdd1d0
[Aug 19 15:53:18]  INFO [localhost] Start scanning
[Aug 19 15:53:18]  INFO [localhost] config: /home/shino/g/vuls/config.toml
[Aug 19 15:53:18]  INFO [localhost] Validating config...
[Aug 19 15:53:18]  INFO [localhost] Detecting Server/Container OS...
[Aug 19 15:53:18]  INFO [localhost] Detecting OS of servers...
[Aug 19 15:53:18]  INFO [localhost] (1/1) Detected: war: pseudo
[Aug 19 15:53:18]  INFO [localhost] Detecting OS of containers...
[Aug 19 15:53:18]  INFO [localhost] Checking Scan Modes...
[Aug 19 15:53:18]  INFO [localhost] Detecting Platforms...
[Aug 19 15:53:18]  INFO [localhost] (1/1) war is running on other
[Aug 19 15:53:18]  INFO [war] Scanning listen port...
[Aug 19 15:53:18]  INFO [war] Using Port Scanner: Vuls built-in Scanner
[Aug 19 15:53:18]  INFO [war] Scanning Language-specific Packages...


Scan Summary
================
war     pseudo  0 installed, 0 updatable        79 libs





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
% ./vuls report
[Aug 19 15:53:30]  INFO [localhost] vuls-v0.33.2-build-20250819_155100_9fdd1d0
[Aug 19 15:53:30]  INFO [localhost] Validating config...
[Aug 19 15:53:30]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/data/vulsctl/docker/cve.sqlite3
[Aug 19 15:53:30]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/home/shino/g/goval-dictionary/oval-suse.lo.sqlite3
[Aug 19 15:53:30]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/data/vulsctl/docker/gost.sqlite3
[Aug 19 15:53:30]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/data/vulsctl/docker/go-exploitdb.sqlite3
[Aug 19 15:53:30]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/data/vulsctl/docker/go-msfdb.sqlite3
[Aug 19 15:53:30]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/data/vulsctl/docker/go-kev.sqlite3
[Aug 19 15:53:30]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/data/vulsctl/docker/go-cti.sqlite3
[Aug 19 15:53:30]  INFO [localhost] Loaded: /home/shino/g/vuls/results/2025-08-19T15-53-18+0900
[Aug 19 15:53:30]  INFO [localhost] Updating library db...
[Aug 19 15:53:30]  INFO [localhost] Trivy Java DB Repository: mirror.gcr.io/aquasec/trivy-java-db:1, ghcr.io/aquasecurity/trivy-java-db:1
[Aug 19 15:53:30]  INFO [localhost] Downloading Trivy Java DB...
2025-08-19T15:53:30+09:00       INFO    Downloading artifact... repo="mirror.gcr.io/aquasec/trivy-java-db:1"
766.16 MiB / 766.16 MiB [-------------------------------------------------------------------------------------------------------] 100.00% 6.88 MiB p/s 1m52s
2025-08-19T15:55:32+09:00       INFO    Artifact successfully downloaded        repo="mirror.gcr.io/aquasec/trivy-java-db:1"
[Aug 19 15:55:32]  INFO [localhost] war: 40 CVEs are detected with Library
[Aug 19 15:55:32]  INFO [localhost] pseudo type. Skip OVAL, gost and vuls2 detection
[Aug 19 15:55:32]  INFO [localhost] war: 0 CVEs are detected with CPE
[Aug 19 15:55:33]  INFO [localhost] war: 0 PoC are detected
[Aug 19 15:55:33]  INFO [localhost] war: 0 exploits are detected
[Aug 19 15:55:33]  INFO [localhost] war: Known Exploited Vulnerabilities are detected for 0 CVEs
[Aug 19 15:55:33]  INFO [localhost] war: Cyber Threat Intelligences are detected for 0 CVEs
[Aug 19 15:55:33]  INFO [localhost] war: total 38 CVEs detected
[Aug 19 15:55:33]  INFO [localhost] war: 0 CVEs filtered by --confidence-over=80
war (pseudo)
============
Total: 38 (Critical:6 High:21 Medium:10 Low:1 ?:0)
38/38 Fixed, 8 poc, 0 exploits, 0 kevs, uscert: 0, jpcert: 0 alerts
0 installed, 79 libs

+------------------+------+--------+-----+-----+-------+-------+---------------------------------------------+
|      CVE-ID      | CVSS | Attack | PoC | KEV | Alert | Fixed |                  Packages                   |
+------------------+------+--------+-----+-----+-------+-------+---------------------------------------------+
| CVE-2016-1000027 | 10.0 | AV:N   | POC |     |       | fixed | org.springframework:spring-web              |
+------------------+------+--------+-----+-----+-------+-------+---------------------------------------------+
| CVE-2019-17571   | 10.0 | AV:N   |     |     |       | fixed | log4j:log4j                                 |
+------------------+------+--------+-----+-----+-------+-------+---------------------------------------------+
| CVE-2020-10683   | 10.0 | AV:N   |     |     |       | fixed | dom4j:dom4j                                 |
[snip]
```


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

