### PR TITLE
feat(detector/cve): support euvd

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -442,7 +442,7 @@ func DetectWordPressCves(r *models.ScanResult, wpCnf config.WpScanConf) error {
 	return nil
 }
 
-// FillCvesWithGoCVEDictionary fills CVE detail with NVD, VulnCheck, JVN, Fortinet, MITRE, Paloalto, Cisco
+// FillCvesWithGoCVEDictionary fills CVE detail with NVD, VulnCheck, JVN, EUVD, Fortinet, MITRE, Paloalto, Cisco
 func FillCvesWithGoCVEDictionary(r *models.ScanResult, cnf config.GoCveDictConf, logOpts logging.LogOpts) (err error) {
 	cveIDs := []string{}
 	for _, v := range r.ScannedCves {
@@ -468,6 +468,7 @@ func FillCvesWithGoCVEDictionary(r *models.ScanResult, cnf config.GoCveDictConf,
 		nvds, exploits, mitigations := models.ConvertNvdToModel(d.CveID, d.Nvds)
 		vulnchecks := models.ConvertVulncheckToModel(d.CveID, d.Vulnchecks)
 		jvns := models.ConvertJvnToModel(d.CveID, d.Jvns)
+		euvds := models.ConvertEuvdToModel(d.CveID, d.Euvds)
 		fortinets := models.ConvertFortinetToModel(d.CveID, d.Fortinets)
 		mitres := models.ConvertMitreToModel(d.CveID, d.Mitres)
 		paloaltos := models.ConvertPaloaltoToModel(d.CveID, d.Paloaltos)
@@ -487,7 +488,7 @@ func FillCvesWithGoCVEDictionary(r *models.ScanResult, cnf config.GoCveDictConf,
 				for _, con := range vulnchecks {
 					vinfo.CveContents[con.Type] = append(vinfo.CveContents[con.Type], con)
 				}
-				for _, cons := range [][]models.CveContent{jvns, fortinets, paloaltos, ciscos} {
+				for _, cons := range [][]models.CveContent{jvns, euvds, fortinets, paloaltos, ciscos} {
 					for _, con := range cons {
 						if !con.Empty() {
 							if !slices.ContainsFunc(vinfo.CveContents[con.Type], func(e models.CveContent) bool {

--- a/detector/util.go
+++ b/detector/util.go
@@ -182,7 +182,7 @@ func getMinusDiffCves(previous, current models.ScanResult) models.VulnInfos {
 }
 
 func isCveInfoUpdated(cveID string, previous, current models.ScanResult) bool {
-	cTypes := append([]models.CveContentType{models.Mitre, models.Nvd, models.Vulncheck, models.Jvn}, models.GetCveContentTypes(current.Family)...)
+	cTypes := append([]models.CveContentType{models.Mitre, models.Nvd, models.Vulncheck, models.Jvn, models.Euvd}, models.GetCveContentTypes(current.Family)...)
 
 	prevLastModified := map[models.CveContentType][]time.Time{}
 	preVinfo, ok := previous.ScannedCves[cveID]

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/gosnmp/gosnmp v1.42.1
 	github.com/gosuri/uitable v0.0.4
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hashicorp/go-version v1.7.0
+	github.com/hashicorp/go-version v1.8.0
 	github.com/jesseduffield/gocui v0.3.0
 	github.com/k0kubun/pp v3.0.1+incompatible
 	github.com/knqyf263/go-apk-version v0.0.0-20200609155635-041fdbb8563f
@@ -52,7 +52,7 @@ require (
 	github.com/spdx/tools-golang v0.5.5
 	github.com/spf13/cobra v1.10.1
 	github.com/vulsio/go-cti v0.3.2
-	github.com/vulsio/go-cve-dictionary v0.14.1-0.20251126061429-9de63913c5a6
+	github.com/vulsio/go-cve-dictionary v0.14.1-0.20251129095104-e3e9f6c5bb88
 	github.com/vulsio/go-exploitdb v0.6.2
 	github.com/vulsio/go-kev v0.4.2
 	github.com/vulsio/go-msfdb v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -502,8 +502,8 @@ github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhE
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
-github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bPle2i4=
+github.com/hashicorp/go-version v1.8.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru/arc/v2 v2.0.5 h1:l2zaLDubNhW4XO3LnliVj0GXO3+/CGNJAg1dcN2Fpfw=
 github.com/hashicorp/golang-lru/arc/v2 v2.0.5/go.mod h1:ny6zBSQZi2JxIeYcv7kt2sH2PXJtirBN7RDhRpxPkxU=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
@@ -888,8 +888,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/vulsio/go-cti v0.3.2 h1:GsFwl18oA0pxEz7lvdKRZcF6ygS6WjaEG4I9wtSMrwE=
 github.com/vulsio/go-cti v0.3.2/go.mod h1:38MJ5oV3yor6YKrMqq0HMydwSvOjlw2JK6fHuq9kYhQ=
-github.com/vulsio/go-cve-dictionary v0.14.1-0.20251126061429-9de63913c5a6 h1:GvlWL6M3P2VJXlRc7TV+os2U5dtfYmGeJA33cG+Ej1c=
-github.com/vulsio/go-cve-dictionary v0.14.1-0.20251126061429-9de63913c5a6/go.mod h1:ERpoGxo8icHzVTNGBagrnqdFHBUlzI20SSo0A+Yvd7w=
+github.com/vulsio/go-cve-dictionary v0.14.1-0.20251129095104-e3e9f6c5bb88 h1:HUv4RG3ZGa5LsxOHfpt2L17YbreVJEgsWDA8buJ3Xik=
+github.com/vulsio/go-cve-dictionary v0.14.1-0.20251129095104-e3e9f6c5bb88/go.mod h1:ERpoGxo8icHzVTNGBagrnqdFHBUlzI20SSo0A+Yvd7w=
 github.com/vulsio/go-exploitdb v0.6.2 h1:FtCXQCE/Rv7x1410aJxcpZRl5xOXRRm6ePlIxmdp6Tc=
 github.com/vulsio/go-exploitdb v0.6.2/go.mod h1:oAu9kwRZcBsmthgju1lupSX2V/MERNIVRgn5a28ldvc=
 github.com/vulsio/go-kev v0.4.2 h1:UHNTC7kElTg2e+vQsB4+wZ64TFYWFQ9ojHbx7FiKWz0=

--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -55,7 +55,7 @@ func (v CveContents) PrimarySrcURLs(lang, myFamily, cveID string, confidences Co
 		return
 	}
 
-	for _, ctype := range append(append(CveContentTypes{Mitre, Nvd, Vulncheck, Jvn}, GetCveContentTypes(myFamily)...), GitHub) {
+	for _, ctype := range append(append(CveContentTypes{Mitre, Nvd, Vulncheck, Jvn, Euvd}, GetCveContentTypes(myFamily)...), GitHub) {
 		for _, cont := range v[ctype] {
 			switch ctype {
 			case Nvd, Vulncheck:
@@ -316,6 +316,8 @@ func NewCveContentType(name string) CveContentType {
 		return Vulncheck
 	case "jvn":
 		return Jvn
+	case "euvd":
+		return Euvd
 	case "redhat", "centos":
 		return RedHat
 	case "alma":
@@ -465,6 +467,9 @@ const (
 
 	// Jvn is Jvn
 	Jvn CveContentType = "jvn"
+
+	// Euvd is Euvd
+	Euvd CveContentType = "euvd"
 
 	// Fortinet is Fortinet
 	Fortinet CveContentType = "fortinet"
@@ -638,6 +643,7 @@ var AllCveContetTypes = CveContentTypes{
 	Nvd,
 	Vulncheck,
 	Jvn,
+	Euvd,
 	Fortinet,
 	Paloalto,
 	Cisco,

--- a/models/utils_test.go
+++ b/models/utils_test.go
@@ -13,6 +13,185 @@ import (
 	cvedict "github.com/vulsio/go-cve-dictionary/models"
 )
 
+func TestConvertEuvdToModel(t *testing.T) {
+	type args struct {
+		cveID string
+		euvds []cvedict.Euvd
+	}
+	tests := []struct {
+		name string
+		args args
+		want []models.CveContent
+	}{
+		{
+			name: "CVE-2025-49575",
+			args: args{
+				cveID: "CVE-2025-49575",
+				euvds: []cvedict.Euvd{
+					{
+						EuvdID:        "EUVD-2025-18144",
+						EnisaUUID:     "e15c6dcd-bca6-37ab-b0e0-e1cd92a91c98",
+						Description:   "Citizen skin vulnerable to stored XSS through multiple system messages",
+						DatePublished: time.Date(2025, time.June, 11, 19, 59, 54, 0, time.UTC),
+						DateUpdated:   time.Date(2025, time.June, 13, 03, 43, 58, 0, time.UTC),
+						References: []cvedict.EuvdReference{
+							{
+								Reference: cvedict.Reference{
+									Link: "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/security/advisories/GHSA-4c2h-67qq-vm87",
+									Name: "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/security/advisories/GHSA-4c2h-67qq-vm87",
+								},
+							},
+							{
+								Reference: cvedict.Reference{
+									Link: "https://nvd.nist.gov/vuln/detail/CVE-2025-49575",
+									Name: "https://nvd.nist.gov/vuln/detail/CVE-2025-49575",
+								},
+							},
+						},
+						Aliases: []cvedict.EuvdAlias{
+							{
+								Alias: "GHSA-4c2h-67qq-vm87",
+							},
+							{
+								Alias: "CVE-2025-49575",
+							},
+						},
+					},
+					{
+						EuvdID:           "EUVD-2025-18208",
+						EnisaUUID:        "c8b99a1b-5107-3825-a99f-30d856d6c47e",
+						Description:      "Citizen skin vulnerable to stored XSS through multiple system messages",
+						DatePublished:    time.Date(2025, time.June, 11, 19, 59, 54, 0, time.UTC),
+						DateUpdated:      time.Date(2025, time.June, 13, 03, 43, 58, 0, time.UTC),
+						BaseScore:        6.5,
+						BaseScoreVersion: "3.1",
+						BaseScoreVector:  "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:N",
+						References: []cvedict.EuvdReference{
+							{
+								Reference: cvedict.Reference{
+									Link: "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/security/advisories/GHSA-4c2h-67qq-vm87",
+									Name: "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/security/advisories/GHSA-4c2h-67qq-vm87",
+								},
+							},
+							{
+								Reference: cvedict.Reference{
+									Link: "https://nvd.nist.gov/vuln/detail/CVE-2025-49575",
+									Name: "https://nvd.nist.gov/vuln/detail/CVE-2025-49575",
+								},
+							},
+						},
+						Aliases: []cvedict.EuvdAlias{
+							{
+								Alias: "CVE-2025-49575",
+							},
+						},
+						Assigner: "GitHub_M",
+						EPSS:     0.02,
+					},
+				},
+			},
+			want: []models.CveContent{
+				{
+					Type:       models.Euvd,
+					CveID:      "CVE-2025-49575",
+					Title:      "EUVD-2025-18144",
+					Summary:    "Citizen skin vulnerable to stored XSS through multiple system messages",
+					SourceLink: "https://euvd.enisa.europa.eu/vulnerability/EUVD-2025-18144",
+					References: []models.Reference{
+						{Link: "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/security/advisories/GHSA-4c2h-67qq-vm87"},
+						{Link: "https://nvd.nist.gov/vuln/detail/CVE-2025-49575"},
+					},
+					Published:    time.Date(2025, time.June, 11, 19, 59, 54, 0, time.UTC),
+					LastModified: time.Date(2025, time.June, 13, 03, 43, 58, 0, time.UTC),
+				},
+				{
+					Type:          models.Euvd,
+					CveID:         "CVE-2025-49575",
+					Title:         "EUVD-2025-18208",
+					Summary:       "Citizen skin vulnerable to stored XSS through multiple system messages",
+					Cvss3Score:    6.5,
+					Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:N",
+					Cvss3Severity: "MEDIUM",
+					SourceLink:    "https://euvd.enisa.europa.eu/vulnerability/EUVD-2025-18208",
+					References: []models.Reference{
+						{Link: "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/security/advisories/GHSA-4c2h-67qq-vm87"},
+						{Link: "https://nvd.nist.gov/vuln/detail/CVE-2025-49575"},
+					},
+					Published:    time.Date(2025, time.June, 11, 19, 59, 54, 0, time.UTC),
+					LastModified: time.Date(2025, time.June, 13, 03, 43, 58, 0, time.UTC),
+				},
+			},
+		},
+		{
+			name: "CVE-2025-34028",
+			args: args{
+				cveID: "CVE-2025-34028",
+				euvds: []cvedict.Euvd{
+					{
+						EuvdID:           "EUVD-2025-12275",
+						EnisaUUID:        "631cd45a-4015-314b-b4b4-099d07280668",
+						Description:      "The Commvault Command Center Innovation Release allows an unauthenticated actor to upload ZIP files that represent install packages that, when expanded by the target server, are vulnerable to path traversal vulnerability that can result in Remote Code Execution via malicious JSP.\n\n\n\n\n\nThis issue affects Command Center Innovation Release: 11.38.0 to 11.38.20. The vulnerability is fixed in 11.38.20 with SP38-CU20-433 and SP38-CU20-436 and also fixed in 11.38.25 with SP38-CU25-434 and SP38-CU25-438.",
+						DatePublished:    time.Date(2025, time.April, 22, 16, 32, 23, 0, time.UTC),
+						DateUpdated:      time.Date(2025, time.November, 29, 02, 06, 36, 0, time.UTC),
+						BaseScore:        9.3,
+						BaseScoreVersion: "4.0",
+						BaseScoreVector:  "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:H/VA:H/SC:L/SI:H/SA:H",
+						References: []cvedict.EuvdReference{
+							{
+								Reference: cvedict.Reference{
+									Link: "https://nvd.nist.gov/vuln/detail/CVE-2025-34028",
+									Name: "https://nvd.nist.gov/vuln/detail/CVE-2025-34028",
+								},
+							},
+							{
+								Reference: cvedict.Reference{
+									Link: "https://documentation.commvault.com/securityadvisories/CV_2025_04_1.html",
+									Name: "https://documentation.commvault.com/securityadvisories/CV_2025_04_1.html",
+								},
+							},
+						},
+						Aliases: []cvedict.EuvdAlias{
+							{
+								Alias: "CVE-2025-34028",
+							},
+							{
+								Alias: "GHSA-6q9c-pjw5-5rjm",
+							},
+						},
+						Assigner:       "VulnCheck",
+						EPSS:           45.93,
+						ExploitedSince: func() *time.Time { t := time.Date(2025, time.May, 02, 12, 00, 00, 0, time.UTC); return &t }(),
+					},
+				},
+			},
+			want: []models.CveContent{
+				{
+					Type:           models.Euvd,
+					CveID:          "CVE-2025-34028",
+					Title:          "EUVD-2025-12275",
+					Summary:        "The Commvault Command Center Innovation Release allows an unauthenticated actor to upload ZIP files that represent install packages that, when expanded by the target server, are vulnerable to path traversal vulnerability that can result in Remote Code Execution via malicious JSP.\n\n\n\n\n\nThis issue affects Command Center Innovation Release: 11.38.0 to 11.38.20. The vulnerability is fixed in 11.38.20 with SP38-CU20-433 and SP38-CU20-436 and also fixed in 11.38.25 with SP38-CU25-434 and SP38-CU25-438.",
+					Cvss40Score:    9.3,
+					Cvss40Vector:   "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:H/VA:H/SC:L/SI:H/SA:H",
+					Cvss40Severity: "CRITICAL",
+					SourceLink:     "https://euvd.enisa.europa.eu/vulnerability/EUVD-2025-12275",
+					References: []models.Reference{
+						{Link: "https://nvd.nist.gov/vuln/detail/CVE-2025-34028"},
+						{Link: "https://documentation.commvault.com/securityadvisories/CV_2025_04_1.html"},
+					},
+					Published:    time.Date(2025, time.April, 22, 16, 32, 23, 0, time.UTC),
+					LastModified: time.Date(2025, time.November, 29, 02, 06, 36, 0, time.UTC),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := models.ConvertEuvdToModel(tt.args.cveID, tt.args.euvds); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ConvertEuvdToModel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 func TestConvertVulncheckToModel(t *testing.T) {
 	type args struct {
 		cveID      string

--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -423,7 +423,7 @@ func (v VulnInfo) Titles(lang, myFamily string) (values []CveContentStr) {
 		}
 	}
 
-	order := append(GetCveContentTypes(string(Trivy)), append(CveContentTypes{Cisco, Paloalto, Fortinet, Nvd, Vulncheck, Mitre}, GetCveContentTypes(myFamily)...)...)
+	order := append(GetCveContentTypes(string(Trivy)), append(CveContentTypes{Cisco, Paloalto, Fortinet, Euvd, Nvd, Vulncheck, Mitre}, GetCveContentTypes(myFamily)...)...)
 	order = append(order, AllCveContetTypes.Except(append(order, Jvn)...)...)
 	for _, ctype := range order {
 		if conts, found := v.CveContents[ctype]; found {
@@ -468,7 +468,7 @@ func (v VulnInfo) Summaries(lang, myFamily string) (values []CveContentStr) {
 		}
 	}
 
-	order := append(append(GetCveContentTypes(string(Trivy)), GetCveContentTypes(myFamily)...), Cisco, Paloalto, Fortinet, Nvd, Vulncheck, Mitre, GitHub)
+	order := append(append(GetCveContentTypes(string(Trivy)), GetCveContentTypes(myFamily)...), Cisco, Paloalto, Fortinet, Euvd, Nvd, Vulncheck, Mitre, GitHub)
 	order = append(order, AllCveContetTypes.Except(append(order, Jvn)...)...)
 	for _, ctype := range order {
 		if conts, found := v.CveContents[ctype]; found {
@@ -514,7 +514,7 @@ func (v VulnInfo) Summaries(lang, myFamily string) (values []CveContentStr) {
 
 // Cvss2Scores returns CVSS V2 Scores
 func (v VulnInfo) Cvss2Scores() (values []CveContentCvss) {
-	order := append([]CveContentType{RedHatAPI, RedHat, Nvd, Vulncheck, Mitre, Jvn}, GetCveContentTypes(string(Trivy))...)
+	order := append([]CveContentType{RedHatAPI, RedHat, Nvd, Vulncheck, Mitre, Jvn, Euvd}, GetCveContentTypes(string(Trivy))...)
 	for _, ctype := range order {
 		if conts, found := v.CveContents[ctype]; found {
 			for _, cont := range conts {
@@ -539,7 +539,7 @@ func (v VulnInfo) Cvss2Scores() (values []CveContentCvss) {
 
 // Cvss3Scores returns CVSS V3 Score
 func (v VulnInfo) Cvss3Scores() (values []CveContentCvss) {
-	order := append([]CveContentType{RedHatAPI, RedHat, Rocky, SUSE, Microsoft, Paloalto, Fortinet, Nvd, Vulncheck, Mitre, Jvn}, GetCveContentTypes(string(Trivy))...)
+	order := append([]CveContentType{RedHatAPI, RedHat, Rocky, SUSE, Microsoft, Paloalto, Fortinet, Nvd, Vulncheck, Mitre, Jvn, Euvd}, GetCveContentTypes(string(Trivy))...)
 	for _, ctype := range order {
 		if conts, found := v.CveContents[ctype]; found {
 			for _, cont := range conts {
@@ -612,7 +612,7 @@ func (v VulnInfo) Cvss3Scores() (values []CveContentCvss) {
 
 // Cvss40Scores returns CVSS V4 Score
 func (v VulnInfo) Cvss40Scores() (values []CveContentCvss) {
-	for _, ctype := range []CveContentType{Paloalto, Mitre, Nvd, Vulncheck} {
+	for _, ctype := range []CveContentType{Paloalto, Mitre, Nvd, Vulncheck, Euvd} {
 		if conts, found := v.CveContents[ctype]; found {
 			for _, cont := range conts {
 				if cont.Cvss40Score == 0 && cont.Cvss40Severity == "" {

--- a/reporter/util.go
+++ b/reporter/util.go
@@ -830,7 +830,7 @@ func getMinusDiffCves(previous, current models.ScanResult) models.VulnInfos {
 }
 
 func isCveInfoUpdated(cveID string, previous, current models.ScanResult) bool {
-	cTypes := append([]models.CveContentType{models.Mitre, models.Nvd, models.Vulncheck, models.Jvn}, models.GetCveContentTypes(current.Family)...)
+	cTypes := append([]models.CveContentType{models.Mitre, models.Nvd, models.Vulncheck, models.Jvn, models.Euvd}, models.GetCveContentTypes(current.Family)...)
 
 	prevLastModifieds := map[models.CveContentType][]time.Time{}
 	preVinfo, ok := previous.ScannedCves[cveID]


### PR DESCRIPTION
# What did you implement:

support EUVD

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
```bash
$ go-cve-dictionary fetch nvd 2025
$ go-cve-dictionary fetch euvd 2025

$ cat << EOS > config.toml
version = "v2"

[cveDict]
type = "sqlite3"

[ovalDict]
type = "sqlite3"

[gost]
type = "sqlite3"

[exploit]
type = "sqlite3"

[metasploit]
type = "sqlite3"

[kevuln]
type = "sqlite3"

[cti]
type = "sqlite3"

[vuls2]
repository = "ghcr.io/vulsio/vuls-nightly-db:0"

[default]
[servers]
[servers.pseudo]
type = "pseudo"
cpeNames = [
    "cpe:2.3:a:starcitizen.tools:citizen:3.3.0:*:*:*:*:*:*:*",
]
EOS

$ vuls scan
$ vuls report
...
[Dec  4 02:19:38]  INFO [localhost] pseudo type. Skip OVAL, gost and vuls2 detection
[Dec  4 02:19:39]  INFO [localhost] pseudo: 7 CVEs are detected with CPE
[Dec  4 02:19:40]  INFO [localhost] pseudo: 0 PoC are detected
[Dec  4 02:19:40]  INFO [localhost] pseudo: 0 exploits are detected
[Dec  4 02:19:40]  INFO [localhost] pseudo: Known Exploited Vulnerabilities are detected for 0 CVEs
[Dec  4 02:19:40]  INFO [localhost] pseudo: Cyber Threat Intelligences are detected for 0 CVEs
[Dec  4 02:19:40]  INFO [localhost] pseudo: total 7 CVEs detected
[Dec  4 02:19:40]  INFO [localhost] pseudo: 0 CVEs filtered by --confidence-over=80
pseudo (pseudo)
===============
Total: 7 (Critical:0 High:2 Medium:5 Low:0 ?:0)
0/0 Fixed, 7 poc, 0 exploits, 0 kevs, uscert: 0, jpcert: 0 alerts
0 installed

+----------------+------+--------+-----+-----+-------+-------+----------------------------------------+
|     CVE-ID     | CVSS | Attack | PoC | KEV | Alert | Fixed |                Packages                |
+----------------+------+--------+-----+-----+-------+-------+----------------------------------------+
| CVE-2025-53368 | 8.6  | AV:N   | POC |     |       |       | cpe:/a:starcitizen.tools:citizen:3.3.0 |
+----------------+------+--------+-----+-----+-------+-------+----------------------------------------+
| CVE-2025-53370 | 8.6  | AV:N   | POC |     |       |       | cpe:/a:starcitizen.tools:citizen:3.3.0 |
+----------------+------+--------+-----+-----+-------+-------+----------------------------------------+
| CVE-2025-49575 | 6.5  | AV:N   | POC |     |       |       | cpe:/a:starcitizen.tools:citizen:3.3.0 |
+----------------+------+--------+-----+-----+-------+-------+----------------------------------------+
| CVE-2025-49576 | 6.5  | AV:N   | POC |     |       |       | cpe:/a:starcitizen.tools:citizen:3.3.0 |
+----------------+------+--------+-----+-----+-------+-------+----------------------------------------+
| CVE-2025-49577 | 6.5  | AV:N   | POC |     |       |       | cpe:/a:starcitizen.tools:citizen:3.3.0 |
+----------------+------+--------+-----+-----+-------+-------+----------------------------------------+
| CVE-2025-49578 | 6.5  | AV:N   | POC |     |       |       | cpe:/a:starcitizen.tools:citizen:3.3.0 |
+----------------+------+--------+-----+-----+-------+-------+----------------------------------------+
| CVE-2025-49579 | 6.5  | AV:N   | POC |     |       |       | cpe:/a:starcitizen.tools:citizen:3.3.0 |
+----------------+------+--------+-----+-----+-------+-------+----------------------------------------+

$ jq -r '.scannedCves."CVE-2025-49575"' results/2025-12-04T02-19-30+0900/pseudo.json
{
  "cveID": "CVE-2025-49575",
  "confidences": [
    {
      "score": 100,
      "detectionMethod": "NvdExactVersionMatch"
    }
  ],
  "cveContents": {
    "euvd": [
      {
        "type": "euvd",
        "cveID": "CVE-2025-49575",
        "title": "EUVD-2025-18208",
        "summary": "Citizen skin vulnerable to stored XSS through multiple system messages",
        "cvss2Score": 0,
        "cvss2Vector": "",
        "cvss2Severity": "",
        "cvss3Score": 6.5,
        "cvss3Vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:N",
        "cvss3Severity": "MEDIUM",
        "cvss40Score": 0,
        "cvss40Vector": "",
        "cvss40Severity": "",
        "sourceLink": "https://euvd.enisa.europa.eu/vulnerability/EUVD-2025-18208",
        "references": [
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/4fa69e1d062dca7e407cc0530cf1da3e2baaf0b5"
          },
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/54c8717d45ce1594918f11cb9ce5d0ccd8dfee65"
          },
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/93c36ac778397e0e7c46cf7adb1e5d848265f1bd"
          },
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/security/advisories/GHSA-4c2h-67qq-vm87"
          },
          {
            "link": "https://nvd.nist.gov/vuln/detail/CVE-2025-49575"
          }
        ],
        "published": "2025-06-11T19:59:54Z",
        "lastModified": "2025-06-13T03:43:58Z"
      },
      {
        "type": "euvd",
        "cveID": "CVE-2025-49575",
        "title": "EUVD-2025-18144",
        "summary": "Citizen skin vulnerable to stored XSS through multiple system messages",
        "cvss2Score": 0,
        "cvss2Vector": "",
        "cvss2Severity": "",
        "cvss3Score": 0,
        "cvss3Vector": "",
        "cvss3Severity": "",
        "cvss40Score": 0,
        "cvss40Vector": "",
        "cvss40Severity": "",
        "sourceLink": "https://euvd.enisa.europa.eu/vulnerability/EUVD-2025-18144",
        "references": [
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen"
          },
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/4fa69e1d062dca7e407cc0530cf1da3e2baaf0b5"
          },
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/54c8717d45ce1594918f11cb9ce5d0ccd8dfee65"
          },
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/93c36ac778397e0e7c46cf7adb1e5d848265f1bd"
          },
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/security/advisories/GHSA-4c2h-67qq-vm87"
          },
          {
            "link": "https://nvd.nist.gov/vuln/detail/CVE-2025-49575"
          }
        ],
        "published": "2025-06-11T19:59:54Z",
        "lastModified": "2025-06-13T03:43:58Z"
      }
    ],
    "nvd": [
      {
        "type": "nvd",
        "cveID": "CVE-2025-49575",
        "title": "",
        "summary": "Citizen is a MediaWiki skin that makes extensions part of the cohesive experience. Multiple system messages are inserted into the CommandPaletteFooter as raw HTML, allowing anybody who can edit those messages to insert arbitrary HTML into the DOM. This impacts wikis where a group has the `editinterface` but not the `editsitejs` user right. This vulnerability is fixed in 3.3.1.\nCitizen es una interfaz de MediaWiki que integra las extensiones en la experiencia cohesiva. Se insertan múltiples mensajes del sistema en CommandPaletteFooter como HTML sin formato, lo que permite que cualquiera que pueda editarlos inserte HTML arbitrario en el DOM. Esto afecta a las wikis donde un grupo tiene el permiso de usuario `editinterface` pero no el de `editsitejs`. Esta vulnerabilidad se corrigió en la versión 3.3.1.",
        "cvss2Score": 0,
        "cvss2Vector": "",
        "cvss2Severity": "",
        "cvss3Score": 6.5,
        "cvss3Vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:N",
        "cvss3Severity": "MEDIUM",
        "cvss40Score": 0,
        "cvss40Vector": "",
        "cvss40Severity": "",
        "sourceLink": "https://nvd.nist.gov/vuln/detail/CVE-2025-49575",
        "references": [
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/4fa69e1d062dca7e407cc0530cf1da3e2baaf0b5",
            "source": "security-advisories@github.com",
            "tags": [
              "Patch"
            ]
          },
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/93c36ac778397e0e7c46cf7adb1e5d848265f1bd",
            "source": "security-advisories@github.com",
            "tags": [
              "Patch"
            ]
          },
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/security/advisories/GHSA-4c2h-67qq-vm87",
            "source": "security-advisories@github.com",
            "tags": [
              "Exploit",
              "Vendor Advisory"
            ]
          }
        ],
        "cweIDs": [
          "CWE-79"
        ],
        "published": "2025-06-12T19:15:20.16Z",
        "lastModified": "2025-08-22T18:59:49.71Z",
        "optional": {
          "source": "security-advisories@github.com"
        }
      },
      {
        "type": "nvd",
        "cveID": "CVE-2025-49575",
        "title": "",
        "summary": "Citizen is a MediaWiki skin that makes extensions part of the cohesive experience. Multiple system messages are inserted into the CommandPaletteFooter as raw HTML, allowing anybody who can edit those messages to insert arbitrary HTML into the DOM. This impacts wikis where a group has the `editinterface` but not the `editsitejs` user right. This vulnerability is fixed in 3.3.1.\nCitizen es una interfaz de MediaWiki que integra las extensiones en la experiencia cohesiva. Se insertan múltiples mensajes del sistema en CommandPaletteFooter como HTML sin formato, lo que permite que cualquiera que pueda editarlos inserte HTML arbitrario en el DOM. Esto afecta a las wikis donde un grupo tiene el permiso de usuario `editinterface` pero no el de `editsitejs`. Esta vulnerabilidad se corrigió en la versión 3.3.1.",
        "cvss2Score": 0,
        "cvss2Vector": "",
        "cvss2Severity": "",
        "cvss3Score": 5.4,
        "cvss3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N",
        "cvss3Severity": "MEDIUM",
        "cvss40Score": 0,
        "cvss40Vector": "",
        "cvss40Severity": "",
        "sourceLink": "https://nvd.nist.gov/vuln/detail/CVE-2025-49575",
        "references": [
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/4fa69e1d062dca7e407cc0530cf1da3e2baaf0b5",
            "source": "security-advisories@github.com",
            "tags": [
              "Patch"
            ]
          },
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/commit/93c36ac778397e0e7c46cf7adb1e5d848265f1bd",
            "source": "security-advisories@github.com",
            "tags": [
              "Patch"
            ]
          },
          {
            "link": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/security/advisories/GHSA-4c2h-67qq-vm87",
            "source": "security-advisories@github.com",
            "tags": [
              "Exploit",
              "Vendor Advisory"
            ]
          }
        ],
        "published": "2025-06-12T19:15:20.16Z",
        "lastModified": "2025-08-22T18:59:49.71Z",
        "optional": {
          "source": "nvd@nist.gov"
        }
      }
    ]
  },
  "exploits": [
    {
      "exploitType": "nvd",
      "id": "",
      "url": "https://github.com/StarCitizenTools/mediawiki-skins-Citizen/security/advisories/GHSA-4c2h-67qq-vm87",
      "description": ""
    }
  ],
  "alertDict": {
    "cisa": null,
    "jpcert": null,
    "uscert": null
  },
  "cpeURIs": [
    "cpe:/a:starcitizen.tools:citizen:3.3.0"
  ]
}
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

