### PR TITLE
feat(contrib/snmp2cpe): add timeout, retry option

### DIFF
--- a/contrib/future-vuls/cmd/main.go
+++ b/contrib/future-vuls/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	vulsConfig "github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/contrib/future-vuls/pkg/config"
@@ -32,6 +33,8 @@ var (
 	snmpVersion string
 	proxy       string
 	community   string
+	timeout     time.Duration
+	retry       int
 )
 
 func main() {
@@ -109,7 +112,7 @@ func main() {
 			if community == "" {
 				community = config.Community
 			}
-			if err := discover.ActiveHosts(cidr, outputFile, snmpVersion, community); err != nil {
+			if err := discover.ActiveHosts(cidr, outputFile, snmpVersion, community, timeout, retry); err != nil {
 				fmt.Printf("%v", err)
 				// avoid to display help message
 				os.Exit(1)
@@ -149,8 +152,10 @@ func main() {
 
 	cmdDiscover.PersistentFlags().StringVar(&cidr, "cidr", "", "cidr range")
 	cmdDiscover.PersistentFlags().StringVar(&outputFile, "output", "", "output file")
-	cmdDiscover.PersistentFlags().StringVar(&snmpVersion, "snmp-version", "", "snmp version v1,v2c and v3. default: v2c")
-	cmdDiscover.PersistentFlags().StringVar(&community, "community", "", "snmp community name. default: public")
+	cmdDiscover.PersistentFlags().StringVar(&snmpVersion, "snmp-version", "v2c", "snmp version v1,v2c and v3")
+	cmdDiscover.PersistentFlags().StringVar(&community, "community", "public", "snmp community name")
+	cmdDiscover.PersistentFlags().DurationVar(&timeout, "timeout", time.Duration(2)*time.Second, "snmp timeout")
+	cmdDiscover.PersistentFlags().IntVar(&retry, "retry", 3, "snmp retry")
 
 	cmdAddCpe.PersistentFlags().StringVarP(&token, "token", "t", "", "future vuls token ENV: VULS_TOKEN")
 	cmdAddCpe.PersistentFlags().StringVar(&outputFile, "output", "", "output file")

--- a/contrib/future-vuls/pkg/discover/discover.go
+++ b/contrib/future-vuls/pkg/discover/discover.go
@@ -16,7 +16,7 @@ import (
 )
 
 // ActiveHosts ...
-func ActiveHosts(cidr string, outputFile string, snmpVersion string, community string) error {
+func ActiveHosts(cidr, outputFile, snmpVersion, community string, timeout time.Duration, retry int) error {
 	scanner := pingscanner.PingScanner{
 		CIDR: cidr,
 		PingOptions: func() []string {
@@ -48,7 +48,7 @@ func ActiveHosts(cidr string, outputFile string, snmpVersion string, community s
 
 	servers := make(config.DiscoverToml)
 	for _, activeHost := range activeHosts {
-		cpes, err := executeSnmp2cpe(activeHost, snmpVersion, community)
+		cpes, err := executeSnmp2cpe(activeHost, snmpVersion, community, timeout, retry)
 		if err != nil {
 			fmt.Printf("failed to execute snmp2cpe. err: %v\n", err)
 			continue
@@ -106,9 +106,9 @@ func ActiveHosts(cidr string, outputFile string, snmpVersion string, community s
 	return nil
 }
 
-func executeSnmp2cpe(addr string, snmpVersion string, community string) (cpes map[string][]string, err error) {
+func executeSnmp2cpe(addr, snmpVersion, community string, timeout time.Duration, retry int) (cpes map[string][]string, err error) {
 	fmt.Printf("%s: Execute snmp2cpe...\n", addr)
-	result, err := exec.Command("./snmp2cpe", snmpVersion, addr, community).CombinedOutput()
+	result, err := exec.Command("./snmp2cpe", snmpVersion, "--timeout", timeout.String(), "--retry", fmt.Sprintf("%d", retry), addr, community).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute snmp2cpe. err: %v", err)
 	}

--- a/contrib/snmp2cpe/pkg/cmd/v2c/v2c.go
+++ b/contrib/snmp2cpe/pkg/cmd/v2c/v2c.go
@@ -3,6 +3,7 @@ package v2c
 import (
 	"encoding/json"
 	"os"
+	"time"
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/pkg/errors"
@@ -13,15 +14,19 @@ import (
 
 // SNMPv2cOptions ...
 type SNMPv2cOptions struct {
-	Port  uint16
-	Debug bool
+	Port    uint16
+	Timeout time.Duration
+	Retry   int
+	Debug   bool
 }
 
 // NewCmdV2c ...
 func NewCmdV2c() *cobra.Command {
 	opts := &SNMPv2cOptions{
-		Port:  161,
-		Debug: false,
+		Port:    161,
+		Timeout: time.Duration(2) * time.Second,
+		Retry:   3,
+		Debug:   false,
 	}
 
 	cmd := &cobra.Command{
@@ -30,7 +35,7 @@ func NewCmdV2c() *cobra.Command {
 		Example: "$ snmp2cpe v2c 192.168.100.1 public",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
-			r, err := snmp.Get(gosnmp.Version2c, args[0], snmp.WithCommunity(args[1]), snmp.WithPort(opts.Port), snmp.WithDebug(opts.Debug))
+			r, err := snmp.Get(gosnmp.Version2c, args[0], snmp.WithCommunity(args[1]), snmp.WithPort(opts.Port), snmp.WithTimeout(opts.Timeout), snmp.WithRetry(opts.Retry), snmp.WithDebug(opts.Debug))
 			if err != nil {
 				return errors.Wrap(err, "failed to snmpget")
 			}
@@ -43,8 +48,10 @@ func NewCmdV2c() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Uint16VarP(&opts.Port, "port", "P", 161, "port")
-	cmd.Flags().BoolVarP(&opts.Debug, "debug", "", false, "debug mode")
+	cmd.Flags().Uint16VarP(&opts.Port, "port", "P", opts.Port, "port")
+	cmd.Flags().DurationVarP(&opts.Timeout, "timeout", "t", opts.Timeout, "timeout")
+	cmd.Flags().IntVarP(&opts.Retry, "retry", "r", opts.Retry, "retry")
+	cmd.Flags().BoolVarP(&opts.Debug, "debug", "", opts.Debug, "debug mode")
 
 	return cmd
 }

--- a/contrib/snmp2cpe/pkg/cmd/v3/v3.go
+++ b/contrib/snmp2cpe/pkg/cmd/v3/v3.go
@@ -1,6 +1,8 @@
 package v3
 
 import (
+	"time"
+
 	"github.com/gosnmp/gosnmp"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -10,15 +12,19 @@ import (
 
 // SNMPv3Options ...
 type SNMPv3Options struct {
-	Port  uint16
-	Debug bool
+	Port    uint16
+	Timeout time.Duration
+	Retry   int
+	Debug   bool
 }
 
 // NewCmdV3 ...
 func NewCmdV3() *cobra.Command {
 	opts := &SNMPv3Options{
-		Port:  161,
-		Debug: false,
+		Port:    161,
+		Timeout: time.Duration(2) * time.Second,
+		Retry:   3,
+		Debug:   false,
 	}
 
 	cmd := &cobra.Command{
@@ -26,7 +32,7 @@ func NewCmdV3() *cobra.Command {
 		Short:   "snmpget with SNMPv3",
 		Example: "$ snmp2cpe v3",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			_, err := snmp.Get(gosnmp.Version3, "", snmp.WithPort(opts.Port), snmp.WithDebug(opts.Debug))
+			_, err := snmp.Get(gosnmp.Version3, "", snmp.WithPort(opts.Port), snmp.WithTimeout(opts.Timeout), snmp.WithRetry(opts.Retry), snmp.WithDebug(opts.Debug))
 			if err != nil {
 				return errors.Wrap(err, "failed to snmpget")
 			}
@@ -35,8 +41,10 @@ func NewCmdV3() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Uint16VarP(&opts.Port, "port", "P", 161, "port")
-	cmd.Flags().BoolVarP(&opts.Debug, "debug", "", false, "debug mode")
+	cmd.Flags().Uint16VarP(&opts.Port, "port", "P", opts.Port, "port")
+	cmd.Flags().DurationVarP(&opts.Timeout, "timeout", "t", opts.Timeout, "timeout")
+	cmd.Flags().IntVarP(&opts.Retry, "retry", "r", opts.Retry, "retry")
+	cmd.Flags().BoolVarP(&opts.Debug, "debug", "", opts.Debug, "debug mode")
 
 	return cmd
 }


### PR DESCRIPTION
# What did you implement:

add timeout, retry option

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```console
$ snmp2cpe v2c --help
snmpget with SNMPv2c

Usage:
  snmp2cpe v2c <IP Address> <Community> [flags]

Examples:
$ snmp2cpe v2c 192.168.100.1 public

Flags:
      --debug              debug mode
  -h, --help               help for v2c
  -P, --port uint16        port (default 161)
  -r, --retry int          retry (default 3)
  -t, --timeout duration   timeout (default 2s)

$ snmp2cpe v2c --timeout 1ms --retry 5 192.168.100.1 public
failed to exec snmp2cpe: request timeout (after 5 retries)
send SNMP GET request
...

$ future-vuls discover --help
discover hosts with CIDR range. Run snmp2cpe on active host to get CPE. Default outputFile is ./discover_list.toml

Usage:
  future-vuls discover --cidr <CIDR_RANGE> --output <OUTPUT_FILE> [flags]

Examples:
future-vuls discover --cidr 192.168.0.0/24 --output discover_list.toml

Flags:
      --cidr string           cidr range
      --community string      snmp community name (default "public")
  -h, --help                  help for discover
      --output string         output file
      --retry int             snmp retry (default 3)
      --snmp-version string   snmp version v1,v2c and v3 (default "v2c")
      --timeout duration      snmp timeout (default 2s)
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
