### PR TITLE
deps: remove trivy/pkg/cache import, replace with local helper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -132,7 +132,6 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
 	github.com/briandowns/spinner v1.23.2 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/cheggaaa/pb/v3 v3.1.7 // indirect
@@ -217,7 +216,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-getter v1.8.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/log15 v3.0.0-testing.5+incompatible // indirect
@@ -249,11 +247,7 @@ require (
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
-	github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 // indirect
-	github.com/masahiro331/go-disk v0.0.0-20240625071113-56c933208fee // indirect
-	github.com/masahiro331/go-ext4-filesystem v0.0.0-20240620024024-ca14e6327bbd // indirect
 	github.com/masahiro331/go-mvn-version v0.0.0-20250131095131-f4974fa13b8a // indirect
-	github.com/masahiro331/go-xfs-filesystem v0.0.0-20231205045356-1b22259a6c44 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
@@ -323,7 +317,6 @@ require (
 	github.com/tchap/go-patricia/v2 v2.3.3 // indirect
 	github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0 // indirect
 	github.com/toqueteos/webbrowser v1.2.0 // indirect
-	github.com/twitchtv/twirp v8.1.3+incompatible // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
 	github.com/vbatts/tar-split v0.12.2 // indirect
@@ -348,8 +341,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -871,8 +871,6 @@ github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0 h1:2f304B10
 github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0/go.mod h1:278M4p8WsNh3n4a1eqiFcV2FGk7wE5fwUpUom9mK9lE=
 github.com/toqueteos/webbrowser v1.2.0 h1:tVP/gpK69Fx+qMJKsLE7TD8LuGWPnEV71wBN9rrstGQ=
 github.com/toqueteos/webbrowser v1.2.0/go.mod h1:XWoZq4cyp9WeUeak7w7LXRUQf1F1ATJMir8RTqb4ayM=
-github.com/twitchtv/twirp v8.1.3+incompatible h1:+F4TdErPgSUbMZMwp13Q/KgDVuI7HJXP61mNV3/7iuU=
-github.com/twitchtv/twirp v8.1.3+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=

--- a/subcmds/report.go
+++ b/subcmds/report.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/aquasecurity/trivy/pkg/cache"
 	"github.com/google/subcommands"
 	"github.com/k0kubun/pp"
 
@@ -182,7 +181,7 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&config.Conf.Pipe, "pipe", false, "Use args passed via PIPE")
 
 	f.StringVar(&config.Conf.TrivyCacheDBDir, "trivy-cachedb-dir",
-		cache.DefaultDir(), "/path/to/dir")
+		defaultTrivyCacheDir(), "/path/to/dir")
 
 	config.Conf.TrivyDBRepositories = detector.DefaultTrivyDBRepositories
 	dbRepos := stringArrayFlag{target: &config.Conf.TrivyDBRepositories}

--- a/subcmds/report_windows.go
+++ b/subcmds/report_windows.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/aquasecurity/trivy/pkg/cache"
 	"github.com/google/subcommands"
 	"github.com/k0kubun/pp"
 
@@ -179,7 +178,7 @@ func (p *ReportCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&config.Conf.Pipe, "pipe", false, "Use args passed via PIPE")
 
 	f.StringVar(&config.Conf.TrivyCacheDBDir, "trivy-cachedb-dir",
-		cache.DefaultDir(), "/path/to/dir")
+		defaultTrivyCacheDir(), "/path/to/dir")
 
 	config.Conf.TrivyDBRepositories = detector.DefaultTrivyDBRepositories
 	dbRepos := stringArrayFlag{target: &config.Conf.TrivyDBRepositories}

--- a/subcmds/tui.go
+++ b/subcmds/tui.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/aquasecurity/trivy/pkg/cache"
 	"github.com/google/subcommands"
 
 	"github.com/future-architect/vuls/config"
@@ -107,7 +106,7 @@ func (p *TuiCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&config.Conf.Pipe, "pipe", false, "Use stdin via PIPE")
 
 	f.StringVar(&config.Conf.TrivyCacheDBDir, "trivy-cachedb-dir",
-		cache.DefaultDir(), "/path/to/dir")
+		defaultTrivyCacheDir(), "/path/to/dir")
 
 	config.Conf.TrivyDBRepositories = detector.DefaultTrivyDBRepositories
 	dbRepos := stringArrayFlag{target: &config.Conf.TrivyDBRepositories}

--- a/subcmds/util.go
+++ b/subcmds/util.go
@@ -20,3 +20,14 @@ func mkdirDotVuls() error {
 	}
 	return nil
 }
+
+// defaultTrivyCacheDir returns the default Trivy cache directory.
+// This replaces trivy/pkg/cache.DefaultDir() to avoid importing the heavy
+// cache package, which pulls in DB and OCI dependencies.
+func defaultTrivyCacheDir() string {
+	tmpDir, err := os.UserCacheDir()
+	if err != nil {
+		tmpDir = os.TempDir()
+	}
+	return filepath.Join(tmpDir, "trivy")
+}


### PR DESCRIPTION
## Summary

Replace `cache.DefaultDir()` with a local `defaultTrivyCacheDir()` helper using only stdlib (`os.UserCacheDir` + `filepath.Join`), removing the `trivy/pkg/cache` import from `subcmds/report.go`, `report_windows.go`, and `tui.go`.

Suggested-by: @shino (https://github.com/future-architect/vuls/pull/2476#issuecomment-4088340741)

## Impact

### Binary size (goreleaser equivalent: `CGO_ENABLED=0 GOEXPERIMENT=jsonv2 go build -a -trimpath -ldflags "-s -w"`)

| | Full build | 
|---|---|
| Before (master) | 139.1 MB |
| After | 138.5 MB |
| **Diff** | **-0.6 MB** |

> Note: scanner-only build (`-tags scanner`) is unaffected since `subcmds` is excluded by build tags.

### Dependencies (`go.mod`)

| | Count |
|---|---|
| Before (master) | 391 |
| After | 382 |
| **Removed** | **9** |

### Removed transitive dependencies

| Package | What it is |
|---|---|
| `github.com/cenkalti/backoff/v4` | Exponential backoff |
| `github.com/hashicorp/golang-lru/v2` | LRU cache |
| `github.com/lunixbochs/struc` | Binary struct packing |
| `github.com/masahiro331/go-disk` | Disk image parsing |
| `github.com/masahiro331/go-ext4-filesystem` | ext4 filesystem parsing |
| `github.com/masahiro331/go-xfs-filesystem` | XFS filesystem parsing |
| `github.com/twitchtv/twirp` | RPC framework |
| `go.uber.org/multierr` | Error combining |
| `go.uber.org/zap` | Structured logging |

These were all pulled in transitively by `trivy/pkg/cache` and are unused by vuls.

## Test plan

- [x] `go build ./cmd/...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./subcmds/...` passes
- [x] Behavior unchanged: `defaultTrivyCacheDir()` returns the same path as `cache.DefaultDir()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)