### PR TITLE
feat(trivy-to-vuls): get exact LockfilePath

### DIFF
--- a/contrib/trivy/parser/v2/parser.go
+++ b/contrib/trivy/parser/v2/parser.go
@@ -24,7 +24,7 @@ func (p ParserV2) Parse(vulnJSON []byte) (result *models.ScanResult, err error) 
 		return nil, err
 	}
 
-	scanResult, err := pkg.Convert(report.Results)
+	scanResult, err := pkg.Convert(report.Results, report.ArtifactType, report.ArtifactName)
 	if err != nil {
 		return nil, err
 	}

--- a/contrib/trivy/parser/v2/parser_test.go
+++ b/contrib/trivy/parser/v2/parser_test.go
@@ -560,8 +560,7 @@ var strutsSR = &models.ScanResult{
 					Name:    "commons-beanutils:commons-beanutils",
 					Version: "1.7.0",
 					FixedIn: "1.9.2",
-					//TODO use Artifactname?
-					Path: "Java",
+					Path:    "/data/struts-1.2.7/lib/Java",
 				},
 			},
 			AffectedPackages: models.PackageFixStatuses{},
@@ -638,8 +637,7 @@ var strutsSR = &models.ScanResult{
 					Name:    "struts:struts",
 					Version: "1.2.7",
 					FixedIn: "",
-					//TODO use Artifactname?
-					Path: "Java",
+					Path:    "/data/struts-1.2.7/lib/Java",
 				},
 			},
 			AffectedPackages: models.PackageFixStatuses{},
@@ -648,7 +646,7 @@ var strutsSR = &models.ScanResult{
 	LibraryScanners: models.LibraryScanners{
 		models.LibraryScanner{
 			Type:         "jar",
-			LockfilePath: "Java",
+			LockfilePath: "/data/struts-1.2.7/lib/Java",
 			Libs: []models.Library{
 				{
 					Name:    "commons-beanutils:commons-beanutils",
@@ -1099,7 +1097,7 @@ var osAndLibSR = &models.ScanResult{
 					Name:    "activesupport",
 					Version: "6.0.2.1",
 					FixedIn: "6.0.3.1, 5.2.4.3",
-					Path:    "Ruby",
+					Path:    "/var/lib/gems/2.5.0/specifications/activesupport-6.0.2.1.gemspec",
 				},
 			},
 		},
@@ -1107,7 +1105,7 @@ var osAndLibSR = &models.ScanResult{
 	LibraryScanners: models.LibraryScanners{
 		models.LibraryScanner{
 			Type:         "gemspec",
-			LockfilePath: "Ruby",
+			LockfilePath: "/var/lib/gems/2.5.0/specifications/activesupport-6.0.2.1.gemspec",
 			Libs: []models.Library{
 				{
 					Name:     "activesupport",
@@ -1589,7 +1587,7 @@ var osAndLib2SR = &models.ScanResult{
 					Name:    "activesupport",
 					Version: "6.0.2.1",
 					FixedIn: "6.0.3.1, 5.2.4.3",
-					Path:    "Ruby",
+					Path:    "/var/lib/gems/2.5.0/specifications/activesupport-6.0.2.1.gemspec",
 				},
 			},
 		},
@@ -1597,7 +1595,7 @@ var osAndLib2SR = &models.ScanResult{
 	LibraryScanners: models.LibraryScanners{
 		models.LibraryScanner{
 			Type:         "gemspec",
-			LockfilePath: "Ruby",
+			LockfilePath: "/var/lib/gems/2.5.0/specifications/activesupport-6.0.2.1.gemspec",
 			Libs: []models.Library{
 				{
 					Name:     "activesupport",
@@ -2884,14 +2882,14 @@ var oneCVEtoNVulnerabilitySR = &models.ScanResult{
 					Name:    "pubnub",
 					Version: "0.3.0",
 					FixedIn: "0.4.0",
-					Path:    "Cargo.lock",
+					Path:    "/Cargo.lock",
 				},
 				{
 					Key:     "composer",
 					Name:    "pubnub/pubnub",
 					Version: "6.0.0",
 					FixedIn: "6.1.0",
-					Path:    "composer.lock",
+					Path:    "/composer.lock",
 				},
 			},
 		},
@@ -2903,7 +2901,7 @@ var oneCVEtoNVulnerabilitySR = &models.ScanResult{
 				Name:    "pubnub",
 				Version: "0.3.0",
 			}},
-			LockfilePath: "Cargo.lock",
+			LockfilePath: "/Cargo.lock",
 		},
 		{
 			Type: "composer",
@@ -2911,7 +2909,7 @@ var oneCVEtoNVulnerabilitySR = &models.ScanResult{
 				Name:    "pubnub/pubnub",
 				Version: "6.0.0",
 			}},
-			LockfilePath: "composer.lock",
+			LockfilePath: "/composer.lock",
 		},
 	},
 	Packages: models.Packages{
@@ -3001,7 +2999,7 @@ var includeDevDependenciesSR = &models.ScanResult{
 					Dev:     true,
 				},
 			},
-			LockfilePath: "pnpm-lock.yaml",
+			LockfilePath: "integration/data/lockfile/pnpm-v9/pnpm-lock.yaml",
 		},
 	},
 	Optional: nil,

--- a/contrib/trivy/pkg/converter_test.go
+++ b/contrib/trivy/pkg/converter_test.go
@@ -1,0 +1,493 @@
+package pkg_test
+
+import (
+	"testing"
+
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/future-architect/vuls/contrib/trivy/pkg"
+)
+
+func Test_getLockfilePath(t *testing.T) {
+	type args struct {
+		scanmode     ftypes.ArtifactType
+		artifactName string
+		libType      ftypes.LangType
+		target       string
+		libFilepath  string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "image lockfiles:latest cargo lockfiles/Cargo.lock (empty)",
+			args: args{
+				scanmode:     ftypes.TypeContainerImage,
+				artifactName: "lockfiles:latest",
+				libType:      ftypes.Cargo,
+				target:       "lockfiles/Cargo.lock",
+				libFilepath:  "",
+			},
+			want: "/lockfiles/Cargo.lock",
+		},
+		{
+			name: "rootfs 4a14f0cecb17 cargo lockfiles/Cargo.lock (empty)",
+			args: args{
+				scanmode:     "rootfs",
+				artifactName: "4a14f0cecb17",
+				libType:      ftypes.Cargo,
+				target:       "lockfiles/Cargo.lock",
+				libFilepath:  "",
+			},
+			want: "lockfiles/Cargo.lock",
+		},
+		{
+			name: "filesystem lockfiles/Cargo.lock cargo Cargo.lock (empty)",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles/Cargo.lock",
+				libType:      ftypes.Cargo,
+				target:       "Cargo.lock",
+				libFilepath:  "",
+			},
+			want: "lockfiles/Cargo.lock",
+		},
+		{
+			name: "filesystem lockfiles cargo Cargo.lock (empty)",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles",
+				libType:      ftypes.Cargo,
+				target:       "Cargo.lock",
+				libFilepath:  "",
+			},
+			want: "lockfiles/Cargo.lock",
+		},
+		{
+			name: "repository lockfiles/Cargo.lock cargo Cargo.lock (empty)",
+			args: args{
+				scanmode:     ftypes.TypeRepository,
+				artifactName: "lockfiles/Cargo.lock",
+				libType:      ftypes.Cargo,
+				target:       "Cargo.lock",
+				libFilepath:  "",
+			},
+			want: "lockfiles/Cargo.lock",
+		},
+		{
+			name: "repository lockfiles cargo Cargo.lock (empty)",
+			args: args{
+				scanmode:     ftypes.TypeRepository,
+				artifactName: "lockfiles",
+				libType:      ftypes.Cargo,
+				target:       "Cargo.lock",
+				libFilepath:  "",
+			},
+			want: "lockfiles/Cargo.lock",
+		},
+		{
+			name: "image lockfiles:latest node-pkg Node.js (empty)",
+			args: args{
+				scanmode:     ftypes.TypeContainerImage,
+				artifactName: "lockfiles:latest",
+				libType:      ftypes.NodePkg,
+				target:       "Node.js",
+				libFilepath:  "",
+			},
+			want: "/Node.js",
+		},
+		{
+			name: "image lockfiles:latest node-pkg Node.js lockfiles/package.json",
+			args: args{
+				scanmode:     ftypes.TypeContainerImage,
+				artifactName: "lockfiles:latest",
+				libType:      ftypes.NodePkg,
+				target:       "Node.js",
+				libFilepath:  "lockfiles/package.json",
+			},
+			want: "/lockfiles/package.json",
+		},
+		{
+			name: "rootfs 4a14f0cecb17 node-pkg Node.js (empty)",
+			args: args{
+				scanmode:     "rootfs",
+				artifactName: "4a14f0cecb17",
+				libType:      ftypes.NodePkg,
+				target:       "Node.js",
+				libFilepath:  "",
+			},
+			want: "Node.js",
+		},
+		{
+			name: "rootfs 4a14f0cecb17 node-pkg Node.js lockfiles/package.json",
+			args: args{
+				scanmode:     "rootfs",
+				artifactName: "4a14f0cecb17",
+				libType:      ftypes.NodePkg,
+				target:       "Node.js",
+				libFilepath:  "lockfiles/package.json",
+			},
+			want: "lockfiles/package.json",
+		},
+		{
+			name: "filesystem lockfiles/package.json node-pkg Node.js (empty)",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles/package.json",
+				libType:      ftypes.NodePkg,
+				target:       "Node.js",
+				libFilepath:  "",
+			},
+			want: "lockfiles/package.json/Node.js",
+		},
+		{
+			name: "filesystem lockfiles/package.json node-pkg Node.js package.json",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles/package.json",
+				libType:      ftypes.NodePkg,
+				target:       "Node.js",
+				libFilepath:  "package.json",
+			},
+			want: "lockfiles/package.json",
+		},
+		{
+			name: "filesystem lockfiles node-pkg Node.js (empty)",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles",
+				libType:      ftypes.NodePkg,
+				target:       "Node.js",
+				libFilepath:  "",
+			},
+			want: "lockfiles/Node.js",
+		},
+		{
+			name: "filesystem lockfiles node-pkg Node.js package.json",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles",
+				libType:      ftypes.NodePkg,
+				target:       "Node.js",
+				libFilepath:  "package.json",
+			},
+			want: "lockfiles/package.json",
+		},
+		{
+			name: "image lockfiles:latest gemspec Ruby (empty)",
+			args: args{
+				scanmode:     ftypes.TypeContainerImage,
+				artifactName: "lockfiles:latest",
+				libType:      ftypes.GemSpec,
+				target:       "Ruby",
+				libFilepath:  "",
+			},
+			want: "/Ruby",
+		},
+		{
+			name: "image lockfiles:latest gemspec Ruby lockfiles/ruby/specifications/rake.gemspec",
+			args: args{
+				scanmode:     ftypes.TypeContainerImage,
+				artifactName: "lockfiles:latest",
+				libType:      ftypes.GemSpec,
+				target:       "Ruby",
+				libFilepath:  "lockfiles/ruby/specifications/rake.gemspec",
+			},
+			want: "/lockfiles/ruby/specifications/rake.gemspec",
+		},
+		{
+			name: "rootfs 4a14f0cecb17 gemspec Ruby (empty)",
+			args: args{
+				scanmode:     "rootfs",
+				artifactName: "4a14f0cecb17",
+				libType:      ftypes.GemSpec,
+				target:       "Ruby",
+				libFilepath:  "",
+			},
+			want: "Ruby",
+		},
+		{
+			name: "rootfs 4a14f0cecb17 gemspec Ruby lockfiles/ruby/specifications/rake.gemspec",
+			args: args{
+				scanmode:     "rootfs",
+				artifactName: "4a14f0cecb17",
+				libType:      ftypes.GemSpec,
+				target:       "Ruby",
+				libFilepath:  "lockfiles/ruby/specifications/rake.gemspec",
+			},
+			want: "lockfiles/ruby/specifications/rake.gemspec",
+		},
+		{
+			name: "filesystem lockfiles/ruby/specifications/rake.gemspec gemspec Ruby (empty)",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles/ruby/specifications/rake.gemspec",
+				libType:      ftypes.GemSpec,
+				target:       "Ruby",
+				libFilepath:  "",
+			},
+			want: "lockfiles/ruby/specifications/rake.gemspec/Ruby",
+		},
+		{
+			name: "filesystem lockfiles/ruby/specifications/rake.gemspec gemspec Ruby rake.gemspec",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles/ruby/specifications/rake.gemspec",
+				libType:      ftypes.GemSpec,
+				target:       "Ruby",
+				libFilepath:  "rake.gemspec",
+			},
+			want: "lockfiles/ruby/specifications/rake.gemspec",
+		},
+		{
+			name: "filesystem lockfiles gemspec Ruby (empty)",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles",
+				libType:      ftypes.GemSpec,
+				target:       "Ruby",
+				libFilepath:  "",
+			},
+			want: "lockfiles/Ruby",
+		},
+		{
+			name: "filesystem lockfiles gemspec Ruby ruby/specifications/rake.gemspec",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles",
+				libType:      ftypes.GemSpec,
+				target:       "Ruby",
+				libFilepath:  "ruby/specifications/rake.gemspec",
+			},
+			want: "lockfiles/ruby/specifications/rake.gemspec",
+		},
+		{
+			name: "image lockfiles:latest python-pkg Python (empty)",
+			args: args{
+				scanmode:     ftypes.TypeContainerImage,
+				artifactName: "lockfiles:latest",
+				libType:      ftypes.PythonPkg,
+				target:       "Python",
+				libFilepath:  "",
+			},
+			want: "/Python",
+		},
+		{
+			name: "image lockfiles:latest python-pkg Python lockfiles/packaging-25.0.dist-info/METADATA",
+			args: args{
+				scanmode:     ftypes.TypeContainerImage,
+				artifactName: "lockfiles:latest",
+				libType:      ftypes.PythonPkg,
+				target:       "Python",
+				libFilepath:  "lockfiles/packaging-25.0.dist-info/METADATA",
+			},
+			want: "/lockfiles/packaging-25.0.dist-info/METADATA",
+		},
+		{
+			name: "rootfs 4a14f0cecb17 python-pkg Python (empty)",
+			args: args{
+				scanmode:     "rootfs",
+				artifactName: "4a14f0cecb17",
+				libType:      ftypes.PythonPkg,
+				target:       "Python",
+				libFilepath:  "",
+			},
+			want: "Python",
+		},
+		{
+			name: "rootfs 4a14f0cecb17 python-pkg Python lockfiles/packaging-25.0.dist-info/METADATA",
+			args: args{
+				scanmode:     "rootfs",
+				artifactName: "4a14f0cecb17",
+				libType:      ftypes.PythonPkg,
+				target:       "Python",
+				libFilepath:  "lockfiles/packaging-25.0.dist-info/METADATA",
+			},
+			want: "lockfiles/packaging-25.0.dist-info/METADATA",
+		},
+		{
+			name: "filesystem lockfiles/packaging-25.0.dist-info python-pkg Python (empty)",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles/packaging-25.0.dist-info",
+				libType:      ftypes.PythonPkg,
+				target:       "Python",
+				libFilepath:  "",
+			},
+			want: "lockfiles/packaging-25.0.dist-info/Python",
+		},
+		{
+			name: "filesystem lockfiles/packaging-25.0.dist-info python-pkg Python METADATA",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles/packaging-25.0.dist-info",
+				libType:      ftypes.PythonPkg,
+				target:       "Python",
+				libFilepath:  "METADATA",
+			},
+			want: "lockfiles/packaging-25.0.dist-info/METADATA",
+		},
+		{
+			name: "filesystem lockfiles python-pkg Python (empty)",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles",
+				libType:      ftypes.PythonPkg,
+				target:       "Python",
+				libFilepath:  "",
+			},
+			want: "lockfiles/Python",
+		},
+		{
+			name: "filesystem lockfiles python-pkg Python packaging-25.0.dist-info/METADATA",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles",
+				libType:      ftypes.PythonPkg,
+				target:       "Python",
+				libFilepath:  "packaging-25.0.dist-info/METADATA",
+			},
+			want: "lockfiles/packaging-25.0.dist-info/METADATA",
+		},
+		{
+			name: "image lockfiles:latest jar Java (empty)",
+			args: args{
+				scanmode:     ftypes.TypeContainerImage,
+				artifactName: "lockfiles:latest",
+				libType:      ftypes.Jar,
+				target:       "Java",
+				libFilepath:  "",
+			},
+			want: "/Java",
+		},
+		{
+			name: "image lockfiles:latest jar Java lockfiles/log4j-core-2.13.0.jar",
+			args: args{
+				scanmode:     ftypes.TypeContainerImage,
+				artifactName: "lockfiles:latest",
+				libType:      ftypes.Jar,
+				target:       "Java",
+				libFilepath:  "lockfiles/log4j-core-2.13.0.jar",
+			},
+			want: "/lockfiles/log4j-core-2.13.0.jar",
+		},
+		{
+			name: "image lockfiles:latest jar Java lockfiles/juddiv3-war-3.3.5.war/WEB-INF/lib/log4j-1.2.17.jar",
+			args: args{
+				scanmode:     ftypes.TypeContainerImage,
+				artifactName: "lockfiles:latest",
+				libType:      ftypes.Jar,
+				target:       "Java",
+				libFilepath:  "lockfiles/juddiv3-war-3.3.5.war/WEB-INF/lib/log4j-1.2.17.jar",
+			},
+			want: "/lockfiles/juddiv3-war-3.3.5.war",
+		},
+		{
+			name: "rootfs 4a14f0cecb17 jar Java (empty)",
+			args: args{
+				scanmode:     "rootfs",
+				artifactName: "4a14f0cecb17",
+				libType:      ftypes.Jar,
+				target:       "Java",
+				libFilepath:  "",
+			},
+			want: "Java",
+		},
+		{
+			name: "rootfs 4a14f0cecb17 jar Java lockfiles/log4j-core-2.13.0.jar",
+			args: args{
+				scanmode:     "rootfs",
+				artifactName: "4a14f0cecb17",
+				libType:      ftypes.Jar,
+				target:       "Java",
+				libFilepath:  "lockfiles/log4j-core-2.13.0.jar",
+			},
+			want: "lockfiles/log4j-core-2.13.0.jar",
+		},
+		{
+			name: "rootfs 4a14f0cecb17 jar Java lockfiles/juddiv3-war-3.3.5.war/WEB-INF/lib/log4j-1.2.17.jar",
+			args: args{
+				scanmode:     "rootfs",
+				artifactName: "4a14f0cecb17",
+				libType:      ftypes.Jar,
+				target:       "Java",
+				libFilepath:  "lockfiles/juddiv3-war-3.3.5.war/WEB-INF/lib/log4j-1.2.17.jar",
+			},
+			want: "lockfiles/juddiv3-war-3.3.5.war",
+		},
+		{
+			name: "filesystem lockfiles/log4j-core-2.13.0.jar jar Java (empty)",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles/log4j-core-2.13.0.jar",
+				libType:      ftypes.Jar,
+				target:       "Java",
+				libFilepath:  "",
+			},
+			want: "lockfiles/log4j-core-2.13.0.jar/Java",
+		},
+		{
+			name: "filesystem lockfiles/log4j-core-2.13.0.jar jar Java log4j-core-2.13.0.jar",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles/log4j-core-2.13.0.jar",
+				libType:      ftypes.Jar,
+				target:       "Java",
+				libFilepath:  "log4j-core-2.13.0.jar",
+			},
+			want: "lockfiles/log4j-core-2.13.0.jar",
+		},
+		{
+			name: "filesystem lockfiles/juddiv3-war-3.3.5.war jar Java juddiv3-war-3.3.5.war/WEB-INF/lib/log4j-1.2.17.jar",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles/juddiv3-war-3.3.5.war",
+				libType:      ftypes.Jar,
+				target:       "Java",
+				libFilepath:  "juddiv3-war-3.3.5.war/WEB-INF/lib/log4j-1.2.17.jar",
+			},
+			want: "lockfiles/juddiv3-war-3.3.5.war",
+		},
+		{
+			name: "filesystem lockfiles jar Java (empty)",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles",
+				libType:      ftypes.Jar,
+				target:       "Java",
+				libFilepath:  "",
+			},
+			want: "lockfiles/Java",
+		},
+		{
+			name: "filesystem lockfiles jar Java log4j-core-2.13.0.jar",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles",
+				libType:      ftypes.Jar,
+				target:       "Java",
+				libFilepath:  "log4j-core-2.13.0.jar",
+			},
+			want: "lockfiles/log4j-core-2.13.0.jar",
+		},
+		{
+			name: "filesystem lockfiles jar Java juddiv3-war-3.3.5.war/WEB-INF/lib/log4j-1.2.17.jar",
+			args: args{
+				scanmode:     ftypes.TypeFilesystem,
+				artifactName: "lockfiles",
+				libType:      ftypes.Jar,
+				target:       "Java",
+				libFilepath:  "juddiv3-war-3.3.5.war/WEB-INF/lib/log4j-1.2.17.jar",
+			},
+			want: "lockfiles/juddiv3-war-3.3.5.war",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pkg.GetLockfilePath(tt.args.scanmode, tt.args.artifactName, tt.args.libType, tt.args.target, tt.args.libFilepath); got != tt.want {
+				t.Errorf("getLockfilePath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/contrib/trivy/pkg/export_test.go
+++ b/contrib/trivy/pkg/export_test.go
@@ -1,0 +1,3 @@
+package pkg
+
+var GetLockfilePath = getLockfilePath


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

LockfilePath is filename only.
https://github.com/future-architect/vuls/blob/7111680e8e4b75848b4bb91fb9d7649f12865169/contrib/trivy/parser/v2/parser_test.go#L3004


There may also be unknown paths, such as for Ruby or Java.
https://github.com/future-architect/vuls/blob/7111680e8e4b75848b4bb91fb9d7649f12865169/contrib/trivy/parser/v2/parser_test.go#L564

https://github.com/future-architect/vuls/blob/7111680e8e4b75848b4bb91fb9d7649f12865169/contrib/trivy/parser/v2/parser_test.go#L1110

For example, vuls scanner is obtained as follows:
```json
        {
            "Type": "jar",
            "Libs": [
                {
                    "Name": "org.apache.logging.log4j:log4j-core",
                    "Version": "2.13.0",
                    "PURL": "pkg:maven/org.apache.logging.log4j/log4j-core@2.13.0",
                    "FilePath": "home/vuls/integration/data/lockfile/log4j-core-2.13.0.jar",
                    "Digest": ""
                }
            ],
            "path": "/home/vuls/integration/data/lockfile/log4j-core-2.13.0.jar"
        },
```

There is also a bug where, because the LockfilePath is not properly separated, only one library with the same Name and Version is managed when passed through trivy-to-vuls.
```console
$ trivy rootfs --format json --list-all-pkgs .
...
  "ArtifactName": ".",
  "ArtifactType": "filesystem",
  "Results": [
    {
      "Target": "Java",
      "Class": "lang-pkgs",
      "Type": "jar",
      "Packages": [
        {
          "Name": "org.apache.logging.log4j:log4j-core",
          "Identifier": {
            "PURL": "pkg:maven/org.apache.logging.log4j/log4j-core@2.13.0",
            "UID": "cc196a0057a107fa"
          },
          "Version": "2.13.0",
          "FilePath": "1/log4j-core-2.13.0.jar",
          "AnalyzedBy": "jar"
        },
        {
          "Name": "org.apache.logging.log4j:log4j-core",
          "Identifier": {
            "PURL": "pkg:maven/org.apache.logging.log4j/log4j-core@2.13.0",
            "UID": "921978cc2760acf4"
          },
          "Version": "2.13.0",
          "FilePath": "2/log4j-core-2.13.0.jar",
          "AnalyzedBy": "jar"
        }
      ],
...

$ trivy rootfs --format json --list-all-pkgs . | trivy-to-vuls parse --stdin | jjq -r '.libraries'
[
  {
    "Type": "jar",
    "Libs": [
      {
        "Name": "org.apache.logging.log4j:log4j-core",
        "Version": "2.13.0",
        "PURL": "pkg:maven/org.apache.logging.log4j/log4j-core@2.13.0",
        "FilePath": "2/log4j-core-2.13.0.jar",
        "Digest": ""
      }
    ],
    "path": "Java"
  }
]
```

Even trivy-to-vuls fills in the exact LockfilePath to get closer to the results of the vuls scanner.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ trivy fs --format json --list-all-pkgs --include-dev-deps /home/vuls/integration/data/lockfile/Cargo.lock | trivy-to-vuls parse --stdin | jq -r '.libraries'
[
  {
    "Type": "cargo",
    "Libs": [
      {
        "Name": "Inflector",
        "Version": "0.11.4",
        "PURL": "pkg:cargo/Inflector@0.11.4",
        "FilePath": "",
        "Digest": ""
      },
      ...
      {
        "Name": "wio",
        "Version": "0.2.2",
        "PURL": "pkg:cargo/wio@0.2.2",
        "FilePath": "",
        "Digest": ""
      }
    ],
    "path": "Cargo.lock"
  }
]

$ trivy rootfs --format json --list-all-pkgs /home/vuls/integration/data/lockfile/juddiv3-war-3.3.5.war | trivy-to-vuls parse --stdin | jq -r '.libraries'
[
  {
    "Type": "jar",
    "Libs": [
      {
        "Name": "antlr:antlr",
        "Version": "2.7.7",
        "PURL": "pkg:maven/antlr/antlr@2.7.7",
        "FilePath": "juddiv3-war-3.3.5.war/WEB-INF/lib/antlr-2.7.7.jar",
        "Digest": ""
      },
      ...
      {
        "Name": "xml-resolver:xml-resolver",
        "Version": "1.2",
        "PURL": "pkg:maven/xml-resolver/xml-resolver@1.2",
        "FilePath": "juddiv3-war-3.3.5.war/WEB-INF/lib/xml-resolver-1.2.jar",
        "Digest": ""
      }
    ],
    "path": "Java"
  }
]
```

## after
```console
$ trivy fs --format json --list-all-pkgs --include-dev-deps /home/vuls/integration/data/lockfile/Cargo.lock | trivy-to-vuls parse --stdin | jq -r '.libraries'
[
  {
    "Type": "cargo",
    "Libs": [
      {
        "Name": "Inflector",
        "Version": "0.11.4",
        "PURL": "pkg:cargo/Inflector@0.11.4",
        "FilePath": "",
        "Digest": "",
        "Dev": false
      },
      ...
      {
        "Name": "wio",
        "Version": "0.2.2",
        "PURL": "pkg:cargo/wio@0.2.2",
        "FilePath": "",
        "Digest": "",
        "Dev": false
      }
    ],
    "path": "/home/vuls/integration/data/lockfile/Cargo.lock"
  }
]

$ trivy rootfs --format json --list-all-pkgs /home/vuls/integration/data/lockfile/juddiv3-war-3.3.5.war | trivy-to-vuls parse --stdin | jq -r '.libraries'
[
  {
    "Type": "jar",
    "Libs": [
      {
        "Name": "antlr:antlr",
        "Version": "2.7.7",
        "PURL": "pkg:maven/antlr/antlr@2.7.7",
        "FilePath": "juddiv3-war-3.3.5.war/WEB-INF/lib/antlr-2.7.7.jar",
        "Digest": "",
        "Dev": false
      },
      ...
      {
        "Name": "xml-resolver:xml-resolver",
        "Version": "1.2",
        "PURL": "pkg:maven/xml-resolver/xml-resolver@1.2",
        "FilePath": "juddiv3-war-3.3.5.war/WEB-INF/lib/xml-resolver-1.2.jar",
        "Digest": "",
        "Dev": false
      }
    ],
    "path": "/home/vuls/integration/data/lockfile/juddiv3-war-3.3.5.war"
  }
]
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

