### PR TITLE
chore(ci): add Diet PR metrics workflow

### DIFF
--- a/.github/workflows/diet-check.yml
+++ b/.github/workflows/diet-check.yml
@@ -10,11 +10,11 @@ jobs:
   diet-metrics:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/diet-check.yml` that automatically measures and reports dependency diet metrics (go.sum lines, direct dep count, binary size) as a **GitHub Actions Step Summary** on any PR that touches `go.mod` or `go.sum`
- Helps reviewers verify the effect of dependency removal PRs at a glance without manual testing

## Where the results appear

When a PR that modifies `go.mod` or `go.sum` is pushed, the workflow runs and writes a metrics table to the **GitHub Actions Step Summary**. You can view it via:

1. On the PR's **Conversation** tab, scroll to the status checks at the bottom
2. Find **"Diet PR Check / diet-metrics"** and click **"Details"**
3. The metrics table is displayed at the top of the job summary page

```
PR page
└── Conversation tab (bottom)
    └── ✅ Diet PR Check / diet-metrics — Details ← click here
        └── Job Summary (top of page) ← table appears here
```

### Sample output

> ## Diet Metrics
> | Metric | Before | After | Delta |
> |--------|--------|-------|-------|
> | go.sum lines | 542 | 538 | -4 |
> | Direct deps | 35 | 34 | -1 |
> | Binary size | 48.3MB | 48.1MB | -204KB |

The table compares the PR branch against the base branch (e.g., master), so reviewers can immediately see the impact of a dependency removal without building locally.

## Security considerations

This workflow was designed with OSS security in mind:

### Why `pull_request` (not `pull_request_target`)

We use the `pull_request` trigger, **not** `pull_request_target`. This is a critical distinction:

- `pull_request_target` runs in the **base branch's security context** with full write tokens and access to repository secrets — even when triggered by a fork PR. This was the root cause of the [Trivy CI incident](https://blog.aquasec.com/github-actions-security-vulnerability-discovered-in-trivy) where an attacker's PR code ran with elevated privileges and exfiltrated secrets from environment variables.
- `pull_request` runs in the **PR branch's security context**. For fork PRs, `GITHUB_TOKEN` is read-only and repository secrets are not exposed.

### Why Step Summary (not PR comment)

We write results to `$GITHUB_STEP_SUMMARY` instead of posting a PR comment via `github.rest.issues.createComment()`. This avoids:

1. **No `actions/github-script` needed** — eliminates the `${{ env.XXX }}` JavaScript injection vector entirely (no JS template expansion occurs)
2. **No write permissions needed** — `permissions: contents: read` is sufficient; fork PRs work without 403 errors
3. **No comment spam** — each push updates the summary in-place rather than adding new comments

### Explicit minimal permissions

```yaml
permissions:
  contents: read
```

Only `contents: read` is requested. No write access to PRs, issues, or packages.

### Build-time code execution (acceptable risk)

The workflow runs `go build ./cmd/vuls` on PR code, which means arbitrary code in `init()` functions could execute on the runner. This is the **same risk level** as the existing `test.yml` (which runs `go test ./...`) and is unavoidable for any Go CI pipeline. Since no secrets are available in the `pull_request` context, there is nothing to exfiltrate.

## Test plan

- [ ] Merge this PR, then rebase an existing diet branch (e.g., `diet-xerrors`) onto master and verify the Step Summary appears in the PR's Checks tab
- [ ] Confirm the workflow does **not** trigger on PRs that don't modify `go.mod`/`go.sum`

🤖 Generated with [Claude Code](https://claude.com/claude-code)