### PR TITLE
fix(scanner/lockfile): remove /tmp/trivy-* directory

### DIFF
--- a/scanner/base.go
+++ b/scanner/base.go
@@ -793,6 +793,9 @@ func AnalyzeLibrary(ctx context.Context, path string, contents []byte, filemode 
 		if err != nil {
 			return nil, xerrors.Errorf("Failed to copy file to temp. err: %w", err)
 		}
+		// As of 2025-08-27, tmpFile is not deleted by composite.Cleaup(), so delete it here.
+		defer os.Remove(tmpFilePath)
+
 		if err := composite.CreateLink(analyzerTypes, "", path, tmpFilePath); err != nil {
 			return nil, xerrors.Errorf("Failed to create link. err: %w", err)
 		}

--- a/scanner/trivy/jar/parse.go
+++ b/scanner/trivy/jar/parse.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/digest"
 	"github.com/aquasecurity/trivy/pkg/log"
 	xio "github.com/aquasecurity/trivy/pkg/x/io"
+	xos "github.com/aquasecurity/trivy/pkg/x/os"
 	"github.com/samber/lo"
 	"golang.org/x/xerrors"
 )
@@ -169,7 +170,7 @@ func (p *parser) parseInnerJar(zf *zip.File, rootPath string) ([]jarLibrary, err
 	}
 	defer fr.Close()
 
-	f, err := os.CreateTemp("", "inner-*")
+	f, err := xos.CreateTemp("", "jar-inner-")
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to create tmp file for %s. err: %w", zf.Name, err)
 	}


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Previously, files were saved under `/tmp/analyzer-fs-*/file-*`, and since Cleanup removed `/tmp/analyzer-fs-*`, the cleanup process completed successfully.

However, due to the following commit, `analyzer-composite-*` and `analyzer-file-*` are now placed separately under `/tmp/trivy-*`. Since composite.Cleanup only deletes `analyzer-composite-*`, the `analyzer-file-*` directories remain after each scan.
https://github.com/aquasecurity/trivy/commit/8f5b56005a4e8752976524750089dc9ea2c91e40

Therefore, in this PR, I update the Cleanup process to remove `/tmp/trivy-*`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## setup
```console
$ curl -sL --output log4j-core-2.13.0.jar https://github.com/vulsio/integration/raw/refs/heads/main/data/lockfile/log4j-core-2.13.0.jar
$ curl -sL --output Cargo.lock https://raw.githubusercontent.com/vulsio/integration/refs/heads/main/data/lockfile/Cargo.lock
$ curl -sL --output package-lock.json https://raw.githubusercontent.com/vulsio/integration/refs/heads/main/data/lockfile/npm-v3/package-lock.json

$ cat << EOS > config.toml
version = "v2"

[default]

[servers]
[servers.pseudo]
type = "pseudo"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = [
    "log4j-core-2.13.0.jar",
    "Cargo.lock",
]

[servers.pseudo2]
type = "pseudo"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = [
    "package-lock.json",
]

EOS
```

## before
```console
$ vuls -v
vuls-0.33.3-30a8e70f58bba07a9fd82ef38c18a6f1a3791f51-2025-08-20T10:22:09Z

$ vuls scan

$ ls /tmp | grep trivy
trivy-2259773

$ tree /tmp/trivy-2259773/
/tmp/trivy-2259773/
├── analyzer-file-1562184755
└── analyzer-file-1946164500

0 directories, 2 files
```

## after
```console
$ vuls scan

$ ls /tmp | grep trivy
(empty)
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

