### PR TITLE
fix(scanner/windows): ignore unexpected lines

### DIFF
--- a/scanner/windows.go
+++ b/scanner/windows.go
@@ -283,7 +283,6 @@ func parseGetComputerInfo(stdout string) (osInfo, error) {
 			}
 			o.installationType = strings.TrimSpace(rhs)
 		default:
-			return osInfo{}, xerrors.Errorf("Failed to parse property. expected: %q, actual: %q", []string{"WindowsProductName : <ProductName>", "OsVersion : <Version>", "WindowsEditionId : <EditionId>", "OsCSDVersion : <CSDVersion>", "CsSystemType : <SystemType>", "WindowsInstallationType : <InstallationType>"}, line)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -503,7 +502,6 @@ func parseWmiObject(stdout string) (osInfo, error) {
 				return osInfo{}, xerrors.Errorf("Failed to detect Installation Type from DomainRole. err: %s is invalid DomainRole", domainRole)
 			}
 		default:
-			return osInfo{}, xerrors.Errorf("Failed to parse property. expected: %q, actual: %q", []string{"Caption : <Caption>", "Version : <Version>", "OperatingSystemSKU : <OperatingSystemSKU>", "CSDVersion : <CSDVersion>", "SystemType : <SystemType>", "DomainRole : <DomainRole>"}, line)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -586,7 +584,6 @@ func parseRegistry(stdout string) (osInfo, error) {
 			}
 			o.arch = strings.TrimSpace(rhs)
 		default:
-			return osInfo{}, xerrors.Errorf("Failed to parse property. expected: %q, actual: %q", []string{"ProductName : <ProductName>", "CurrentVersion : <Version>", "CurrentMajorVersionNumber : <MajorVersion>", "CurrentMinorVersionNumber : <MinorVersion>", "CurrentBuildNumber : <Build>", "UBR : <Revision>", "EditionID : <EditionID>", "CSDVersion : <CSDVersion>", "InstallationType : <InstallationType>", "PROCESSOR_ARCHITECTURE : <PROCESSOR_ARCHITECTURE>"}, line)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -1200,7 +1197,6 @@ func (w *windows) parseInstalledPackages(stdout string) (models.Packages, models
 			}
 			vendor = strings.TrimSpace(rhs)
 		default:
-			return nil, nil, xerrors.Errorf("Failed to parse property. expected: %q, actual: %q", []string{"Name : <PackageName>", "Version : <Version>", "ProviderName : <ProviderName>", "Publisher : <Publisher>"}, line)
 		}
 	}
 
@@ -1240,7 +1236,6 @@ func (w *windows) parseRegistryPublishers(stdout string) (map[string]string, err
 				publisher = strings.TrimSpace(rhs)
 			}
 		default:
-			return nil, xerrors.Errorf("Failed to parse property. expected: %q, actual: %q", []string{"DisplayName : <DisplayName>", "Publisher : <Publisher>"}, line)
 		}
 	}
 
@@ -1370,7 +1365,6 @@ func (w *windows) parseGetHotfix(stdout string) ([]string, error) {
 			}
 			kbs = append(kbs, strings.TrimPrefix(strings.TrimSpace(rhs), "KB"))
 		default:
-			return nil, xerrors.Errorf("Failed to parse property. expected: %q, actual: %q", "HotFixID : <KBID>", line)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -1399,7 +1393,6 @@ func (w *windows) parseGetPackageMSU(stdout string) ([]string, error) {
 				kbs = append(kbs, m[1])
 			}
 		default:
-			return nil, xerrors.Errorf("Failed to parse property. expected: %q, actual: %q", "Name : <PackageName>", line)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -1471,7 +1464,6 @@ func (w *windows) parseWindowsUpdateHistory(stdout string) ([]string, error) {
 				}
 			}
 		default:
-			return nil, xerrors.Errorf("Failed to parse property. expected: %q, actual: %q", []string{"Title : <Title>", "Operation : <Operation>", "ResultCode : <ResultCode>"}, line)
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/scanner/windows_test.go
+++ b/scanner/windows_test.go
@@ -662,6 +662,22 @@ ProviderName : msu
 			},
 			wantErr: false,
 		},
+		{
+			name: "include MSG:UnableToDownload warning",
+			args: args{stdout: "WARNING: MSG:UnableToDownload \r\n\xaehttps://go.microsoft.com/fwlink/?LinkID=627338&clcid=0x409\xaf \xae\xaf\n\r\n\r\nName         : Oracle VM VirtualBox Guest Additions 6.1.0\r\nVersion      : 6.1.0.0\r\nProviderName : Programs\r\nPublisher    : Oracle Corporation\r\n\r\nName         : Vim 8.2 (x64)\r\nVersion      : 8.2\r\nProviderName : Programs\r\nPublisher    : Bram Moolenaar et al.\r\n\r\n\r\n\r\n\r\n"},
+			want: models.Packages{
+				"Oracle VM VirtualBox Guest Additions 6.1.0": {
+					Name:    "Oracle VM VirtualBox Guest Additions 6.1.0",
+					Version: "6.1.0.0",
+					Vendor:  "Oracle Corporation",
+				},
+				"Vim 8.2 (x64)": {
+					Name:    "Vim 8.2 (x64)",
+					Version: "8.2",
+					Vendor:  "Bram Moolenaar et al.",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

It seems that a warning like the one added to the test case may be added.
This log appears to occur when TLS1.2 is not being used in an older environment.

```powershell
Microsoft Windows [Version 10.0.14393]                                                                                          
(c) 2016 Microsoft Corporation. All rights reserved.                                                                            

vagrant@WIN-P3C51FA1CBE C:\Users\vagrant>powershell                                                                             
Windows PowerShell                                                                                                              
Copyright (C) 2016 Microsoft Corporation. All rights reserved.

PS C:\Users\vagrant> [Net.ServicePointManager]::SecurityProtocol                                                                
Ssl3, Tls

PS C:\Users\vagrant> Get-Package | Select-Object Name, Version, ProviderName, @{Name='Publisher';Expression={$_.Metadata['Publisher']}} | Format-List | Out-String -Width 1024                                                                                  
WARNING: MSG:UnableToDownload «https://go.microsoft.com/fwlink/?LinkID=627338&clcid=0x409» «»                                   
WARNING: Unable to download the list of available providers. Check your internet connection.                                    


Name         : Oracle VM VirtualBox Guest Additions 6.1.0                                                                       
Version      : 6.1.0.0                                                                                                          
ProviderName : Programs                                                                                                         
Publisher    : Oracle Corporation                                                                                               

Name         : Vim 8.2 (x64)                                                                                                    
Version      : 8.2                                                                                                              
ProviderName : Programs                                                                                                         
Publisher    : Bram Moolenaar et al.
```

I've been working on several PRs(https://github.com/future-architect/vuls/pull/2419, https://github.com/future-architect/vuls/pull/2428, https://github.com/future-architect/vuls/pull/2431) with the goal of making the scanner stricter, but if the parse fails within the scanner, the whole scan fails, so I've given up on reading it strictly.

In this pattern, it would have been possible to skip reading until the expected property appeared, but this would not have achieved the goal of generating an error when an invalid string was entered.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

## before
```console
$ vuls scan
[Mar  3 15:46:23]  INFO [localhost] vuls-0.38.4-9efad2a9e7b9ceaef0d1b6f3c41a54ba18bde714-2026-03-02T07:33:24Z
[Mar  3 15:46:23]  INFO [localhost] Start scanning
[Mar  3 15:46:23]  INFO [localhost] config: /home/vuls/config.toml
[Mar  3 15:46:23]  INFO [localhost] Validating config...
[Mar  3 15:46:23]  INFO [localhost] Detecting Server/Container OS... 
[Mar  3 15:46:23]  INFO [localhost] Detecting OS of servers... 
[Mar  3 15:46:24]  INFO [localhost] (1/1) Detected: vagrant: windows Windows Server 2016
[Mar  3 15:46:24]  INFO [localhost] Detecting OS of containers... 
[Mar  3 15:46:24]  INFO [localhost] Checking Scan Modes... 
[Mar  3 15:46:24]  INFO [localhost] Detecting Platforms... 
[Mar  3 15:46:25]  INFO [localhost] (1/1) vagrant is running on other
[Mar  3 15:46:27] ERROR [localhost] Error on vagrant, err: [Failed to parse installed packages. err:
    github.com/future-architect/vuls/scanner.(*windows).scanPackages
        github.com/future-architect/vuls/scanner/windows.go:1127
  - Failed to parse property. expected: ["Name : <PackageName>" "Version : <Version>" "ProviderName : <ProviderName>" "Publisher : <Publisher>"], actual: "WARNING: MSG:UnableToDownload ":
    github.com/future-architect/vuls/scanner.(*windows).parseInstalledPackages
        github.com/future-architect/vuls/scanner/windows.go:1203]


Scan Summary
================
vagrant	Error		Use configtest subcommand or scan with --debug to view the details


[Mar  3 15:46:27] ERROR [localhost] Failed to scan: Failed to scan. err:
    github.com/future-architect/vuls/scanner.Scanner.Scan
        github.com/future-architect/vuls/scanner/scanner.go:110
  - An error occurred on [vagrant]

```

## after
```console
[Mar  3 16:06:40]  INFO [localhost] vuls-v0.38.4-build-20260303_160627_3c07fb6
[Mar  3 16:06:40]  INFO [localhost] Start scanning
[Mar  3 16:06:40]  INFO [localhost] config: /home/vuls/config.toml
[Mar  3 16:06:40]  INFO [localhost] Validating config...
[Mar  3 16:06:40]  INFO [localhost] Detecting Server/Container OS... 
[Mar  3 16:06:40]  INFO [localhost] Detecting OS of servers... 
[Mar  3 16:06:40]  INFO [localhost] (1/1) Detected: vagrant: windows Windows Server 2016
[Mar  3 16:06:40]  INFO [localhost] Detecting OS of containers... 
[Mar  3 16:06:40]  INFO [localhost] Checking Scan Modes... 
[Mar  3 16:06:40]  INFO [localhost] Detecting Platforms... 
[Mar  3 16:06:41]  INFO [localhost] (1/1) vagrant is running on other


Scan Summary
================
vagrant	windowsWindows Server 2016	2 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

