### PR TITLE
fix(report): sort datetime dir in descending order

### DIFF
--- a/reporter/util.go
+++ b/reporter/util.go
@@ -2,6 +2,7 @@ package reporter
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -110,7 +111,9 @@ func ListValidJSONDirs(resultsDir string) (dirs []string, err error) {
 			}
 		}
 	}
-	slices.Sort(dirs)
+	slices.SortFunc(dirs, func(a, b string) int {
+		return -cmp.Compare(a, b)
+	})
 	return
 }
 

--- a/subcmds/report_windows.go
+++ b/subcmds/report_windows.go
@@ -193,7 +193,7 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 }
 
 // Execute execute
-func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
+func (p *ReportCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	logging.Log = logging.NewCustomLogger(config.Conf.Debug, config.Conf.Quiet, config.Conf.LogToFile, config.Conf.LogDir, "", "")
 	logging.Log.Infof("vuls-%s-%s", config.Version, config.Revision)
 


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Run report on the contents of the most recent date directory.
Therefore, we reverse the compare in the sort.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```
$ tree results/
results/
├── 2024-03-06T18-50-16+0900
│   └── docker.json
└── 2026-02-20T15-26-00+0900
    └── vagrant.json

2 directories, 2 files
```

## before
```console
$ vuls report
[Feb 20 15:45:56]  INFO [localhost] vuls-v0.38.0-build-20260220_154547_5eff007
...
[Feb 20 15:45:56]  INFO [localhost] Loaded: /home/vuls/results/2024-03-06T18-50-16+0900
...
```

## after
```console
$ vuls report
[Feb 20 15:47:03]  INFO [localhost] vuls-v0.38.0-build-20260220_154655_71f184f
...
[Feb 20 15:47:03]  INFO [localhost] Loaded: /home/vuls/results/2026-02-20T15-26-00+0900
...
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

