### PR TITLE
fix(model/CveContents): initialize CveContents to avoid nil map

### DIFF
--- a/contrib/future-vuls/pkg/fvuls/fvuls.go
+++ b/contrib/future-vuls/pkg/fvuls/fvuls.go
@@ -46,6 +46,12 @@ func (f Client) UploadToFvuls(serverUUID string, groupID int64, tags []string, s
 		fmt.Printf("failed to parse json. err: %v\nPerhaps scan has failed. Please check the scan results above or run trivy without pipes.\n", err)
 		return err
 	}
+	for k, v := range scanResult.ScannedCves {
+		if v.CveContents == nil {
+			v.CveContents = models.NewCveContents()
+			scanResult.ScannedCves[k] = v
+		}
+	}
 	scanResult.ServerUUID = serverUUID
 	if 0 < len(tags) {
 		if scanResult.Optional == nil {

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -691,6 +691,7 @@ func DetectCpeURIsCves(r *models.ScanResult, cpes []Cpe, cnf config.GoCveDictCon
 					CpeURIs:          []string{cpe.CpeURI},
 					Confidences:      models.Confidences{maxConfidence},
 					DistroAdvisories: advisories,
+					CveContents:      models.CveContents{},
 				}
 				r.ScannedCves[detail.CveID] = v
 				nCVEs++

--- a/detector/util.go
+++ b/detector/util.go
@@ -258,6 +258,13 @@ func loadOneServerScanResult(jsonFile string) (*models.ScanResult, error) {
 	if err := json.Unmarshal(data, result); err != nil {
 		return nil, xerrors.Errorf("Failed to parse %s: %w", jsonFile, err)
 	}
+
+	for k, v := range result.ScannedCves {
+		if v.CveContents == nil {
+			v.CveContents = models.NewCveContents()
+			result.ScannedCves[k] = v
+		}
+	}
 	return result, nil
 }
 

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -703,7 +703,8 @@ func mergeVulnInfo(a, b models.VulnInfo) (models.VulnInfo, error) {
 	}
 
 	info := models.VulnInfo{
-		CveID: a.CveID,
+		CveID:       a.CveID,
+		CveContents: models.CveContents{},
 	}
 
 	for _, cc := range []models.Confidences{a.Confidences, b.Confidences} {

--- a/reporter/util.go
+++ b/reporter/util.go
@@ -81,6 +81,13 @@ func loadOneServerScanResult(jsonFile string) (*models.ScanResult, error) {
 	if err := json.Unmarshal(data, result); err != nil {
 		return nil, xerrors.Errorf("Failed to parse %s: %w", jsonFile, err)
 	}
+
+	for k, v := range result.ScannedCves {
+		if v.CveContents == nil {
+			v.CveContents = models.NewCveContents()
+			result.ScannedCves[k] = v
+		}
+	}
 	return result, nil
 }
 

--- a/scanner/debian.go
+++ b/scanner/debian.go
@@ -825,6 +825,7 @@ func (o *debian) scanChangelogs(updatablePacks models.Packages, meta *cache.Meta
 			CveID:            cveID.CveID,
 			Confidences:      models.Confidences{cveID.Confidence},
 			AffectedPackages: affected,
+			CveContents:      models.CveContents{},
 		}
 	}
 

--- a/scanner/freebsd.go
+++ b/scanner/freebsd.go
@@ -232,6 +232,7 @@ func (o *bsd) scanUnsecurePackages() (models.VulnInfos, error) {
 			CveID:            cveID,
 			AffectedPackages: affected,
 			DistroAdvisories: disAdvs,
+			CveContents:      models.CveContents{},
 			Confidences:      models.Confidences{models.PkgAuditMatch},
 		}
 	}


### PR DESCRIPTION
# What did you implement:

There are some blind map accesses, for example
- https://github.com/future-architect/vuls/blob/c29a32f6ca3b8c112a4b4521431878fc928854c6/detector/vuls2/vuls2.go#L90
- https://github.com/future-architect/vuls/blob/c29a32f6ca3b8c112a4b4521431878fc928854c6/detector/wordpress.go#L123
- https://github.com/future-architect/vuls/blob/c29a32f6ca3b8c112a4b4521431878fc928854c6/detector/github.go#L135

To avoid nil map panics, add instantiations in initializing VulnInfo{}'s.
I listed out possible lines by grepping
- 'VulnInfo{' and
- 'json.Unmarshal`

If there are other possibilities, please let me know.

The changes should cover all CveContents instatiations, then no nil map panics should occur. But I leave existing nil checks for avoiding regression.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Just only single pattern:

Scan CPE and GitHub alerts:

Preparation
- config.toml
```
[servers.fix-nil-map]
type = "pseudo"
cpeNames = ["cpe:2.3:a:jwt-go_project:jwt-go:3.1.0:*:*:*:*:*:*:*"]

[servers.fix-nil-map.githubs."shino/dependabot-security-sample"]
token = "ghp_XXX"
```

- and scan it
```
[0]% ./bin.lo/vuls.c29a32f scan fix-nil-map
[Dec 19 16:19:25]  INFO [localhost] vuls-v0.37.0-build-20251219_155953_c29a32f
[Dec 19 16:19:25]  INFO [localhost] Start scanning
[Dec 19 16:19:25]  INFO [localhost] config: /home/shino/g/vuls/config.toml
[Dec 19 16:19:25]  INFO [localhost] Validating config...
[Dec 19 16:19:25]  INFO [localhost] Detecting Server/Container OS...
[Dec 19 16:19:25]  INFO [localhost] Detecting OS of servers...
[Dec 19 16:19:25]  INFO [localhost] (1/1) Detected: fix-nil-map: pseudo
[Dec 19 16:19:25]  INFO [localhost] Detecting OS of containers...
[Dec 19 16:19:25]  INFO [localhost] Checking Scan Modes...
[Dec 19 16:19:25]  INFO [localhost] Detecting Platforms...
[Dec 19 16:19:25]  INFO [localhost] (1/1) fix-nil-map is running on other
[Dec 19 16:19:25]  INFO [fix-nil-map] Scanning listen port...
[Dec 19 16:19:25]  INFO [fix-nil-map] Using Port Scanner: Vuls built-in Scanner


Scan Summary
================
fix-nil-map     pseudo  0 installed, 0 updatable
```

Before:
```
[0]% ./bin.lo/vuls.c29a32f report -refresh-cve
[Dec 19 16:05:20]  INFO [localhost] vuls-v0.37.0-build-20251219_155953_c29a32f
[Dec 19 16:05:20]  INFO [localhost] Validating config...
[Dec 19 16:05:20]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/data/vulsctl/docker.full/cve.sqlite3
[Dec 19 16:05:20]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/data/vulsctl/docker.empty/oval.sqlite3
[Dec 19 16:05:20]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/data/vulsctl/docker.empty/gost.sqlite3
[Dec 19 16:05:20]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/data/vulsctl/docker.empty/go-exploitdb.sqlite3
[Dec 19 16:05:20]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/data/vulsctl/docker.empty/go-msfdb.sqlite3
[Dec 19 16:05:20]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/data/vulsctl/docker.empty/go-kev.sqlite3
[Dec 19 16:05:20]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/data/vulsctl/docker.empty/go-cti.sqlite3
[Dec 19 16:05:20]  INFO [localhost] Loaded: /home/shino/g/vuls/results/2025-12-19T15-55-34+0900
[Dec 19 16:05:20]  INFO [localhost] pseudo type. Skip OVAL, gost and vuls2 detection
[Dec 19 16:05:20]  INFO [localhost] ghsa: 1 CVEs are detected with CPE
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/future-architect/vuls/detector.DetectGitHubSecurityAlerts(0xc000edb808, {0xc000cceeb5, 0x5}, {0xc000cceebb, 0x1a}, {0xc000cceee1, 0x28}, 0x0)
        github.com/future-architect/vuls/detector/github.go:135 +0x1413
github.com/future-architect/vuls/detector.DetectGitHubCves(0xc000edb808, 0xc000d7d8f0)
        github.com/future-architect/vuls/detector/detector.go:417 +0x1a5
github.com/future-architect/vuls/detector.Detect({0xc000eda008, 0x1, 0x1}, {0xc000d7b640, 0x33})
        github.com/future-architect/vuls/detector/detector.go:196 +0xde5
github.com/future-architect/vuls/subcmds.(*ReportCmd).Execute(0xc0006612f0, {0xc000154d70?, 0xc000d3fd90?}, 0xc00047d0a0, {0x1?, 0x4309620?, 0xc000d3fd01?})
        github.com/future-architect/vuls/subcmds/report.go:288 +0xa7d
github.com/google/subcommands.(*Commander).Execute(0xc000152700, {0x5f04410, 0x8b41dc0}, {0x0, 0x0, 0x0})
        github.com/google/subcommands@v1.2.0/subcommands.go:209 +0x37a
github.com/google/subcommands.Execute(...)
        github.com/google/subcommands@v1.2.0/subcommands.go:492
main.main()
        github.com/future-architect/vuls/cmd/vuls/main.go:37 +0x1794
```

After:
```
[2]% ./bin.lo/vuls.pr2379 report -refresh-cve
[Dec 19 16:05:35]  INFO [localhost] vuls-v0.37.0-build-20251219_155645_d66e4c8
[Dec 19 16:05:35]  INFO [localhost] Validating config...
[Dec 19 16:05:35]  INFO [localhost] cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=/data/vulsctl/docker.full/cve.sqlite3
[Dec 19 16:05:35]  INFO [localhost] ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=/data/vulsctl/docker.empty/oval.sqlite3
[Dec 19 16:05:35]  INFO [localhost] gost.type=sqlite3, gost.url=, gost.SQLite3Path=/data/vulsctl/docker.empty/gost.sqlite3
[Dec 19 16:05:35]  INFO [localhost] exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=/data/vulsctl/docker.empty/go-exploitdb.sqlite3
[Dec 19 16:05:35]  INFO [localhost] metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=/data/vulsctl/docker.empty/go-msfdb.sqlite3
[Dec 19 16:05:35]  INFO [localhost] kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=/data/vulsctl/docker.empty/go-kev.sqlite3
[Dec 19 16:05:35]  INFO [localhost] cti.type=sqlite3, cti.url=, cti.SQLite3Path=/data/vulsctl/docker.empty/go-cti.sqlite3
[Dec 19 16:05:35]  INFO [localhost] Loaded: /home/shino/g/vuls/results/2025-12-19T15-55-34+0900
[Dec 19 16:05:35]  INFO [localhost] pseudo type. Skip OVAL, gost and vuls2 detection
[Dec 19 16:05:36]  INFO [localhost] ghsa: 1 CVEs are detected with CPE
[Dec 19 16:05:36]  INFO [localhost] ghsa: 1 CVEs detected with GHSA shino/dependabot-security-sample
[Dec 19 16:05:37]  INFO [localhost] ghsa: 0 PoC are detected
[Dec 19 16:05:37]  INFO [localhost] ghsa: 0 exploits are detected
[Dec 19 16:05:37]  INFO [localhost] ghsa: Known Exploited Vulnerabilities are detected for 0 CVEs
[Dec 19 16:05:37]  INFO [localhost] ghsa: Cyber Threat Intelligences are detected for 0 CVEs
[Dec 19 16:05:37]  INFO [localhost] ghsa: total 1 CVEs detected
[Dec 19 16:05:37]  INFO [localhost] ghsa: 0 CVEs filtered by --confidence-over=80
ghsa (pseudo)
=============
Total: 1 (Critical:0 High:1 Medium:0 Low:0 ?:0)
0/0 Fixed, 0 poc, 0 exploits, 0 kevs, uscert: 0, jpcert: 0 alerts
0 installed

+----------------+------+--------+-----+-----+-------+-------+-----------------------------------------------------+
|     CVE-ID     | CVSS | Attack | PoC | KEV | Alert | Fixed |                      Packages                       |
+----------------+------+--------+-----+-----+-------+-------+-----------------------------------------------------+
| CVE-2020-26160 | 8.9  | AV:N   |     |     |       |       | cpe:/a:jwt-go_project:jwt-go:3.1.0,                 |
|                |      |        |     |     |       |       | https://github.com/shino/dependabot-security-sample |
|                |      |        |     |     |       |       | github.com/dgrijalva/jwt-go                         |
+----------------+------+--------+-----+-----+-------+-------+-----------------------------------------------------+
```


# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below


# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

