### PR TITLE
fix(scanner/windows): revert "check invalid property, scanner err (#2419)

### DIFF
--- a/scanner/windows_test.go
+++ b/scanner/windows_test.go
@@ -814,10 +814,16 @@ func Test_parseGetPackageMSU(t *testing.T) {
 			args: args{
 				stdout: `
 Name         : Git
+Version      : 2.35.1.2
+ProviderName : Programs
 
 Name         : Oracle Database 11g Express Edition
+Version      : 11.2.0
+ProviderName : msi
 
 Name         : 2022-12 x64 ベース システム用 Windows 10 Version 21H2 の累積更新プログラム (KB5021233)
+Version      :
+ProviderName : msu
 `,
 			},
 			want:    []string{"5021233"},
@@ -1017,17 +1023,17 @@ func Test_windows_detectKBsFromKernelVersion(t *testing.T) {
 
 func Test_windows_parseIP(t *testing.T) {
 	tests := []struct {
-		name          string
-		args          string
-		wantIPv4Addrs []string
-		wantIPv6Addrs []string
-		wantErr       bool
+		name      string
+		args      string
+		ipv4Addrs []string
+		ipv6Addrs []string
 	}{
 		{
 			name: "en",
 			args: `
 
 Windows IP Configuration
+
 
 Ethernet adapter イーサネット 4:
 
@@ -1068,14 +1074,15 @@ Ethernet adapter Bluetooth ネットワーク接続:
    Media State . . . . . . . . . . . : Media disconnected
    Connection-specific DNS Suffix  . :
 `,
-			wantIPv4Addrs: []string{"10.145.8.50", "192.168.56.1", "192.168.0.205"},
-			wantIPv6Addrs: []string{"fe80::19b6:ae27:d1fe:2041", "fe80::7080:8828:5cc8:c0ba", "fe80::f49d:2c16:4270:759d"},
+			ipv4Addrs: []string{"10.145.8.50", "192.168.56.1", "192.168.0.205"},
+			ipv6Addrs: []string{"fe80::19b6:ae27:d1fe:2041", "fe80::7080:8828:5cc8:c0ba", "fe80::f49d:2c16:4270:759d"},
 		},
 		{
 			name: "ja",
 			args: `
 
 Windows IP 構成
+
 
 イーサネット アダプター イーサネット 4:
 
@@ -1116,22 +1123,18 @@ Wireless LAN adapter Wi-Fi:
    メディアの状態. . . . . . . . . . . .: メディアは接続されていません
    接続固有の DNS サフィックス . . . . .:
 `,
-			wantIPv4Addrs: []string{"10.145.8.50", "192.168.56.1", "192.168.0.205"},
-			wantIPv6Addrs: []string{"fe80::19b6:ae27:d1fe:2041", "fe80::7080:8828:5cc8:c0ba", "fe80::f49d:2c16:4270:759d"},
+			ipv4Addrs: []string{"10.145.8.50", "192.168.56.1", "192.168.0.205"},
+			ipv6Addrs: []string{"fe80::19b6:ae27:d1fe:2041", "fe80::7080:8828:5cc8:c0ba", "fe80::f49d:2c16:4270:759d"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotIPv4s, gotIPv6s, gotErr := (&windows{}).parseIP(tt.args)
-			if (gotErr != nil) != tt.wantErr {
-				t.Errorf("windows.parseIP() error = %v, wantErr %v", gotErr, tt.wantErr)
-				return
+			gotIPv4s, gotIPv6s := (&windows{}).parseIP(tt.args)
+			if !reflect.DeepEqual(gotIPv4s, tt.ipv4Addrs) {
+				t.Errorf("windows.parseIP() got = %v, want %v", gotIPv4s, tt.ipv4Addrs)
 			}
-			if !reflect.DeepEqual(gotIPv4s, tt.wantIPv4Addrs) {
-				t.Errorf("windows.parseIP() got = %v, want %v", gotIPv4s, tt.wantIPv4Addrs)
-			}
-			if !reflect.DeepEqual(gotIPv6s, tt.wantIPv6Addrs) {
-				t.Errorf("windows.parseIP() got = %v, want %v", gotIPv6s, tt.wantIPv6Addrs)
+			if !reflect.DeepEqual(gotIPv6s, tt.ipv6Addrs) {
+				t.Errorf("windows.parseIP() got = %v, want %v", gotIPv6s, tt.ipv6Addrs)
 			}
 		})
 	}


### PR DESCRIPTION
This reverts #2419 (commit 44a04b79d3a7daffb35d0307fed00412578f7c81).

# What did you implement:

Because v0.38.1 scanner failed as #2427, this reverts it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
[servers.localhost]
host = "localhost"
port = "local"
```

scan & report

```
PS C:\Users\shino\vuls> ./vuls.exe -v
vuls-v0.38.1-build-20260220_181007_e09dea0
PS C:\Users\shino\vuls> ./vuls.exe scan localhost
time="Feb 20 18:15:20" level=info msg="vuls-v0.38.1-build-20260220_181007_e09dea0"
time="Feb 20 18:15:20" level=info msg="Start scanning"
time="Feb 20 18:15:20" level=info msg="config: C:\\Users\\shino\\vuls\\config.toml"
time="Feb 20 18:15:20" level=info msg="Validating config..."
time="Feb 20 18:15:20" level=info msg="Detecting Server/Container OS... "
time="Feb 20 18:15:20" level=info msg="Detecting OS of servers... "
time="Feb 20 18:15:22" level=info msg="(1/1) Detected: localhost: windows Windows 11 Version 24H2 for x64-based Systems"
time="Feb 20 18:15:22" level=info msg="Detecting OS of containers... "
time="Feb 20 18:15:22" level=info msg="Checking Scan Modes... "
time="Feb 20 18:15:22" level=info msg="Detecting Platforms... "
time="Feb 20 18:15:25" level=info msg="(1/1) localhost is running on other"
time="Feb 20 18:15:35" level=info msg="Scanning listen port..."
time="Feb 20 18:15:35" level=info msg="Using Port Scanner: Vuls built-in Scanner"


Scan Summary
================
localhost       windowsWindows 11 Version 24H2 for x64-based Systems    38 installed, 0 updatable
```

```
PS C:\Users\shino\vuls> ./vuls.exe report
time="Feb 20 18:15:40" level=info msg="vuls-v0.38.1-build-20260220_181007_e09dea0"
time="Feb 20 18:15:40" level=info msg="Validating config..."
time="Feb 20 18:15:40" level=info msg="cveDict.type=sqlite3, cveDict.url=, cveDict.SQLite3Path=C:\\Users\\shino\\vuls\\cve.sqlite3"
time="Feb 20 18:15:40" level=warning msg="cveDict.SQLite3Path=C:\\Users\\shino\\vuls\\cve.sqlite3 file not found"
time="Feb 20 18:15:40" level=info msg="ovalDict.type=sqlite3, ovalDict.url=, ovalDict.SQLite3Path=C:\\Users\\shino\\vuls\\oval.sqlite3"
time="Feb 20 18:15:40" level=warning msg="ovalDict.SQLite3Path=C:\\Users\\shino\\vuls\\oval.sqlite3 file not found"
time="Feb 20 18:15:40" level=info msg="gost.type=sqlite3, gost.url=, gost.SQLite3Path=C:\\Users\\shino\\vuls\\gost.sqlite3"
time="Feb 20 18:15:40" level=warning msg="gost.SQLite3Path=C:\\Users\\shino\\vuls\\gost.sqlite3 file not found"
time="Feb 20 18:15:40" level=info msg="exploit.type=sqlite3, exploit.url=, exploit.SQLite3Path=C:\\Users\\shino\\vuls\\go-exploitdb.sqlite3"
time="Feb 20 18:15:40" level=warning msg="exploit.SQLite3Path=C:\\Users\\shino\\vuls\\go-exploitdb.sqlite3 file not found"
time="Feb 20 18:15:40" level=info msg="metasploit.type=sqlite3, metasploit.url=, metasploit.SQLite3Path=C:\\Users\\shino\\vuls\\go-msfdb.sqlite3"
time="Feb 20 18:15:40" level=warning msg="metasploit.SQLite3Path=C:\\Users\\shino\\vuls\\go-msfdb.sqlite3 file not found"
time="Feb 20 18:15:40" level=info msg="kevuln.type=sqlite3, kevuln.url=, kevuln.SQLite3Path=C:\\Users\\shino\\vuls\\go-kev.sqlite3"
time="Feb 20 18:15:40" level=warning msg="kevuln.SQLite3Path=C:\\Users\\shino\\vuls\\go-kev.sqlite3 file not found"
time="Feb 20 18:15:40" level=info msg="cti.type=sqlite3, cti.url=, cti.SQLite3Path=C:\\Users\\shino\\vuls\\go-cti.sqlite3"
time="Feb 20 18:15:40" level=warning msg="cti.SQLite3Path=C:\\Users\\shino\\vuls\\go-cti.sqlite3 file not found"
time="Feb 20 18:15:40" level=info msg="Loaded: C:\\Users\\shino\\vuls\\results\\2026-02-20T18-15-25+0900"
time="Feb 20 18:15:41" level=info msg="localhost: 0 CVEs are detected with gost"
time="Feb 20 18:15:44" level=info msg="localhost: 0 CVEs are detected with CPE"
time="Feb 20 18:15:44" level=info msg="localhost: 0 PoC are detected"
time="Feb 20 18:15:44" level=info msg="localhost: 0 exploits are detected"
time="Feb 20 18:15:44" level=info msg="localhost: Known Exploited Vulnerabilities are detected for 0 CVEs"
time="Feb 20 18:15:45" level=info msg="localhost: Cyber Threat Intelligences are detected for 0 CVEs"
time="Feb 20 18:15:45" level=info msg="localhost: total 0 CVEs detected"
time="Feb 20 18:15:45" level=info msg="localhost: 0 CVEs filtered by --confidence-over=80"

localhost (windowsWindows 11 Version 24H2 for x64-based Systems)
================================================================
Total: 0 (Critical:0 High:0 Medium:0 Low:0 ?:0)
0/0 Fixed, 0 poc, 0 exploits, 0 kevs, uscert: 0, jpcert: 0 alerts
38 installed

No CVE-IDs are found in updatable packages.
38 installed
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

