### PR TITLE
fix(contrib/future-vuls): add O_TRUNC flag

### DIFF
--- a/contrib/future-vuls/pkg/cpe/cpe.go
+++ b/contrib/future-vuls/pkg/cpe/cpe.go
@@ -173,7 +173,7 @@ func (c *AddCpeConfig) AddCpeToFvuls(ctx context.Context, needAddCpes config.Dis
 
 // WriteDiscoverToml ...
 func (c *AddCpeConfig) WriteDiscoverToml() error {
-	f, err := os.OpenFile(c.DiscoverTomlPath, os.O_RDWR, 0666)
+	f, err := os.OpenFile(c.DiscoverTomlPath, os.O_RDWR|os.O_TRUNC, 0666)
 	if err != nil {
 		return fmt.Errorf("failed to open toml file. err: %v", err)
 	}


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

When modifying the contents of the same file, if O_TRUNC is not used, only a portion of the file may be overwritten, potentially corrupting the file format. Therefore, O_TRUNC is added.

https://github.com/future-architect/vuls/blob/2e83bf40dd86e6f007bb217e61a068900f11c58e/contrib/future-vuls/pkg/cpe/cpe.go#L176

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ cat test.toml 
[test]
id = "42"
name = "example"

$ cat main.go 
package main

import (
	"os"

	"github.com/BurntSushi/toml"
)

func main() {
	if err := exec(); err != nil {
		panic(err)
	}
}

func exec() error {
	f, err := os.OpenFile("test.toml", os.O_RDWR, 0666)
	if err != nil {
		return err
	}
	defer f.Close()

	if err := toml.NewEncoder(f).Encode(
		map[string]struct {
			ID string `toml:"id"`
		}{"test": {ID: "42"}},
	); err != nil {
		return err
	}

	return nil
}

$ go run main.go

$ cat test.toml
[test]
  id = "42"
me = "example"
```

## after
```console
$ cat test.toml 
[test]
id = "42"
name = "example"

$ cat main.go 
package main

import (
	"os"

	"github.com/BurntSushi/toml"
)

func main() {
	if err := exec(); err != nil {
		panic(err)
	}
}

func exec() error {
	f, err := os.OpenFile("test.toml", os.O_RDWR|os.O_TRUNC, 0666)
	if err != nil {
		return err
	}
	defer f.Close()

	if err := toml.NewEncoder(f).Encode(
		map[string]struct {
			ID string `toml:"id"`
		}{"test": {ID: "42"}},
	); err != nil {
		return err
	}

	return nil
}

$ go run main.go

$ cat test.toml
[test]
  id = "42"
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

