### PR TITLE
chore(deps): add cooldown periods

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: /
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 14
     groups:
       all:
         patterns:
@@ -20,6 +22,8 @@ updates:
       - /contrib
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 14
     groups:
       all:
         patterns:
@@ -30,6 +34,8 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 0 1-7,15-21 * 1" # at 00:00 on the 1st and 3rd Monday of each month
+    cooldown:
+      default-days: 3
     groups:
       vuls:
         patterns:


### PR DESCRIPTION
# What did you implement:

Add cooldown periods to dependabot settings.
- Two weeks for Github actions' SHA pins and docker images
- Three days for go modules

I want to discuss about these numbers.

cf.
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#setting-up-a-cooldown-period-for-dependency-updates

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

