### PR TITLE
chore(ci/docker): Fix ENOSPC for docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,8 +7,8 @@ on:
     tags:
       - '*'
 
-permissions: 
-  contents: read  
+permissions:
+  contents: read
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -25,6 +25,17 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+        with:
+          path: "vuls"
+
+      - name: Setup Docker data root
+        run: |
+          sudo systemctl stop docker.service
+          sudo systemctl stop docker.socket
+          DOCKER_DATA_DIR="$GITHUB_WORKSPACE/.docker-data"
+          sudo mkdir -p "$DOCKER_DATA_DIR"
+          echo "{\"data-root\": \"$DOCKER_DATA_DIR\"}" | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker.service
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
@@ -57,8 +68,8 @@ jobs:
       - name: OSS image build and push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
-          context: .
-          file: ./Dockerfile
+          context: ./vuls/
+          file: ./vuls/Dockerfile
           push: true
           tags: |
             vuls/vuls:latest
@@ -70,8 +81,8 @@ jobs:
       - name: FutureVuls image build and push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
-          context: .
-          file: ./contrib/Dockerfile
+          context: ./vuls/
+          file: ./vuls/contrib/Dockerfile
           push: true
           tags: |
             vuls/fvuls:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb as builder
+FROM golang:alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS builder
 
 RUN apk add --no-cache \
         git \
@@ -6,27 +6,27 @@ RUN apk add --no-cache \
         gcc \
         musl-dev
 
-ENV REPOSITORY github.com/future-architect/vuls
+ENV REPOSITORY=github.com/future-architect/vuls
 COPY . $GOPATH/src/$REPOSITORY
 RUN cd $GOPATH/src/$REPOSITORY && make install
 
 FROM alpine:3.22@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
 
-ENV LOGDIR /var/log/vuls
-ENV WORKDIR /vuls
+ENV LOGDIR=/var/log/vuls
+ENV WORKDIR=/vuls
 
 RUN apk add --no-cache \
         openssh-client \
         ca-certificates \
         git \
         nmap \
-    && mkdir -p $WORKDIR $LOGDIR
+        && mkdir -p $WORKDIR $LOGDIR
 
 COPY --from=builder /go/bin/vuls /usr/local/bin/
 
 VOLUME ["$WORKDIR", "$LOGDIR"]
 WORKDIR $WORKDIR
-ENV PWD $WORKDIR
+ENV PWD=$WORKDIR
 
 ENTRYPOINT ["vuls"]
 CMD ["--help"]

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb as builder
+FROM golang:alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS builder
 
 RUN apk add --no-cache \
         git \
@@ -6,7 +6,7 @@ RUN apk add --no-cache \
         gcc \
         musl-dev
 
-ENV REPOSITORY github.com/future-architect/vuls
+ENV REPOSITORY=github.com/future-architect/vuls
 COPY . $GOPATH/src/$REPOSITORY
 RUN cd $GOPATH/src/$REPOSITORY && \
         make build-scanner && mv vuls $GOPATH/bin && \
@@ -16,19 +16,19 @@ RUN cd $GOPATH/src/$REPOSITORY && \
 
 FROM alpine:3.22@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
 
-ENV LOGDIR /var/log/vuls
-ENV WORKDIR /vuls
+ENV LOGDIR=/var/log/vuls
+ENV WORKDIR=/vuls
 
 RUN apk add --no-cache \
         openssh-client \
         ca-certificates \
         git \
         nmap \
-    && mkdir -p $WORKDIR $LOGDIR
+        && mkdir -p $WORKDIR $LOGDIR
 
 COPY --from=builder /go/bin/vuls /go/bin/trivy-to-vuls /go/bin/future-vuls /go/bin/snmp2cpe /usr/local/bin/
 COPY --from=aquasec/trivy:latest /usr/local/bin/trivy /usr/local/bin/trivy
 
 VOLUME ["$WORKDIR", "$LOGDIR"]
 WORKDIR $WORKDIR
-ENV PWD $WORKDIR
+ENV PWD=$WORKDIR


### PR DESCRIPTION
# What did you implement:

Docker publish CI became to fail recently by "no space".
e.g. https://github.com/future-architect/vuls/actions/runs/21624366538/job/62320708608

This PR moved docker data root to inside of "$GITHUB_WORKSPACE".
Also fixes some warnings of Dockerfiles.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

After moving, the workflow succeeded:
https://github.com/future-architect/vuls/actions/runs/21663167980/job/62452227017

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO  

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

