### PR TITLE
chore(ci/lint): update golangci-lint to v2.5.0 and adjust config

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -22,4 +22,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@7574dab08b6e7a561d21c7f5c153fe1107cc0b2f
         with:
-          version: v2.1.6
+          version: v2.5.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,10 @@ linters:
         - name: unused-parameter
         - name: var-declaration
         - name: var-naming
+          arguments:
+            - [] # AllowList
+            - [] # DenyList
+            - - skip-package-name-checks: true
     staticcheck: # https://golangci-lint.run/usage/linters/#staticcheck
       checks:
         - all


### PR DESCRIPTION
# What did you implement:

CI lint failed at https://github.com/future-architect/vuls/actions/runs/18150169777/job/51659320388
with golangci-lint 2.1.6 .

I could not reproduce this error.
Update the binary to latest, then the different error came in:

```
% golangci-lint run
util/util_test.go:1:9: var-naming: avoid meaningless package names (revive)
package util
        ^
1 issues:
* revive: 1
```

Add skip configuration in the same way as https://github.com/vulsio/go-cpe-dictionary/pull/242/files .

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

by CI https://github.com/future-architect/vuls/actions/runs/18151878378/job/51664211446?pr=2332

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below


# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

