### PR TITLE
fix(scanner/base): set abspath to LockfilePath

### DIFF
--- a/scanner/base.go
+++ b/scanner/base.go
@@ -741,7 +741,10 @@ func (l *base) scanLibraries() (err error) {
 		if err != nil {
 			return xerrors.Errorf("Failed to analyze library. err: %w, filepath: %s", err, abspath)
 		}
-		l.LibraryScanners = append(l.LibraryScanners, libraryScanners...)
+		for _, libscanner := range libraryScanners {
+			libscanner.LockfilePath = abspath
+			l.LibraryScanners = append(l.LibraryScanners, libscanner)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

When scanning a library, the path to the lockfile was notated differently in pseudo scan and base (linux) scan.

```json
{
    "family": "pseudo",
    "release": "",
    "libraries": [
        {
            "Type": "bundler",
            "Libs": [
                {
                    "Name": "actionmailer",
                    "Version": "4.2.6",
                    "PURL": "pkg:gem/actionmailer@4.2.6",
                    "FilePath": "",
                    "Digest": "",
                    "Dev": false
                },
                ...
                {
                    "Name": "yard",
                    "Version": "0.8.7.6",
                    "PURL": "pkg:gem/yard@0.8.7.6",
                    "FilePath": "",
                    "Digest": "",
                    "Dev": false
                }
            ],
            "path": "/home/vuls/integration/data/lockfile/Gemfile.lock"
        },
        {
            "Type": "cargo",
            "Libs": [
                {
                    "Name": "Inflector",
                    "Version": "0.11.4",
                    "PURL": "pkg:cargo/Inflector@0.11.4",
                    "FilePath": "",
                    "Digest": "",
                    "Dev": false
                },
                ...
                {
                    "Name": "wio",
                    "Version": "0.2.2",
                    "PURL": "pkg:cargo/wio@0.2.2",
                    "FilePath": "",
                    "Digest": "",
                    "Dev": false
                }
            ],
            "path": "/home/vuls/integration/data/lockfile/Cargo.lock"
        }
    ],
}
```

```json
{
    "family": "ubuntu",
    "release": "22.04",
    "libraries": [
        {
            "Type": "bundler",
            "Libs": [
                {
                    "Name": "actionmailer",
                    "Version": "4.2.6",
                    "PURL": "pkg:gem/actionmailer@4.2.6",
                    "FilePath": "",
                    "Digest": "",
                    "Dev": false
                },
                ...
                {
                    "Name": "yard",
                    "Version": "0.8.7.6",
                    "PURL": "pkg:gem/yard@0.8.7.6",
                    "FilePath": "",
                    "Digest": "",
                    "Dev": false
                }
            ],
            "path": "/home/vuls/integration/data/lockfile/Gemfile.lock"
        },
        {
            "Type": "cargo",
            "Libs": [
                {
                    "Name": "Inflector",
                    "Version": "0.11.4",
                    "PURL": "pkg:cargo/Inflector@0.11.4",
                    "FilePath": "",
                    "Digest": "",
                    "Dev": false
                },
                ...
                {
                    "Name": "wio",
                    "Version": "0.2.2",
                    "PURL": "pkg:cargo/wio@0.2.2",
                    "FilePath": "",
                    "Digest": "",
                    "Dev": false
                }
            ],
            "path": "home/vuls/integration/data/lockfile/Cargo.lock"
        }
    ],
}
```

This is because pseudo re-sets abspath in the LockfilePath of AnalyzeLibrary, but the Linux system remains the result of AnalyzeLibrary.

- base: https://github.com/future-architect/vuls/blob/44a04b79d3a7daffb35d0307fed00412578f7c81/scanner/base.go#L813
- windows: https://github.com/future-architect/vuls/blob/44a04b79d3a7daffb35d0307fed00412578f7c81/scanner/windows.go#L5504-L5507
- pseudo: https://github.com/future-architect/vuls/blob/44a04b79d3a7daffb35d0307fed00412578f7c81/scanner/pseudo.go#L138-L141

The library is scanned in two ways using Trivy's AnalyzeFile and PostAnalyze.

AnalyzeFile: https://github.com/future-architect/vuls/blob/44a04b79d3a7daffb35d0307fed00412578f7c81/scanner/base.go#L766
PostAnalyze: https://github.com/future-architect/vuls/blob/44a04b79d3a7daffb35d0307fed00412578f7c81/scanner/base.go#L804

This time, Gemfile.lock was scanned with AnalyzeFile and Cargo.lock was scanned with PostAnalyze.

https://github.com/aquasecurity/trivy/blob/7acb5f6f095a11cb9911af5a0bc03aecc7c88f8f/pkg/fanal/analyzer/language/ruby/bundler/bundler.go#L17
https://github.com/aquasecurity/trivy/blob/7acb5f6f095a11cb9911af5a0bc03aecc7c88f8f/pkg/fanal/analyzer/language/rust/cargo/cargo.go#L35

In PostAnalyze, the leading "/" was removed by clean path.

https://github.com/aquasecurity/trivy/blob/7acb5f6f095a11cb9911af5a0bc03aecc7c88f8f/pkg/mapfs/fs.go#L204

This is why the notation was different between pseudo and base.
Therefore, in this PR, base scan also sets abspath in LockfilePath.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

### config.toml
```toml
[servers]
[servers.library]
host = "localhost"
port = "local"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = [
    "/home/vuls/integration/data/lockfile/Gemfile.lock",
    "/home/vuls/integration/data/lockfile/Cargo.lock",
]
```

## before
```console
$ vuls -v
vuls-0.38.0-c5cdf1ceb8601c272ab16aea54edb23f07435b3c-2026-02-13T03:29:28Z
$ vuls scan
$ jq -r '.libraries[].path' results/2026-02-20T06-14-36+0900/library.json 
/home/vuls/integration/data/lockfile/Gemfile.lock
home/vuls/integration/data/lockfile/Cargo.lock
```

## after
```console
$ vuls scan
$ jq -r '.libraries[].path' results/2026-02-20T09-18-35+0900/library.json 
/home/vuls/integration/data/lockfile/Gemfile.lock
/home/vuls/integration/data/lockfile/Cargo.lock
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

