### PR TITLE
chore!(ci/release): update cosign to v3

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -15,9 +15,7 @@ jobs:
       id-token: write # For cosign
     steps:
       - name: Cosign install
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad
-        with:
-          cosign-release: "v2.6.1"
+        uses: sigstore/cosign-installer@4d14d7f17e7112af04ea6108fbb4bfc714c00390
       - name: Maximize build space
         uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c
         with:
@@ -43,4 +41,3 @@ jobs:
           args: release --clean --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -167,13 +167,10 @@ signs:
 - cmd: cosign
   env:
   - COSIGN_EXPERIMENTAL=1
-  signature: "${artifact}.sig"
-  certificate: "${artifact}.pem"
+  signature: "${artifact}.sigstore.json"
   args:
   - "sign-blob"
-  - "--oidc-issuer=https://token.actions.githubusercontent.com"
-  - "--output-certificate=${certificate}"
-  - "--output-signature=${signature}"
+  - "--bundle=${signature}"
   - "${artifact}"
   - "--yes"
   artifacts: all


### PR DESCRIPTION
# What did you implement:

Fixes #2347

- Update cosign installer to the latest commit 
  - https://github.com/sigstore/cosign-installer/commit/4d14d7f17e7112af04ea6108fbb4bfc714c00390
  - 3 weeks ago
  - remove cosign version restriction
- Fixes cosign args for v3

This is slightly breaking change, the output files of cosign becomes JSON instread of plain text ones.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

Counts of assets:
- previous release https://github.com/future-architect/vuls/releases/tag/v0.37.0
  - 95 assets
  - 2 are sources
  - Then, 31 {binary, sig, pem} groups
 - This release https://github.com/future-architect/vuls/releases/tag/v0.37.1-alpha.2
   - 64 assets
   - 2 are sources
   - Then, 31 {binary, signature.json} groups, the same

Verification and intentional failure:
```
[0]% cosign -d verify-blob vuls_0.37.1-alpha.2_linux_amd64.tar.gz \
  --bundle vuls_0.37.1-alpha.2_linux_amd64.tar.gz.sigstore.json \
  --certificate-identity "https://github.com/future-architect/vuls/.github/workflows/goreleaser.yml@refs/tags/v0.37.1-alpha.2" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
Verified OK
```

```
[0]% cat vuls_0.37.1-alpha.2_linux_amd64.tar.gz vuls_0.37.1-alpha.2_linux_amd64.tar.gz.sigstore.json > invalid-binary
[0]% cosign -d verify-blob invalid-binary \
  --bundle vuls_0.37.1-alpha.2_linux_amd64.tar.gz.sigstore.json \
  --certificate-identity "https://github.com/future-architect/vuls/.github/workflows/goreleaser.yml@refs/tags/v0.37.1-alpha.2" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
Error: failed to verify signature: could not verify message: invalid signature when validating ASN.1 encoded signature
error during command execution: failed to verify signature: could not verify message: invalid signature when validating ASN.1 encoded signature
```

Executions:

```
[0]% curl -L https://github.com/future-architect/vuls/releases/download/v0.37.1-alpha.2/future-vuls_0.37.1-alpha.2_linux_amd64.tar.gz | tar -zx
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 4350k  100 4350k    0     0  3710k      0  0:00:01  0:00:01 --:--:-- 3710k
[0]% ./future-vuls
Usage:
  future-vuls [command]

Available Commands:
  add-cpe     Create a pseudo server in Fvuls and register CPE. Default outputFile is ./discover_list.toml
  completion  Generate the autocompletion script for the specified shell
  discover    discover hosts with CIDR range. Run snmp2cpe on active host to get CPE. Default outputFile is ./discover_list.toml
  help        Help about any command
  upload      Upload to FutureVuls
  version     Show version

Flags:
  -h, --help   help for future-vuls

Use "future-vuls [command] --help" for more information about a command.

[0]% curl -L https://github.com/future-architect/vuls/releases/download/v0.37.1-alpha.2/vuls_0.37.1-alpha.2_linux_amd64.tar.gz | tar -zx
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 40.2M  100 40.2M    0     0  9476k      0  0:00:04  0:00:04 --:--:-- 11.3M
[0]% ./vuls
Usage: vuls <flags> <subcommand> <subcommand args>

Subcommands:
        commands         list all command names
        flags            describe all known top-level flags
        help             describe subcommands and their syntax

Subcommands for configtest:
        configtest       Test configuration

Subcommands for discover:
        discover         Host discovery in the CIDR

Subcommands for history:
        history          List history of scanning.

Subcommands for report:
        report           Reporting

Subcommands for scan:
        scan             Scan vulnerabilities

Subcommands for server:
        server           Server

Subcommands for tui:
        tui              Run Tui view to analyze vulnerabilities


Use "vuls flags" for a list of top-level flags
[2]%
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

