### PR TITLE
chore(deps): revert the revert of docker cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
       - /contrib
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 14
     groups:
       all:
         patterns:


### PR DESCRIPTION
Reverts the revert of future-architect/vuls#2317

- The developer says it's supported https://github.com/dependabot/dependabot-core/issues/13039#issuecomment-3392693747
- The issue does not get responses much, it may be temporal?

So try once more.