### PR TITLE
refactor(scanner/windows): check invalid property, scanner err

### DIFF
--- a/scanner/windows_test.go
+++ b/scanner/windows_test.go
@@ -814,16 +814,10 @@ func Test_parseGetPackageMSU(t *testing.T) {
 			args: args{
 				stdout: `
 Name         : Git
-Version      : 2.35.1.2
-ProviderName : Programs
 
 Name         : Oracle Database 11g Express Edition
-Version      : 11.2.0
-ProviderName : msi
 
 Name         : 2022-12 x64 ベース システム用 Windows 10 Version 21H2 の累積更新プログラム (KB5021233)
-Version      :
-ProviderName : msu
 `,
 			},
 			want:    []string{"5021233"},
@@ -1023,17 +1017,17 @@ func Test_windows_detectKBsFromKernelVersion(t *testing.T) {
 
 func Test_windows_parseIP(t *testing.T) {
 	tests := []struct {
-		name      string
-		args      string
-		ipv4Addrs []string
-		ipv6Addrs []string
+		name          string
+		args          string
+		wantIPv4Addrs []string
+		wantIPv6Addrs []string
+		wantErr       bool
 	}{
 		{
 			name: "en",
 			args: `
 
 Windows IP Configuration
-
 
 Ethernet adapter イーサネット 4:
 
@@ -1074,15 +1068,14 @@ Ethernet adapter Bluetooth ネットワーク接続:
    Media State . . . . . . . . . . . : Media disconnected
    Connection-specific DNS Suffix  . :
 `,
-			ipv4Addrs: []string{"10.145.8.50", "192.168.56.1", "192.168.0.205"},
-			ipv6Addrs: []string{"fe80::19b6:ae27:d1fe:2041", "fe80::7080:8828:5cc8:c0ba", "fe80::f49d:2c16:4270:759d"},
+			wantIPv4Addrs: []string{"10.145.8.50", "192.168.56.1", "192.168.0.205"},
+			wantIPv6Addrs: []string{"fe80::19b6:ae27:d1fe:2041", "fe80::7080:8828:5cc8:c0ba", "fe80::f49d:2c16:4270:759d"},
 		},
 		{
 			name: "ja",
 			args: `
 
 Windows IP 構成
-
 
 イーサネット アダプター イーサネット 4:
 
@@ -1123,18 +1116,22 @@ Wireless LAN adapter Wi-Fi:
    メディアの状態. . . . . . . . . . . .: メディアは接続されていません
    接続固有の DNS サフィックス . . . . .:
 `,
-			ipv4Addrs: []string{"10.145.8.50", "192.168.56.1", "192.168.0.205"},
-			ipv6Addrs: []string{"fe80::19b6:ae27:d1fe:2041", "fe80::7080:8828:5cc8:c0ba", "fe80::f49d:2c16:4270:759d"},
+			wantIPv4Addrs: []string{"10.145.8.50", "192.168.56.1", "192.168.0.205"},
+			wantIPv6Addrs: []string{"fe80::19b6:ae27:d1fe:2041", "fe80::7080:8828:5cc8:c0ba", "fe80::f49d:2c16:4270:759d"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotIPv4s, gotIPv6s := (&windows{}).parseIP(tt.args)
-			if !reflect.DeepEqual(gotIPv4s, tt.ipv4Addrs) {
-				t.Errorf("windows.parseIP() got = %v, want %v", gotIPv4s, tt.ipv4Addrs)
+			gotIPv4s, gotIPv6s, gotErr := (&windows{}).parseIP(tt.args)
+			if (gotErr != nil) != tt.wantErr {
+				t.Errorf("windows.parseIP() error = %v, wantErr %v", gotErr, tt.wantErr)
+				return
 			}
-			if !reflect.DeepEqual(gotIPv6s, tt.ipv6Addrs) {
-				t.Errorf("windows.parseIP() got = %v, want %v", gotIPv6s, tt.ipv6Addrs)
+			if !reflect.DeepEqual(gotIPv4s, tt.wantIPv4Addrs) {
+				t.Errorf("windows.parseIP() got = %v, want %v", gotIPv4s, tt.wantIPv4Addrs)
+			}
+			if !reflect.DeepEqual(gotIPv6s, tt.wantIPv6Addrs) {
+				t.Errorf("windows.parseIP() got = %v, want %v", gotIPv6s, tt.wantIPv6Addrs)
 			}
 		})
 	}


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Fixes #2427 

By adding Out-String, we prevented the text from wrapping.
```console
PS C:\Users\vagrant> Get-Package -ProviderName msu | Format-List -Property Name


Name : Windows Malicious Software Removal Tool x64 - v5.139 (KB890830)

Name : Update for Windows Security platform - KB5007651 (Version 10.0.29510.1001)

Name : Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.445.218.0) - Current 
       Channel (Broad)

Name : Update for Microsoft Defender Antivirus antimalware platform - KB4052623 (Version 4.18.26010.5) - Current 
       Channel (Broad)

PS C:\Users\vagrant> Get-Package -ProviderName msu | Format-List -Property Name | Out-String -Width 1024


Name : Windows Malicious Software Removal Tool x64 - v5.139 (KB890830)

Name : Update for Windows Security platform - KB5007651 (Version 10.0.29510.1001)

Name : Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.445.218.0) - Current Channel (Broad)

Name : Update for Microsoft Defender Antivirus antimalware platform - KB4052623 (Version 4.18.26010.5) - Current Channel (Broad)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before
```console
$ vuls scan
[Feb 24 17:33:52]  INFO [localhost] vuls-0.38.1-e9134f3748443b4e19cc3bd6d9d257a2e4bae3dc-2026-02-20T07:37:42Z
...
[Feb 24 17:33:54]  INFO [localhost] (1/1) Detected: vagrant: windows Windows 11 Version 24H2 for x64-based Systems
[Feb 24 17:33:54]  INFO [localhost] Detecting OS of containers... 
[Feb 24 17:33:54]  INFO [localhost] Checking Scan Modes... 
[Feb 24 17:33:54]  INFO [localhost] Detecting Platforms... 
[Feb 24 17:34:00]  INFO [localhost] (1/1) vagrant is running on other
[Feb 24 17:34:05] ERROR [localhost] Error on vagrant, err: [Failed to parse installed packages. err:
    github.com/future-architect/vuls/scanner.(*windows).scanPackages
        github.com/future-architect/vuls/scanner/windows.go:1127
  - Failed to parse property. expected: ["Name : <PackageName>" "Version : <Version>" "ProviderName : <ProviderName>" "Publisher : <Publisher>"], actual: "               Current Channel (Broad)":
    github.com/future-architect/vuls/scanner.(*windows).parseInstalledPackages
        github.com/future-architect/vuls/scanner/windows.go:1203]


Scan Summary
================
vagrant	Error		Use configtest subcommand or scan with --debug to view the details


[Feb 24 17:34:05] ERROR [localhost] Failed to scan: Failed to scan. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        github.com/future-architect/vuls/scanner/scanner.go:110
  - An error occurred on [vagrant]
```

## after
```console
$ vuls scan
...

Scan Summary
================
vagrant	windowsWindows 11 Version 24H2 for x64-based Systems	4 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.

$ jq -r '.windowsKB' results/2026-02-24T17-24-11+0900/vagrant.json
{
  "applied": [
    "5066835",
    "5067036",
    "5077181",
    "5071142",
    "890830",
    "5007651",
    "4052623",
    "5065789",
    "5070773",
    "5066128",
    "5054156",
    "5071430",
    "5077869",
    "2267602"
  ],
  "unapplied": [
    "2267602"
  ]
}
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

