### PR TITLE
fix(contrib): Fix trivy image reference to mitigate supply chain compromise (CVE-2026-33634)

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -27,7 +27,7 @@ RUN apk add --no-cache \
     && mkdir -p $WORKDIR $LOGDIR
 
 COPY --from=builder /go/bin/vuls /go/bin/trivy-to-vuls /go/bin/future-vuls /go/bin/snmp2cpe /usr/local/bin/
-COPY --from=aquasec/trivy:latest /usr/local/bin/trivy /usr/local/bin/trivy
+COPY --from=ghcr.io/aquasecurity/trivy:0.69.3@sha256:bcc376de8d77cfe086a917230e818dc9f8528e3c852f7b1aff648949b6258d1c /usr/local/bin/trivy /usr/local/bin/trivy
 
 VOLUME ["$WORKDIR", "$LOGDIR"]
 WORKDIR $WORKDIR

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -27,7 +27,7 @@ RUN apk add --no-cache \
     && mkdir -p $WORKDIR $LOGDIR
 
 COPY --from=builder /go/bin/vuls /go/bin/trivy-to-vuls /go/bin/future-vuls /go/bin/snmp2cpe /usr/local/bin/
-COPY --from=ghcr.io/aquasecurity/trivy:0.69.3@sha256:bcc376de8d77cfe086a917230e818dc9f8528e3c852f7b1aff648949b6258d1c /usr/local/bin/trivy /usr/local/bin/trivy
+COPY --from=ghcr.io/aquasecurity/trivy@sha256:bcc376de8d77cfe086a917230e818dc9f8528e3c852f7b1aff648949b6258d1c /usr/local/bin/trivy /usr/local/bin/trivy
 
 VOLUME ["$WORKDIR", "$LOGDIR"]
 WORKDIR $WORKDIR


### PR DESCRIPTION
# What did you implement:

Pin the trivy container image to a verified-safe version with digest to mitigate the Trivy supply chain attack (CVE-2026-33634 / GHSA-69fq-xp46-6x23).

- Replace `COPY --from=aquasec/trivy:latest` with a digest-pinned reference from GHCR: ``` COPY --from=ghcr.io/aquasecurity/trivy:0.69.3@sha256:bcc376de8d77cfe086a917230e818dc9f8528e3c852f7b1aff648949b6258d1c ```

On March 19, 2026, a threat actor published malicious trivy releases (v0.69.4, v0.69.5, v0.69.6) containing credential-stealing malware (TeamPCP Cloud stealer). The `aquasec/trivy:latest` tag on Docker Hub pointed to compromised images during multiple exposure windows. Additionally, `mirror.gcr.io` (containerd's default Docker Hub mirror) still serves the malicious v0.69.6 image as of March 25.

The previous image (`vuls/fvuls:latest`, pushed 2026-03-23 02:12 UTC) was built during or immediately after the third compromise window and may contain the malicious trivy binary.

The safety of `ghcr.io/aquasecurity/trivy:0.69.3` digest `sha256:bcc376de...` has been cryptographically verified:

1. **cosign** — Signature verified against Aqua's GitHub Actions OIDC identity
2. **Rekor transparency log** — All signing timestamps predate the attack (2026-03-03, 2026-03-18), confirming the image was built before any compromise

- [GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23)
- [CVE-2026-33634](https://nvd.nist.gov/vuln/detail/CVE-2026-33634)
- [Trivy Security incident discussion](https://github.com/aquasecurity/trivy/discussions/10425)



Why switch from Docker Hub to GHCR

1. **mirror.gcr.io contamination**: Docker Hub images are subject to pull-through caching by `mirror.gcr.io`, which is containerd's default Docker Hub mirror. As of March 25, the malicious v0.69.6 image is still cached there. GHCR is not affected by this mirror.

2. **Verified source consistency**: The image safety was cryptographically verified via cosign and Rekor against `ghcr.io/aquasecurity/trivy:0.69.3`. Using GHCR as the pull source ensures we fetch from the same registry we verified.

3. **Docker Hub instability**: Aqua has deleted the `:latest` tag and disabled all push operations to Docker Hub as a containment measure. GHCR remains fully operational.



```
% DIGEST=$(cosign verify \
  --certificate-identity-regexp 'https://github\.com/aquasecurity/' \ --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \ --new-bundle-format -o json ghcr.io/aquasecurity/trivy:0.69.3 | \ jq -r '.[0].critical.image."docker-manifest-digest"')

Verification for ghcr.io/aquasecurity/trivy:0.69.3 -- The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates sha256:bcc376de8d77cfe086a917230e818dc9f8528e3c852f7b1aff648949b6258d1c

[0]% rekor-cli search --sha "$DIGEST"
Found matching entries (listed by UUID):
108e9186e8c5677a3e68b2066766f717f25677fb812e2eb9687fac7267204586dbf8c7b0fac75011 108e9186e8c5677a58a4298178a14490406206be9a5c8aa825ac0f0b1a6e2953317d8ff029c3b964 108e9186e8c5677a66abc91174f4cc699a17489178499d240fb9c1929808a1c7e072d28abbe3004a 108e9186e8c5677afb5ad459e5a7d483de34846fecc385f62fa8118bafb7b9c3eb6277490ed53892 108e9186e8c5677a6b7a3a023b10818d3213683dc0864b4f38753d7c7f237f5e6b1f23d3d16b9962 108e9186e8c5677a6d20d6991a06a3f17a3ce4bb654d9e5f5335355775f6e3e8f7db39913ea2a7e7 108e9186e8c5677aa4d9676c2239e1fa1ca4a226ad80348d4fb2b45293fa982d0210fd22936e0920 108e9186e8c5677aceed02725a5f2687cc9ab40aa39a5c5221819010268d98be7e7aa1efcdc5495f 108e9186e8c5677aed41d394c6b901942b33e496d3e87cb6e9ab6252db3e5d86b369b3a526d7af75

[0]% rekor-cli search --sha "$DIGEST" | grep -v 'Found' | while read uuid; do
    rekor-cli get --uuid "$uuid" | grep IntegratedTime
done
Found matching entries (listed by UUID):
IntegratedTime: 2026-03-03T13:14:19Z
IntegratedTime: 2026-03-03T13:14:30Z
IntegratedTime: 2026-03-18T18:30:05Z
IntegratedTime: 2026-03-19T18:25:13Z
IntegratedTime: 2026-03-03T13:14:23Z
IntegratedTime: 2026-03-18T18:30:13Z
IntegratedTime: 2026-03-03T13:14:17Z
IntegratedTime: 2026-03-03T13:14:25Z
IntegratedTime: 2026-03-03T13:14:27Z
```

All Rekor entries for `ghcr.io/aquasecurity/trivy:0.69.3` (digest `sha256:bcc376de8d77cfe086a917230e818dc9f8528e3c852f7b1aff648949b6258d1c`) were retrieved and their signing timestamps inspected:

| IntegratedTime (UTC) | Assessment |
|---|---|
| 2026-03-03 13:14:17 | Safe — initial v0.69.3 release signing |
| 2026-03-03 13:14:19 | Safe — initial release (multi-arch) |
| 2026-03-03 13:14:23 | Safe — initial release (multi-arch) |
| 2026-03-03 13:14:25 | Safe — initial release (multi-arch) |
| 2026-03-03 13:14:27 | Safe — initial release (multi-arch) |
| 2026-03-03 13:14:30 | Safe — initial release (multi-arch) |
| 2026-03-18 18:30:05 | Safe — predates attack (Mar 19 17:43 UTC) |
| 2026-03-18 18:30:13 | Safe — predates attack (Mar 19 17:43 UTC) |
| 2026-03-19 18:25:13 | Safe — see note below |

**Note on the 2026-03-19 18:25:13 entry:** This entry was created by the attacker's v0.69.4 release workflow (run 23308651970, since deleted), which resolved the `:latest` tag to the v0.69.3 digest during the signing step. As confirmed by the Trivy maintainer ([discussion comment](https://github.com/aquasecurity/trivy/discussions/10425)), the digest is identical across all entries — same digest means same content. The image itself was not modified.

**Conclusion:** The image content has remained unchanged since its original release on March 3, well before any compromise activity began on March 19. Rekor is an append-only transparency log whose timestamps cannot be forged by signers, providing cryptographic proof that this image predates the attack.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

CI

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [ ] Check that there aren't other open pull requests for the same issue/feature
- [ ] Format your source code by `make fmt`
- [ ] Pass the test by `make test`
- [ ] Provide verification config / commands
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES

# Reference

* https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/

