### PR TITLE
chore(deps): revert docker cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,6 @@ updates:
       - /contrib
     schedule:
       interval: "monthly"
-    cooldown:
-      default-days: 14
     groups:
       all:
         patterns:


### PR DESCRIPTION
It looks like a bug, but I want dependabot to run.

cf.
- https://github.com/future-architect/vuls/pull/2311/checks?check_run_id=50097805254
- https://github.com/dependabot/dependabot-core/issues/13039


# What did you implement:

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

