### PR TITLE
fix(detector/vuls2): temporarily fill in the version

### DIFF
--- a/detector/vuls2/export_test.go
+++ b/detector/vuls2/export_test.go
@@ -3,6 +3,7 @@ package vuls2
 var (
 	ShouldDownload = shouldDownload
 
+	PreConvert  = preConvert
 	PostConvert = postConvert
 )
 

--- a/detector/vuls2/vendor.go
+++ b/detector/vuls2/vendor.go
@@ -30,6 +30,21 @@ import (
 	"github.com/future-architect/vuls/models"
 )
 
+func preConvertBinaryVersion(family, version string) string {
+	switch family {
+	case constant.Debian, constant.Raspbian, constant.Ubuntu:
+		// https://github.com/future-architect/vuls/pull/2329
+		// If you are using a scanner from before this PR was merged, the binary package version will be lost when updating NeedRestartProcs during a fast-root scan.
+		// However, the current data source does not require the binary package version, so it will be filled in with "0".
+		if version == "" {
+			return "0"
+		}
+		return version
+	default:
+		return version
+	}
+}
+
 func ignoreVulnerability(e ecosystemTypes.Ecosystem, v vulnerabilityTypes.Vulnerability, as models.DistroAdvisories) bool {
 	et, _, _ := strings.Cut(string(e), ":")
 

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -111,7 +111,7 @@ func preConvert(sr *models.ScanResult) scanTypes.ScanResult {
 	for _, p := range sr.Packages {
 		base := pkgs[p.Name]
 		base.Name = p.Name
-		base.Version = p.Version
+		base.Version = preConvertBinaryVersion(sr.Family, p.Version)
 		base.Release = p.Release
 		base.NewVersion = p.NewVersion
 		base.NewRelease = p.NewRelease


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Before this PR was merged, there was a bug in fast-root scan where the binary package version would be left empty when filling in NeedRestartProcs information.
The data source used in vuls2 does not use the binary package version, so for the time being we have filled the version with "0".
https://github.com/future-architect/vuls/pull/2329

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## setup
```console
$ cat << EOS > config.toml
version = "v2"

[servers]
[servers.vagrant]
host = "127.0.0.1"
port = "2222"
user = "vagrant"
keyPath = "/home/vuls/.ssh/id_rsa"
scanMode           = ["fast-root", "offline"]
scanModules        = ["ospkg"]
EOS

$ vuls scan
[Sep 29 13:47:34]  INFO [localhost] vuls-0.35.0-5d61693fa12d91fbe9a0d0b08b4ba51236b57e47-2025-09-25T06:11:08Z
...
Scan Summary
================
[Reboot Required] vagrant	ubuntu22.04	669 installed
```

## before
```console
$ vuls report --refresh-cve --format-one-line-text 2025-09-29T13-47-34+0900
[Sep 29 15:08:33]  INFO [localhost] vuls-0.35.0-5d61693fa12d91fbe9a0d0b08b4ba51236b57e47-2025-09-25T06:11:08Z
...
[Sep 29 15:08:33]  INFO [localhost] Loaded: /home/vuls/results/2025-09-29T13-47-34+0900
[Sep 29 15:08:33] ERROR [localhost] Failed to detect Pkg CVE:
    github.com/future-architect/vuls/detector.Detect
        github.com/future-architect/vuls/detector/detector.go:55
  - Failed to detect CVE with Vuls2:
    github.com/future-architect/vuls/detector.DetectPkgCves
        github.com/future-architect/vuls/detector/detector.go:327
  - Failed to detect. err:
    github.com/future-architect/vuls/detector/vuls2.Detect
        github.com/future-architect/vuls/detector/vuls2/vuls2.go:69
  - Failed to detect os packages. err:
    github.com/future-architect/vuls/detector/vuls2.detect
        github.com/future-architect/vuls/detector/vuls2/vuls2.go:149
  - version is empty
    github.com/MaineK00n/vuls2/pkg/detect/ospkg.convertVCQueryPackage.func2
    	github.com/MaineK00n/vuls2@v0.0.1-alpha.0.20250728115051-467f2c79767c/pkg/detect/ospkg/ospkg.go:114
    github.com/MaineK00n/vuls2/pkg/detect/ospkg.convertVCQueryPackage.func3
    	github.com/MaineK00n/vuls2@v0.0.1-alpha.0.20250728115051-467f2c79767c/pkg/detect/ospkg/ospkg.go:140
    github.com/MaineK00n/vuls2/pkg/detect/ospkg.convertVCQueryPackage
    	github.com/MaineK00n/vuls2@v0.0.1-alpha.0.20250728115051-467f2c79767c/pkg/detect/ospkg/ospkg.go:146
    github.com/MaineK00n/vuls2/pkg/detect/ospkg.Detect
    	github.com/MaineK00n/vuls2@v0.0.1-alpha.0.20250728115051-467f2c79767c/pkg/detect/ospkg/ospkg.go:35
    github.com/future-architect/vuls/detector/vuls2.detect
    	github.com/future-architect/vuls/detector/vuls2/vuls2.go:147
    github.com/future-architect/vuls/detector/vuls2.Detect
    	github.com/future-architect/vuls/detector/vuls2/vuls2.go:67
    github.com/future-architect/vuls/detector.DetectPkgCves
    	github.com/future-architect/vuls/detector/detector.go:326
    github.com/future-architect/vuls/detector.Detect
    	github.com/future-architect/vuls/detector/detector.go:54
    github.com/future-architect/vuls/subcmds.(*ReportCmd).Execute
    	github.com/future-architect/vuls/subcmds/report.go:284
    github.com/google/subcommands.(*Commander).Execute
    	github.com/google/subcommands@v1.2.0/subcommands.go:209
    github.com/google/subcommands.Execute
    	github.com/google/subcommands@v1.2.0/subcommands.go:492
    main.main
    	./main.go:37
    runtime.main
    	runtime/proc.go:283
    runtime.goexit
    	runtime/asm_amd64.s:1700
    form binary package version
    github.com/MaineK00n/vuls2/pkg/detect/ospkg.convertVCQueryPackage.func3
    	github.com/MaineK00n/vuls2@v0.0.1-alpha.0.20250728115051-467f2c79767c/pkg/detect/ospkg/ospkg.go:142
    github.com/MaineK00n/vuls2/pkg/detect/ospkg.convertVCQueryPackage
    	github.com/MaineK00n/vuls2@v0.0.1-alpha.0.20250728115051-467f2c79767c/pkg/detect/ospkg/ospkg.go:146
    github.com/MaineK00n/vuls2/pkg/detect/ospkg.Detect
    	github.com/MaineK00n/vuls2@v0.0.1-alpha.0.20250728115051-467f2c79767c/pkg/detect/ospkg/ospkg.go:35
    github.com/future-architect/vuls/detector/vuls2.detect
    	github.com/future-architect/vuls/detector/vuls2/vuls2.go:147
    github.com/future-architect/vuls/detector/vuls2.Detect
    	github.com/future-architect/vuls/detector/vuls2/vuls2.go:67
    github.com/future-architect/vuls/detector.DetectPkgCves
    	github.com/future-architect/vuls/detector/detector.go:326
    github.com/future-architect/vuls/detector.Detect
    	github.com/future-architect/vuls/detector/detector.go:54
    github.com/future-architect/vuls/subcmds.(*ReportCmd).Execute
    	github.com/future-architect/vuls/subcmds/report.go:284
    github.com/google/subcommands.(*Commander).Execute
    	github.com/google/subcommands@v1.2.0/subcommands.go:209
    github.com/google/subcommands.Execute
    	github.com/google/subcommands@v1.2.0/subcommands.go:492
    main.main
    	./main.go:37
    runtime.main
    	runtime/proc.go:283
    runtime.goexit
    	runtime/asm_amd64.s:1700
    form binary package
    github.com/MaineK00n/vuls2/pkg/detect/ospkg.convertVCQueryPackage
    	github.com/MaineK00n/vuls2@v0.0.1-alpha.0.20250728115051-467f2c79767c/pkg/detect/ospkg/ospkg.go:148
    github.com/MaineK00n/vuls2/pkg/detect/ospkg.Detect
    	github.com/MaineK00n/vuls2@v0.0.1-alpha.0.20250728115051-467f2c79767c/pkg/detect/ospkg/ospkg.go:35
    github.com/future-architect/vuls/detector/vuls2.detect
    	github.com/future-architect/vuls/detector/vuls2/vuls2.go:147
    github.com/future-architect/vuls/detector/vuls2.Detect
    	github.com/future-architect/vuls/detector/vuls2/vuls2.go:67
    github.com/future-architect/vuls/detector.DetectPkgCves
    	github.com/future-architect/vuls/detector/detector.go:326
    github.com/future-architect/vuls/detector.Detect
    	github.com/future-architect/vuls/detector/detector.go:54
    github.com/future-architect/vuls/subcmds.(*ReportCmd).Execute
    	github.com/future-architect/vuls/subcmds/report.go:284
    github.com/google/subcommands.(*Commander).Execute
    	github.com/google/subcommands@v1.2.0/subcommands.go:209
    github.com/google/subcommands.Execute
    	github.com/google/subcommands@v1.2.0/subcommands.go:492
    main.main
    	./main.go:37
    runtime.main
    	runtime/proc.go:283
    runtime.goexit
    	runtime/asm_amd64.s:1700
    convert version criterion package
    github.com/MaineK00n/vuls2/pkg/detect/ospkg.Detect
    	github.com/MaineK00n/vuls2@v0.0.1-alpha.0.20250728115051-467f2c79767c/pkg/detect/ospkg/ospkg.go:37
    github.com/future-architect/vuls/detector/vuls2.detect
    	github.com/future-architect/vuls/detector/vuls2/vuls2.go:147
    github.com/future-architect/vuls/detector/vuls2.Detect
    	github.com/future-architect/vuls/detector/vuls2/vuls2.go:67
    github.com/future-architect/vuls/detector.DetectPkgCves
    	github.com/future-architect/vuls/detector/detector.go:326
    github.com/future-architect/vuls/detector.Detect
    	github.com/future-architect/vuls/detector/detector.go:54
    github.com/future-architect/vuls/subcmds.(*ReportCmd).Execute
    	github.com/future-architect/vuls/subcmds/report.go:284
    github.com/google/subcommands.(*Commander).Execute
    	github.com/google/subcommands@v1.2.0/subcommands.go:209
    github.com/google/subcommands.Execute
    	github.com/google/subcommands@v1.2.0/subcommands.go:492
    main.main
    	./main.go:37
    runtime.main
    	runtime/proc.go:283
    runtime.goexit
    	runtime/asm_amd64.s:1700
```

## after
```console
$ vuls report --refresh-cve --format-one-line-text 2025-09-29T13-47-34+0900
[Sep 29 15:07:50]  INFO [localhost] vuls-v0.35.0-build-20250929_150716_99b65d8
...
[Sep 29 15:07:50]  INFO [localhost] Loaded: /home/vuls/results/2025-09-29T13-47-34+0900
[Sep 29 15:07:50]  INFO [localhost] Fetching vuls2 db. repository: ghcr.io/vulsio/vuls-nightly-db:0
⠦ fetching (1.8 GB, 74 MB/s) [24s] 
[Sep 29 15:08:25]  INFO [localhost] [Reboot Required] vagrant: 1562 CVEs are detected with vuls2
[Sep 29 15:08:25]  INFO [localhost] [Reboot Required] vagrant: 0 CVEs are detected with CPE
[Sep 29 15:08:26]  INFO [localhost] [Reboot Required] vagrant: 0 PoC are detected
[Sep 29 15:08:26]  INFO [localhost] [Reboot Required] vagrant: 0 exploits are detected
[Sep 29 15:08:26]  INFO [localhost] [Reboot Required] vagrant: Known Exploited Vulnerabilities are detected for 0 CVEs
[Sep 29 15:08:26]  INFO [localhost] [Reboot Required] vagrant: Cyber Threat Intelligences are detected for 0 CVEs
[Sep 29 15:08:26]  INFO [localhost] [Reboot Required] vagrant: total 1562 CVEs detected
[Sep 29 15:08:26]  INFO [localhost] [Reboot Required] vagrant: 0 CVEs filtered by --confidence-over=80


One Line Summary
================
[Reboot Required] vagrant	Total: 1562 (Critical:0 High:3 Medium:1487 Low:72 ?:0)	182/1562 Fixed	669 installed	0 poc	0 exploits	0 kevs	uscert: 0, jpcert: 0 alerts
```


# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference
