### PR TITLE
fix(scanner): set executed command string

### DIFF
--- a/scanner/executil.go
+++ b/scanner/executil.go
@@ -181,7 +181,7 @@ func localExec(c config.ServerInfo, cmdstr string, sudo bool) (result execResult
 	}
 	result.Stdout = toUTF8(stdoutBuf.String())
 	result.Stderr = toUTF8(stderrBuf.String())
-	result.Cmd = strings.ReplaceAll(cmdstr, "\n", "")
+	result.Cmd = cmd.String()
 	return
 }
 
@@ -275,7 +275,7 @@ func sshExecExternal(c config.ServerInfo, cmdstr string, sudo bool) (result exec
 	result.Container = c.Container
 	result.Host = c.Host
 	result.Port = c.Port
-	result.Cmd = fmt.Sprintf("%s %s", sshBinaryPath, strings.Join(args, " "))
+	result.Cmd = cmd.String()
 	return
 }
 


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

There was an issue where executed commands were not being set properly in the debug log, etc., making the logs unhelpful.

This PR will fix this so that commands are displayed correctly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## local scan
### before
```bash
$ vuls scan -debug
[Sep 13 21:42:26]  INFO [localhost] vuls-0.34.0-5bcf29389a4705ad8aea6db6ce75e9d755ee17fc-2025-09-06T08:12:25Z
...
[Sep 13 21:42:26] DEBUG [localhost] Executing... ls /etc/debian_version
[Sep 13 21:42:26] DEBUG [localhost] execResult: servername: 
  cmd: ls /etc/debian_version
  exitstatus: 0
  stdout: /etc/debian_version

  stderr: 
  err: %!s(<nil>)
```

### after
```bash
$ vuls scan -debug
...
[Sep 13 21:43:36] DEBUG [localhost] execResult: servername: 
  cmd: /bin/sh -c ls /etc/debian_version
  exitstatus: 0
  stdout: /etc/debian_version

  stderr: 
  err: %!s(<nil>)
```

## remote scan
### before
```bash
$ vuls scan -debug
[Sep 13 21:40:10]  INFO [localhost] vuls-0.34.0-5bcf29389a4705ad8aea6db6ce75e9d755ee17fc-2025-09-06T08:12:25Z
...
[Sep 13 21:40:10] DEBUG [localhost] Executing... ls /etc/debian_version
[Sep 13 21:40:10] DEBUG [localhost] execResult: servername: docker
  cmd: /usr/bin/ssh -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/cm-a3722a6d-%C -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -o PasswordAuthentication=no 127.0.0.1
  exitstatus: 0
  stdout: /etc/debian_version

  stderr: stty: 'standard input': Inappropriate ioctl for device

  err: %!s(<nil>)
```

### after
```bash
$ vuls scan -debug
...
[Sep 13 21:41:21] DEBUG [localhost] Executing... ls /etc/debian_version
[Sep 13 21:41:21] DEBUG [localhost] execResult: servername: docker
  cmd: /usr/bin/ssh -o StrictHostKeyChecking=yes -o LogLevel=quiet -o ConnectionAttempts=3 -o ConnectTimeout=10 -o ControlMaster=auto -o ControlPath=/home/mainek00n/.vuls/cm-a3722a6d-%C -o Controlpersist=10m -l root -p 2222 -i /home/mainek00n/github/github.com/MaineK00n/vuls-targets-docker/.ssh/id_rsa -o PasswordAuthentication=no 127.0.0.1 stty cols 1000; ls /etc/debian_version
  exitstatus: 0
  stdout: /etc/debian_version

  stderr: stty: 'standard input': Inappropriate ioctl for device

  err: %!s(<nil>)
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

