### PR TITLE
refactor(scanner/rpm): remove warn when output is only y/n prompt

### DIFF
--- a/scanner/redhatbase_test.go
+++ b/scanner/redhatbase_test.go
@@ -606,7 +606,7 @@ func Test_redhatBase_parseUpdatablePacksLine(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		want    models.Package
+		want    *models.Package
 		wantErr bool
 	}{
 		{
@@ -622,7 +622,7 @@ func Test_redhatBase_parseUpdatablePacksLine(t *testing.T) {
 			args: args{
 				line: `"zlib" "0" "1.2.7" "17.el7" "rhui-REGION-rhel-server-releases"`,
 			},
-			want: models.Package{
+			want: &models.Package{
 				Name:       "zlib",
 				NewVersion: "1.2.7",
 				NewRelease: "17.el7",
@@ -642,12 +642,27 @@ func Test_redhatBase_parseUpdatablePacksLine(t *testing.T) {
 			args: args{
 				line: `"shadow-utils" "2" "4.1.5.1" "24.el7" "rhui-REGION-rhel-server-releases"`,
 			},
-			want: models.Package{
+			want: &models.Package{
 				Name:       "shadow-utils",
 				NewVersion: "2:4.1.5.1",
 				NewRelease: "24.el7",
 				Repository: "rhui-REGION-rhel-server-releases",
 			},
+		},
+		{
+			name: `amazon 2023: Is this ok [y/N]: `,
+			fields: fields{
+				base: base{
+					Distro: config.Distro{
+						Family:  constant.Amazon,
+						Release: "2023.7.20250512",
+					},
+				},
+			},
+			args: args{
+				line: `Is this ok [y/N]: `,
+			},
+			want: nil,
 		},
 		{
 			name: `amazon 2023: Is this ok [y/N]: "dnf" "0" "4.14.0" "1.amzn2023.0.6" "amazonlinux"`,
@@ -662,7 +677,7 @@ func Test_redhatBase_parseUpdatablePacksLine(t *testing.T) {
 			args: args{
 				line: `Is this ok [y/N]: "dnf" "0" "4.14.0" "1.amzn2023.0.6" "amazonlinux"`,
 			},
-			want: models.Package{
+			want: &models.Package{
 				Name:       "dnf",
 				NewVersion: "4.14.0",
 				NewRelease: "1.amzn2023.0.6",


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

#2218 addressed the case where the y/n prompt is included. 
However, it did not take into account the case where only the y/n prompt is output, which resulted in a warning. 
This PR fixes that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## setup
```console
$ cat << EOS > Dockerfile
FROM public.ecr.aws/amazonlinux/amazonlinux:2023

RUN dnf upgrade -y && dnf install -y openssh-server glibc-langpack-en
RUN mkdir -p /var/run/sshd

RUN sed -i 's/#\?PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
RUN sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd

ENV NOTVISIBLE "in users profile"
RUN echo "export VISIBLE=now" >> /etc/profile

COPY .ssh/id_rsa.pub /root/authorized_keys
RUN mkdir -p ~/.ssh && \
    mv ~/authorized_keys ~/.ssh/authorized_keys && \
    chmod 0600 ~/.ssh/authorized_keys

RUN ssh-keygen -A
RUN rm -rf /run/nologin

EXPOSE 22

# Vuls Setting
RUN dnf install -y dnf-utils which lsof procps-ng iproute

RUN dnf update -y
RUN curl -o /etc/yum.repos.d/newrelic-infra.repo https://download.newrelic.com/infrastructure_agent/linux/yum/amazonlinux/2023/x86_64/newrelic-infra.repo

CMD ["/usr/sbin/sshd", "-D"]
EOS

$ docker build -t vuls-target:latest .
$ docker run --rm -d --name vuls-target -p 2222:22 vuls-target:latest

$ ssh-keygen -f "/home/vuls/.ssh/known_hosts" -R "[127.0.0.1]:2222" && ssh -i /home/vuls/.ssh/id_rsa -p 2222 root@127.0.0.1
...
   ,     #_
   ~\_  ####_        Amazon Linux 2023
  ~~  \_#####\
  ~~     \###|
  ~~       \#/ ___   https://aws.amazon.com/linux/amazon-linux-2023
   ~~       V~' '->
    ~~~         /
      ~~._.   _/
         _/ _/
       _/m/'
Last login: Tue May 27 02:17:04 2025 from 172.17.0.1

$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.docker]
host = "127.0.0.1"
port = "2222"
user = "root"
keyPath = "/home/vuls/.ssh/id_rsa"
scanMode           = ["fast-root"]
scanModules        = ["ospkg"]
EOS
```

## before
```console
$ curl -sL https://github.com/future-architect/vuls/releases/download/v0.37.0/vuls_0.37.0_linux_amd64.tar.gz | tar zxf - vuls
$ vuls scan
[Jan 14 15:32:32]  INFO [localhost] vuls-0.37.0-a27a33971c50f2218bc5118dea6edac0ec2ee1c0-2025-12-09T06:37:30Z
[Jan 14 15:32:32]  INFO [localhost] Start scanning
[Jan 14 15:32:32]  INFO [localhost] config: /home/vuls/config.toml
[Jan 14 15:32:32]  INFO [localhost] Validating config...
[Jan 14 15:32:32]  INFO [localhost] Detecting Server/Container OS... 
[Jan 14 15:32:32]  INFO [localhost] Detecting OS of servers... 
[Jan 14 15:32:33]  INFO [localhost] (1/1) Detected: docker: amazon 2023.10.20260105
[Jan 14 15:32:33]  INFO [localhost] Detecting OS of containers... 
[Jan 14 15:32:33]  INFO [localhost] Checking Scan Modes... 
[Jan 14 15:32:33]  INFO [localhost] Detecting Platforms... 
[Jan 14 15:32:35]  INFO [localhost] (1/1) docker is running on other
[Jan 14 15:32:35]  INFO [docker] Scanning OS pkg in fast-root mode
[Jan 14 15:32:39]  WARN [docker] err: Failed to scan updatable packages:
    github.com/future-architect/vuls/scanner.(*redhatBase).scanPackages
        github.com/future-architect/vuls/scanner/redhatbase.go:439
  - unexpected format. expected: "\"<name>\" \"<epoch>\" \"<version>\" \"<release>\" \"<repository>\"", actual: "":
    github.com/future-architect/vuls/scanner.(*redhatBase).parseUpdatablePacksLine
        github.com/future-architect/vuls/scanner/redhatbase.go:840
[Jan 14 15:32:39]  WARN [docker] Failed to detect a init system: File: /proc/1/exe -> /usr/sbin/sshd
[Jan 14 15:32:39]  WARN [localhost] Some warnings occurred during scanning on docker. Please fix the warnings to get a useful information. Execute configtest subcommand before scanning to know the cause of the warnings. warnings: [Failed to scan updatable packages:
    github.com/future-architect/vuls/scanner.(*redhatBase).scanPackages
        github.com/future-architect/vuls/scanner/redhatbase.go:439
  - unexpected format. expected: "\"<name>\" \"<epoch>\" \"<version>\" \"<release>\" \"<repository>\"", actual: "":
    github.com/future-architect/vuls/scanner.(*redhatBase).parseUpdatablePacksLine
        github.com/future-architect/vuls/scanner/redhatbase.go:840]
Scan Summary
================
docker  amazon2023.10.20260105  165 installed, 0 updatable
Warning: [Failed to scan updatable packages:
    github.com/future-architect/vuls/scanner.(*redhatBase).scanPackages
        github.com/future-architect/vuls/scanner/redhatbase.go:439
  - unexpected format. expected: "\"<name>\" \"<epoch>\" \"<version>\" \"<release>\" \"<repository>\"", actual: "":
    github.com/future-architect/vuls/scanner.(*redhatBase).parseUpdatablePacksLine
        github.com/future-architect/vuls/scanner/redhatbase.go:840]
To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

## after
```console
$ vuls scan
[Jan 14 15:37:34]  INFO [localhost] vuls-v0.37.0-build-20260114_153428_7ed7f8d
[Jan 14 15:37:34]  INFO [localhost] Start scanning
[Jan 14 15:37:34]  INFO [localhost] config: /home/vuls/config.toml
[Jan 14 15:37:34]  INFO [localhost] Validating config...
[Jan 14 15:37:34]  INFO [localhost] Detecting Server/Container OS... 
[Jan 14 15:37:34]  INFO [localhost] Detecting OS of servers... 
[Jan 14 15:37:35]  INFO [localhost] (1/1) Detected: docker: amazon 2023.10.20260105
[Jan 14 15:37:35]  INFO [localhost] Detecting OS of containers... 
[Jan 14 15:37:35]  INFO [localhost] Checking Scan Modes... 
[Jan 14 15:37:35]  INFO [localhost] Detecting Platforms... 
[Jan 14 15:37:37]  INFO [localhost] (1/1) docker is running on other
[Jan 14 15:37:37]  INFO [docker] Scanning OS pkg in fast-root mode
[Jan 14 15:37:41]  WARN [docker] Failed to detect a init system: File: /proc/1/exe -> /usr/sbin/sshd
Scan Summary
================
docker  amazon2023.10.20260105  165 installed, 0 updatable
To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://github.com/future-architect/vuls/pull/2218

