### PR TITLE
chore(config): move trivy db default value ​​to detector

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aquasecurity/trivy/pkg/db"
-	"github.com/aquasecurity/trivy/pkg/javadb"
 	"github.com/asaskevich/govalidator"
 	"golang.org/x/xerrors"
 
@@ -89,13 +87,6 @@ type ReportOpts struct {
 
 	TrivyOpts
 }
-
-var (
-	// DefaultTrivyDBRepositories is the official repositories of Trivy DB
-	DefaultTrivyDBRepositories = []string{db.DefaultGCRRepository, db.DefaultGHCRRepository}
-	// DefaultTrivyJavaDBRepositories is the official repositories of Trivy Java DB
-	DefaultTrivyJavaDBRepositories = []string{javadb.DefaultGCRRepository, javadb.DefaultGHCRRepository}
-)
 
 // TrivyOpts is options for trivy DBs
 type TrivyOpts struct {

--- a/detector/javadb/javadb.go
+++ b/detector/javadb/javadb.go
@@ -24,6 +24,9 @@ import (
 	"github.com/future-architect/vuls/logging"
 )
 
+// DefaultTrivyJavaDBRepositories is the official repositories of Trivy Java DB
+var DefaultTrivyJavaDBRepositories = []string{trivyjavadb.DefaultGCRRepository, trivyjavadb.DefaultGHCRRepository}
+
 // UpdateJavaDB updates Trivy Java DB
 func UpdateJavaDB(trivyOpts config.TrivyOpts, noProgress bool) error {
 	dbDir := filepath.Join(trivyOpts.TrivyCacheDBDir, "java-db")
@@ -49,7 +52,7 @@ func UpdateJavaDB(trivyOpts config.TrivyOpts, noProgress bool) error {
 
 	// Download DB
 	if len(trivyOpts.TrivyJavaDBRepositories) == 0 {
-		trivyOpts.TrivyJavaDBRepositories = config.DefaultTrivyJavaDBRepositories
+		trivyOpts.TrivyJavaDBRepositories = DefaultTrivyJavaDBRepositories
 	}
 	logging.Log.Infof("Trivy Java DB Repository: %s", strings.Join(trivyOpts.TrivyJavaDBRepositories, ", "))
 	logging.Log.Info("Downloading Trivy Java DB...")

--- a/detector/library.go
+++ b/detector/library.go
@@ -29,6 +29,9 @@ import (
 	"github.com/future-architect/vuls/models"
 )
 
+// DefaultTrivyDBRepositories is the official repositories of Trivy DB
+var DefaultTrivyDBRepositories = []string{db.DefaultGCRRepository, db.DefaultGHCRRepository}
+
 type libraryDetector struct {
 	scanner      models.LibraryScanner
 	javaDBClient *javadb.DBClient
@@ -96,7 +99,7 @@ func DetectLibsCves(r *models.ScanResult, trivyOpts config.TrivyOpts, logOpts lo
 
 func downloadDB(appVersion string, trivyOpts config.TrivyOpts, noProgress, skipUpdate bool) error {
 	if len(trivyOpts.TrivyDBRepositories) == 0 {
-		trivyOpts.TrivyDBRepositories = config.DefaultTrivyDBRepositories
+		trivyOpts.TrivyDBRepositories = DefaultTrivyDBRepositories
 	}
 	refs := make([]name.Reference, 0, len(trivyOpts.TrivyDBRepositories))
 	for _, repo := range trivyOpts.TrivyDBRepositories {

--- a/subcmds/report.go
+++ b/subcmds/report.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/detector"
+	detectorJavaDB "github.com/future-architect/vuls/detector/javadb"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
 	"github.com/future-architect/vuls/reporter"
@@ -180,11 +181,11 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&config.Conf.TrivyCacheDBDir, "trivy-cachedb-dir",
 		cache.DefaultDir(), "/path/to/dir")
 
-	config.Conf.TrivyDBRepositories = config.DefaultTrivyDBRepositories
+	config.Conf.TrivyDBRepositories = detector.DefaultTrivyDBRepositories
 	dbRepos := stringArrayFlag{target: &config.Conf.TrivyDBRepositories}
 	f.Var(&dbRepos, "trivy-db-repository", "Trivy DB Repository in a comma-separated list")
 
-	config.Conf.TrivyJavaDBRepositories = config.DefaultTrivyJavaDBRepositories
+	config.Conf.TrivyJavaDBRepositories = detectorJavaDB.DefaultTrivyJavaDBRepositories
 	javaDBRepos := stringArrayFlag{target: &config.Conf.TrivyJavaDBRepositories}
 	f.Var(&javaDBRepos, "trivy-java-db-repository", "Trivy Java DB Repository in a comma-separated list")
 

--- a/subcmds/report_windows.go
+++ b/subcmds/report_windows.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/detector"
+	detectorJavaDB "github.com/future-architect/vuls/detector/javadb"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
 	"github.com/future-architect/vuls/reporter"
@@ -177,11 +178,11 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&config.Conf.TrivyCacheDBDir, "trivy-cachedb-dir",
 		cache.DefaultDir(), "/path/to/dir")
 
-	config.Conf.TrivyDBRepositories = config.DefaultTrivyDBRepositories
+	config.Conf.TrivyDBRepositories = detector.DefaultTrivyDBRepositories
 	dbRepos := stringArrayFlag{target: &config.Conf.TrivyDBRepositories}
 	f.Var(&dbRepos, "trivy-db-repository", "Trivy DB Repository in a comma-separated list")
 
-	config.Conf.TrivyJavaDBRepositories = config.DefaultTrivyJavaDBRepositories
+	config.Conf.TrivyJavaDBRepositories = detectorJavaDB.DefaultTrivyJavaDBRepositories
 	javaDBRepos := stringArrayFlag{target: &config.Conf.TrivyJavaDBRepositories}
 	f.Var(&javaDBRepos, "trivy-java-db-repository", "Trivy Java DB Repository in a comma-separated list")
 

--- a/subcmds/tui.go
+++ b/subcmds/tui.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/detector"
+	detectorJavaDB "github.com/future-architect/vuls/detector/javadb"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
 	"github.com/future-architect/vuls/reporter"
@@ -108,11 +109,11 @@ func (p *TuiCmd) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&config.Conf.TrivyCacheDBDir, "trivy-cachedb-dir",
 		cache.DefaultDir(), "/path/to/dir")
 
-	config.Conf.TrivyDBRepositories = config.DefaultTrivyDBRepositories
+	config.Conf.TrivyDBRepositories = detector.DefaultTrivyDBRepositories
 	dbRepos := stringArrayFlag{target: &config.Conf.TrivyDBRepositories}
 	f.Var(&dbRepos, "trivy-db-repository", "Trivy DB Repository in a comma-separated list")
 
-	config.Conf.TrivyJavaDBRepositories = config.DefaultTrivyJavaDBRepositories
+	config.Conf.TrivyJavaDBRepositories = detectorJavaDB.DefaultTrivyJavaDBRepositories
 	javaDBRepos := stringArrayFlag{target: &config.Conf.TrivyJavaDBRepositories}
 	f.Var(&javaDBRepos, "trivy-java-db-repository", "Trivy Java DB Repository in a comma-separated list")
 


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Fixes #2325 

Trivy DB/JavaDB imports the "github.com/aquasecurity/trivy/pkg/log" package.

https://github.com/aquasecurity/trivy/blob/b7947b37ee47ea79dff550462c297164eb47aa9e/pkg/db/db.go#L18
https://github.com/aquasecurity/trivy/blob/b7947b37ee47ea79dff550462c297164eb47aa9e/pkg/javadb/client.go#L20

The "github.com/aquasecurity/trivy/pkg/log" package replaces the default logger with slog.

https://github.com/aquasecurity/trivy/blob/b7947b37ee47ea79dff550462c297164eb47aa9e/pkg/log/deferred.go#L9-L12

When importing packages related to Trivy DB/JavaDB from the "github.com/future-architect/vuls/config" package, it appears to affect the log output in the snmp2cpe package, which also imports the same "github.com/future-architect/vuls/config" package.
Therefore, we believe this issue can be resolved by relocating the import of the trivy package from "github.com/future-architect/vuls/config".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ snmp2cpe version
snmp2cpe 0.34.0 5bcf29389a4705ad8aea6db6ce75e9d755ee17fc-2025-09-06T08:12:25Z

$ snmp2cpe v2c --debug 127.0.0.1 juniper-mx960-13-3r9-13
{"127.0.0.1":{"sysDescr0":"Juniper Networks, Inc. mx960 internet router, kernel JUNOS 13.3R9.13, Build date: 2016-03-01 08:56:00 UTC Copyright (c) 1996-2016 Juniper Networks, Inc."}}
```

## after
```console
$ snmp2cpe v2c --debug 127.0.0.1 juniper-mx960-13-3r9-13
2025/09/24 16:20:15 DEBUG: .1.3.6.1.2.1.1.1.0 -> Juniper Networks, Inc. mx960 internet router, kernel JUNOS 13.3R9.13, Build date: 2016-03-01 08:56:00 UTC Copyright (c) 1996-2016 Juniper Networks, Inc.
2025/09/24 16:20:15 DEBUG: .1.3.6.1.2.1.47.1.1.1.1.12.1 -> <nil>
2025/09/24 16:20:16 DEBUG: .1.3.6.1.2.1.47.1.1.1.1.7.1 -> <nil>
2025/09/24 16:20:16 DEBUG: .1.3.6.1.2.1.47.1.1.1.1.10.1 -> <nil>
{"127.0.0.1":{"sysDescr0":"Juniper Networks, Inc. mx960 internet router, kernel JUNOS 13.3R9.13, Build date: 2016-03-01 08:56:00 UTC Copyright (c) 1996-2016 Juniper Networks, Inc."}}
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
