### PR TITLE
refactor(scanner/windows): detect version by build number only

### DIFF
--- a/scanner/windows.go
+++ b/scanner/windows.go
@@ -793,23 +793,11 @@ func detectOSNameFromOSInfo(osInfo osInfo) (string, error) {
 	case "10.0":
 		switch osInfo.installationType {
 		case "Client":
-			if strings.Contains(osInfo.productName, "Windows 11") {
-				arch, err := formatArch(osInfo.arch)
-				if err != nil {
-					return "", xerrors.Errorf("Failed to format architecture: %w", err)
-				}
-				name, err := formatNamebyBuild("11", osInfo.build)
-				if err != nil {
-					return "", xerrors.Errorf("Failed to format name by build: %w", err)
-				}
-				return fmt.Sprintf("%s for %s Systems", name, arch), nil
-			}
-
 			arch, err := formatArch(osInfo.arch)
 			if err != nil {
 				return "", xerrors.Errorf("Failed to format architecture: %w", err)
 			}
-			name, err := formatNamebyBuild("10", osInfo.build)
+			name, err := formatNamebyBuild("Client", osInfo.build)
 			if err != nil {
 				return "", xerrors.Errorf("Failed to format name by build: %w", err)
 			}
@@ -849,7 +837,7 @@ type buildNumber struct {
 
 var (
 	winBuilds = map[string][]buildNumber{
-		"10": {
+		"Client": {
 			{
 				build: "10240",
 				name:  "Windows 10", // not "Windows 10 Version 1507"
@@ -908,24 +896,6 @@ var (
 			},
 			// It seems that there are cases where the Product Name is Windows 10 even though it is Windows 11
 			// ref: https://docs.microsoft.com/en-us/answers/questions/586548/in-the-official-version-of-windows-11-why-the-key.html
-			{
-				build: "22000",
-				name:  "Windows 11 Version 21H2",
-			},
-			{
-				build: "22621",
-				name:  "Windows 11 Version 22H2",
-			},
-			{
-				build: "22631",
-				name:  "Windows 11 Version 23H2",
-			},
-			{
-				build: "26100",
-				name:  "Windows 11 Version 24H2",
-			},
-		},
-		"11": {
 			{
 				build: "22000",
 				name:  "Windows 11 Version 21H2",

--- a/scanner/windows_test.go
+++ b/scanner/windows_test.go
@@ -444,6 +444,20 @@ func Test_detectOSName(t *testing.T) {
 			want: "Windows 11 Version 24H2 for x64-based Systems",
 		},
 		{
+			name: "Windows 11 Version 25H2 for x64-based Systems (productName says Windows 10)",
+			args: osInfo{
+				productName:      "Windows 10 Enterprise Evaluation",
+				version:          "10.0",
+				build:            "26200",
+				revision:         "7623",
+				edition:          "EnterpriseEval",
+				servicePack:      "",
+				arch:             "AMD64",
+				installationType: "Client",
+			},
+			want: "Windows 11 Version 25H2 for x64-based Systems",
+		},
+		{
 			name: "Windows 11 latest release",
 			args: osInfo{
 				productName:      "Microsoft Windows 11 Pro",


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:
 Replace winBuilds map keys "10"/"11"/"Server" with "Client"/"Server" based on
 installationType registry value. This removes the unreliable productName-based
 Windows 11 detection, since productName can report "Windows 10" even on
 Windows 11 systems (e.g. build 26200 with "Windows 10 Enterprise Evaluation").

 The build number alone is sufficient to distinguish Windows 10/11 versions.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## before (v0.38.6)
```console
$ vuls scan
[Apr  8 20:06:01]  INFO [localhost] vuls-0.38.6-6827f2d6404e32b781d7c2f3cd00fdb025df76a8-2026-03-10T09:54:28Z
[Apr  8 20:06:01]  INFO [localhost] Start scanning
[Apr  8 20:06:01]  INFO [localhost] config: /home/vuls/config.toml
[Apr  8 20:06:01]  INFO [localhost] Validating config...
[Apr  8 20:06:01]  INFO [localhost] Detecting Server/Container OS... 
[Apr  8 20:06:01]  INFO [localhost] Detecting OS of servers... 
[Apr  8 20:06:04]  INFO [localhost] (1/1) Detected: vagrant: windows Windows 11 Version 24H2 for x64-based Systems
[Apr  8 20:06:04]  INFO [localhost] Detecting OS of containers... 
[Apr  8 20:06:04]  INFO [localhost] Checking Scan Modes... 
[Apr  8 20:06:04]  INFO [localhost] Detecting Platforms... 
[Apr  8 20:06:11]  INFO [localhost] (1/1) vagrant is running on other


Scan Summary
================
vagrant windowsWindows 11 Version 24H2 for x64-based Systems    4 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

## after
```console
$ vuls scan
[Apr  8 20:07:39]  INFO [localhost] vuls-v0.38.6-build-20260408_200326_f40a69f
[Apr  8 20:07:39]  INFO [localhost] Start scanning
[Apr  8 20:07:39]  INFO [localhost] config: /home/vuls/config.toml
[Apr  8 20:07:39]  INFO [localhost] Validating config...
[Apr  8 20:07:39]  INFO [localhost] Detecting Server/Container OS... 
[Apr  8 20:07:39]  INFO [localhost] Detecting OS of servers... 
[Apr  8 20:07:42]  INFO [localhost] (1/1) Detected: vagrant: windows Windows 11 Version 25H2 for x64-based Systems
[Apr  8 20:07:42]  INFO [localhost] Detecting OS of containers... 
[Apr  8 20:07:42]  INFO [localhost] Checking Scan Modes... 
[Apr  8 20:07:42]  INFO [localhost] Detecting Platforms... 
[Apr  8 20:07:49]  INFO [localhost] (1/1) vagrant is running on other


Scan Summary
================
vagrant windowsWindows 11 Version 25H2 for x64-based Systems    4 installed, 0 updatable





To view the detail, vuls tui is useful.
To send a report, run vuls report -h.
```

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

