### PR TITLE
fix(reporter/sbom): add WindowsKB to SBOM output

### DIFF
--- a/reporter/sbom/cyclonedx.go
+++ b/reporter/sbom/cyclonedx.go
@@ -137,6 +137,20 @@ func osToCdxComponent(r models.ScanResult) *cdx.Component {
 			Value: r.RunningKernel.Version,
 		})
 	}
+	if r.WindowsKB != nil {
+		for _, kb := range r.WindowsKB.Applied {
+			props = append(props, cdx.Property{
+				Name:  "future-architect:vuls:WindowsKB:Applied",
+				Value: kb,
+			})
+		}
+		for _, kb := range r.WindowsKB.Unapplied {
+			props = append(props, cdx.Property{
+				Name:  "future-architect:vuls:WindowsKB:Unapplied",
+				Value: kb,
+			})
+		}
+	}
 	return &cdx.Component{
 		BOMRef:     uuid.NewString(),
 		Type:       cdx.ComponentTypeOS,

--- a/reporter/sbom/cyclonedx_test.go
+++ b/reporter/sbom/cyclonedx_test.go
@@ -1,0 +1,124 @@
+package sbom_test
+
+import (
+	"testing"
+	"time"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/future-architect/vuls/models"
+	"github.com/future-architect/vuls/reporter/sbom"
+)
+
+func TestToCycloneDX(t *testing.T) {
+	tests := []struct {
+		name string
+		args models.ScanResult
+		want *cdx.BOM
+	}{
+		{
+			name: "windows",
+			args: models.ScanResult{
+				Family:           "windows",
+				Release:          "Windows Server 2022",
+				ReportedAt:       time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				ReportedVersion:  "v0.38.5",
+				ReportedRevision: "build-20260311_001506_6827f2d",
+				WindowsKB: &models.WindowsKB{
+					Applied:   []string{"5025221", "5022282"},
+					Unapplied: []string{"5026370"},
+				},
+			},
+			want: &cdx.BOM{
+				XMLNS:       "http://cyclonedx.org/schema/bom/1.6",
+				JSONSchema:  "http://cyclonedx.org/schema/bom-1.6.schema.json",
+				BOMFormat:   "CycloneDX",
+				SpecVersion: cdx.SpecVersion1_6,
+				Version:     1,
+				Metadata: &cdx.Metadata{
+					Timestamp: "2025-01-01T00:00:00Z",
+					Tools: &cdx.ToolsChoice{
+						Components: &[]cdx.Component{
+							{
+								Type:    cdx.ComponentTypeApplication,
+								Group:   "future-architect",
+								Name:    "vuls",
+								Version: "v0.38.5-build-20260311_001506_6827f2d",
+							},
+						},
+					},
+					Component: &cdx.Component{
+						Type:    cdx.ComponentTypeOS,
+						Name:    "windows",
+						Version: "Windows Server 2022",
+						Properties: &[]cdx.Property{
+							{Name: "future-architect:vuls:Type", Value: "windows"},
+							{Name: "future-architect:vuls:WindowsKB:Applied", Value: "5025221"},
+							{Name: "future-architect:vuls:WindowsKB:Applied", Value: "5022282"},
+							{Name: "future-architect:vuls:WindowsKB:Unapplied", Value: "5026370"},
+						},
+					},
+				},
+				Components:      new([]cdx.Component),
+				Dependencies:    &[]cdx.Dependency{},
+				Vulnerabilities: &[]cdx.Vulnerability{},
+			},
+		},
+		{
+			name: "non-windows",
+			args: models.ScanResult{
+				Family:           "centos",
+				Release:          "7",
+				ReportedAt:       time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				ReportedVersion:  "v0.38.5",
+				ReportedRevision: "build-20260311_001506_6827f2d",
+			},
+			want: &cdx.BOM{
+				XMLNS:       "http://cyclonedx.org/schema/bom/1.6",
+				JSONSchema:  "http://cyclonedx.org/schema/bom-1.6.schema.json",
+				BOMFormat:   "CycloneDX",
+				SpecVersion: cdx.SpecVersion1_6,
+				Version:     1,
+				Metadata: &cdx.Metadata{
+					Timestamp: "2025-01-01T00:00:00Z",
+					Tools: &cdx.ToolsChoice{
+						Components: &[]cdx.Component{
+							{
+								Type:    cdx.ComponentTypeApplication,
+								Group:   "future-architect",
+								Name:    "vuls",
+								Version: "v0.38.5-build-20260311_001506_6827f2d",
+							},
+						},
+					},
+					Component: &cdx.Component{
+						Type:    cdx.ComponentTypeOS,
+						Name:    "centos",
+						Version: "7",
+						Properties: &[]cdx.Property{
+							{Name: "future-architect:vuls:Type", Value: "centos"},
+						},
+					},
+				},
+				Components:      new([]cdx.Component),
+				Dependencies:    &[]cdx.Dependency{},
+				Vulnerabilities: &[]cdx.Vulnerability{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sbom.ToCycloneDX(tt.args)
+
+			opts := cmp.Options{
+				cmpopts.IgnoreFields(cdx.BOM{}, "SerialNumber"),
+				cmpopts.IgnoreFields(cdx.Component{}, "BOMRef"),
+			}
+			if diff := cmp.Diff(tt.want, got, opts...); diff != "" {
+				t.Errorf("ToCycloneDX() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/reporter/sbom/spdx.go
+++ b/reporter/sbom/spdx.go
@@ -90,6 +90,14 @@ func osToSpdxPackage(r models.ScanResult) spdx.Package {
 	if r.RunningKernel.Version != "" {
 		annotations = appendAnnotation(annotations, "RunningKernelVersion", r.RunningKernel.Version, r.ReportedAt)
 	}
+	if r.WindowsKB != nil {
+		for _, kb := range r.WindowsKB.Applied {
+			annotations = appendAnnotation(annotations, "WindowsKB:Applied", kb, r.ReportedAt)
+		}
+		for _, kb := range r.WindowsKB.Unapplied {
+			annotations = appendAnnotation(annotations, "WindowsKB:Unapplied", kb, r.ReportedAt)
+		}
+	}
 
 	return spdx.Package{
 		PackageSPDXIdentifier:     generateSDPXIDentifier(elementOperatingSystem),

--- a/reporter/sbom/spdx_test.go
+++ b/reporter/sbom/spdx_test.go
@@ -1,0 +1,144 @@
+package sbom_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/spdx/tools-golang/spdx"
+	"github.com/spdx/tools-golang/spdx/v2/common"
+
+	"github.com/future-architect/vuls/models"
+	"github.com/future-architect/vuls/reporter/sbom"
+)
+
+func TestToSPDX(t *testing.T) {
+	tests := []struct {
+		name string
+		args models.ScanResult
+		want spdx.Document
+	}{
+		{
+			name: "windows",
+			args: models.ScanResult{
+				Family:           "windows",
+				Release:          "Windows Server 2022",
+				ReportedAt:       time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				ReportedVersion:  "v0.38.5",
+				ReportedRevision: "build-20260311_001506_6827f2d",
+				WindowsKB: &models.WindowsKB{
+					Applied:   []string{"5025221", "5022282"},
+					Unapplied: []string{"5026370"},
+				},
+			},
+			want: spdx.Document{
+				SPDXVersion:    spdx.Version,
+				DataLicense:    spdx.DataLicense,
+				SPDXIdentifier: "DOCUMENT",
+				DocumentName:   "windows",
+				CreationInfo: &spdx.CreationInfo{
+					Creators: []common.Creator{
+						{Creator: "future-architect", CreatorType: "Organization"},
+						{Creator: "test-tool", CreatorType: "Tool"},
+					},
+					Created: "2025-01-01T00:00:00Z",
+				},
+				Packages: []*spdx.Package{
+					{
+						PackageName:             "windows",
+						PackageVersion:          "Windows Server 2022",
+						PackageDownloadLocation: "NONE",
+						PrimaryPackagePurpose:   "OPERATING-SYSTEM",
+						Annotations: []spdx.Annotation{
+							{
+								Annotator:         spdx.Annotator{Annotator: "future-architect:vuls", AnnotatorType: "Tool"},
+								AnnotationDate:    "2025-01-01T00:00:00Z",
+								AnnotationType:    "Other",
+								AnnotationComment: "OsFamily: windows",
+							},
+							{
+								Annotator:         spdx.Annotator{Annotator: "future-architect:vuls", AnnotatorType: "Tool"},
+								AnnotationDate:    "2025-01-01T00:00:00Z",
+								AnnotationType:    "Other",
+								AnnotationComment: "WindowsKB:Applied: 5022282",
+							},
+							{
+								Annotator:         spdx.Annotator{Annotator: "future-architect:vuls", AnnotatorType: "Tool"},
+								AnnotationDate:    "2025-01-01T00:00:00Z",
+								AnnotationType:    "Other",
+								AnnotationComment: "WindowsKB:Applied: 5025221",
+							},
+							{
+								Annotator:         spdx.Annotator{Annotator: "future-architect:vuls", AnnotatorType: "Tool"},
+								AnnotationDate:    "2025-01-01T00:00:00Z",
+								AnnotationType:    "Other",
+								AnnotationComment: "WindowsKB:Unapplied: 5026370",
+							},
+						},
+					},
+				},
+				Relationships: []*spdx.Relationship{
+					{Relationship: "DESCRIBES"},
+				},
+			},
+		},
+		{
+			name: "non-windows",
+			args: models.ScanResult{
+				Family:           "centos",
+				Release:          "7",
+				ReportedAt:       time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				ReportedVersion:  "v0.38.5",
+				ReportedRevision: "build-20260311_001506_6827f2d",
+			},
+			want: spdx.Document{
+				SPDXVersion:    spdx.Version,
+				DataLicense:    spdx.DataLicense,
+				SPDXIdentifier: "DOCUMENT",
+				DocumentName:   "centos",
+				CreationInfo: &spdx.CreationInfo{
+					Creators: []common.Creator{
+						{Creator: "future-architect", CreatorType: "Organization"},
+						{Creator: "test-tool", CreatorType: "Tool"},
+					},
+					Created: "2025-01-01T00:00:00Z",
+				},
+				Packages: []*spdx.Package{
+					{
+						PackageName:             "centos",
+						PackageVersion:          "7",
+						PackageDownloadLocation: "NONE",
+						PrimaryPackagePurpose:   "OPERATING-SYSTEM",
+						Annotations: []spdx.Annotation{
+							{
+								Annotator:         spdx.Annotator{Annotator: "future-architect:vuls", AnnotatorType: "Tool"},
+								AnnotationDate:    "2025-01-01T00:00:00Z",
+								AnnotationType:    "Other",
+								AnnotationComment: "OsFamily: centos",
+							},
+						},
+					},
+				},
+				Relationships: []*spdx.Relationship{
+					{Relationship: "DESCRIBES"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sbom.ToSPDX(tt.args, "test-tool")
+
+			opts := cmp.Options{
+				cmpopts.IgnoreUnexported(spdx.Package{}),
+				cmpopts.IgnoreFields(spdx.Document{}, "DocumentNamespace"),
+				cmpopts.IgnoreFields(spdx.Package{}, "PackageSPDXIdentifier"),
+				cmpopts.IgnoreFields(spdx.Relationship{}, "RefA", "RefB"),
+			}
+			if diff := cmp.Diff(tt.want, got, opts...); diff != "" {
+				t.Errorf("ToSPDX() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

add WindowsKB to SBOM output

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## setup
```console
$ mkdir -p results/2026-03-11T00-00-00+0900/
$ cp integration/data/results/windows.json results/2026-03-11T00-00-00+0900/localhost.json
```

## before
```console
$ curl -sL https://github.com/future-architect/vuls/releases/download/v0.38.5/vuls_0.38.5_linux_amd64.tar.gz | tar zxf - vuls
$ vuls report --to-localfile --format-cyclonedx-json 2026-03-11T00-00-00+0900
$ jq -r '.metadata.component' results/2026-03-11T00-00-00+0900/localhost_cyclonedx.json 
{
  "bom-ref": "541a3f5d-4ba2-47ff-bc62-186b5266d61b",
  "type": "operating-system",
  "name": "windows",
  "version": "Windows 10 Version 21H2 for x64-based Systems",
  "properties": [
    {
      "name": "future-architect:vuls:Type",
      "value": "windows"
    },
    {
      "name": "RunningKernelVersion",
      "value": "10.0.19044.2364"
    }
  ]
}
$ rm results/2026-03-11T00-00-00+0900/localhost_cyclonedx.json 

$ vuls report --to-localfile --format-spdx-json 2026-03-11T00-00-00+0900
$ jq '.packages[] | select(.primaryPackagePurpose == "OPERATING-SYSTEM")' results/2026-03-11T00-00-00+0900/localhost_spdx.json
{
  "name": "windows",
  "SPDXID": "SPDXRef-Operating-System-b83bb0e881fcb6d0",
  "versionInfo": "Windows 10 Version 21H2 for x64-based Systems",
  "downloadLocation": "NONE",
  "filesAnalyzed": false,
  "primaryPackagePurpose": "OPERATING-SYSTEM",
  "annotations": [
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T00:43:31+09:00",
      "annotationType": "Other",
      "comment": "OsFamily: windows"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T00:43:31+09:00",
      "annotationType": "Other",
      "comment": "RunningKernelVersion: 10.0.19044.2364"
    }
  ]
}
$ results/2026-03-11T00-00-00+0900/localhost_spdx.json
```

## after
```console
$ vuls report --to-localfile --format-cyclonedx-json 2026-03-11T00-00-00+0900
$ jq -r '.metadata.component' results/2026-03-11T00-00-00+0900/localhost_cyclonedx.json
{
  "bom-ref": "e0cd5fb2-797b-4ade-ad76-67b68e1116c9",
  "type": "operating-system",
  "name": "windows",
  "version": "Windows 10 Version 21H2 for x64-based Systems",
  "properties": [
    {
      "name": "future-architect:vuls:Type",
      "value": "windows"
    },
    {
      "name": "RunningKernelVersion",
      "value": "10.0.19044.2364"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5011487"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5020872"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5014671"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5005699"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5010793"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5010342"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5020372"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5007253"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5014023"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5017380"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5011543"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5012599"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5014699"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5015807"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5016616"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5020030"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5003791"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5017500"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5008212"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5014666"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5020953"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5022728"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5010415"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5020435"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5007401"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5014032"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5014035"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5015895"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5016705"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5019959"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5021233"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5015878"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "4562830"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5011651"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5009596"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5013942"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5015020"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5012170"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5011831"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5016139"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5016688"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5017308"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5022834"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5021088"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5009543"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5018410"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Applied",
      "value": "5018482"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Unapplied",
      "value": "5022282"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Unapplied",
      "value": "5019275"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Unapplied",
      "value": "5022906"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Unapplied",
      "value": "5023696"
    },
    {
      "name": "future-architect:vuls:WindowsKB:Unapplied",
      "value": "5022834"
    }
  ]
}
$ rm results/2026-03-11T00-00-00+0900/localhost_cyclonedx.json 

$ vuls report --to-localfile --format-spdx-json 2026-03-11T00-00-00+0900
$ jq '.packages[] | select(.primaryPackagePurpose == "OPERATING-SYSTEM")' results/2026-03-11T00-00-00+0900/localhost_spdx.json
{
  "name": "windows",
  "SPDXID": "SPDXRef-Operating-System-92cba627832d4444",
  "versionInfo": "Windows 10 Version 21H2 for x64-based Systems",
  "downloadLocation": "NONE",
  "filesAnalyzed": false,
  "primaryPackagePurpose": "OPERATING-SYSTEM",
  "annotations": [
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "OsFamily: windows"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "RunningKernelVersion: 10.0.19044.2364"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 4562830"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5003791"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5005699"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5007253"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5007401"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5008212"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5009543"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5009596"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5010342"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5010415"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5010793"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5011487"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5011543"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5011651"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5011831"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5012170"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5012599"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5013942"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5014023"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5014032"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5014035"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5014666"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5014671"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5014699"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5015020"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5015807"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5015878"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5015895"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5016139"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5016616"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5016688"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5016705"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5017308"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5017380"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5017500"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5018410"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5018482"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5019959"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5020030"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5020372"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5020435"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5020872"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5020953"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5021088"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5021233"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5022728"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Applied: 5022834"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Unapplied: 5019275"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Unapplied: 5022282"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Unapplied: 5022834"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Unapplied: 5022906"
    },
    {
      "annotator": "Tool: future-architect:vuls",
      "annotationDate": "2026-03-11T20:49:51+09:00",
      "annotationType": "Other",
      "comment": "WindowsKB:Unapplied: 5023696"
    }
  ]
}
$ results/2026-03-11T00-00-00+0900/localhost_spdx.json
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

