### PR TITLE
feat!(detector): replace gost.FillCVEsWithRedHat with vuls2

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -195,10 +195,6 @@ func Detect(rs []models.ScanResult, dir string) ([]models.ScanResult, error) {
 			return nil, xerrors.Errorf("Failed to detect WordPress Cves: %w", err)
 		}
 
-		if err := gost.FillCVEsWithRedHat(&r, config.Conf.Gost, config.Conf.LogOpts); err != nil {
-			return nil, xerrors.Errorf("Failed to fill with gost: %w", err)
-		}
-
 		if err := FillCvesWithGoCVEDictionary(&r, config.Conf.CveDict, config.Conf.LogOpts); err != nil {
 			return nil, xerrors.Errorf("Failed to fill with CVE: %w", err)
 		}

--- a/detector/vuls2/export_test.go
+++ b/detector/vuls2/export_test.go
@@ -6,6 +6,7 @@ var (
 	PreConvert    = preConvert
 	PostConvert   = postConvert
 	PruneCriteria = pruneCriteria
+	Enrich        = enrich
 )
 
 type Source source

--- a/detector/vuls2/internal/test/test.go
+++ b/detector/vuls2/internal/test/test.go
@@ -1,0 +1,49 @@
+package test
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/MaineK00n/vuls2/pkg/db/session"
+)
+
+// PopulateDB populates the database specified by c with test data from fixtureDir.
+// Children of fixtureDir are datasource directories, each has "datasource.json" file and "data/" directory.
+func PopulateDB(c session.Config, fixtureDir string) error {
+	if c.Path == "" {
+		return errors.New("Config.Path must not be empty")
+	}
+
+	if fixtureDir == "" {
+		return errors.New("fixtureDir must not be empty")
+	}
+
+	s, err := c.New()
+	if err != nil {
+		return errors.Wrap(err, "new db connection")
+	}
+
+	if err := s.Storage().Open(); err != nil {
+		return errors.Wrap(err, "open db connection")
+	}
+	defer s.Storage().Close()
+
+	if err := s.Storage().Initialize(); err != nil {
+		return errors.Wrap(err, "initialize")
+	}
+
+	datasources, err := os.ReadDir(fixtureDir)
+	if err != nil {
+		return err
+	}
+
+	for _, ds := range datasources {
+		if err := s.Storage().Put(filepath.Join(fixtureDir, ds.Name())); err != nil {
+			return errors.Wrapf(err, "put %s", ds.Name())
+		}
+	}
+
+	return nil
+}

--- a/detector/vuls2/testdata/fixtures/enrich/redhat-cve/data/CVE-2024-1102.json
+++ b/detector/vuls2/testdata/fixtures/enrich/redhat-cve/data/CVE-2024-1102.json
@@ -1,0 +1,65 @@
+{
+	"id": "CVE-2024-1102",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-1102",
+				"title": "jberet: jberet-core logging database credentials",
+				"description": "A vulnerability was found in jberet-core logging. An exception in 'dbProperties' might display user credentials such as the username and password for the database-connection.\nA vulnerability was found in jberet-core logging. An exception in 'dbProperties' might display user credentials such as the username and password for the database-connection.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "secalert@redhat.com",
+						"vendor": "Moderate"
+					},
+					{
+						"type": "cvss_v31",
+						"source": "secalert@redhat.com",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+							"base_score": 6.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 6.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 6.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "secalert@redhat.com",
+						"cwe": [
+							"CWE-523"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://bugzilla.redhat.com/show_bug.cgi?id=2262060"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://github.com/jberet/jsr352/issues/452"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-1102"
+					},
+					{
+						"source": "secalert@redhat.com",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2024-1102"
+					}
+				],
+				"published": "2024-01-29T00:00:00Z"
+			}
+		}
+	],
+	"data_source": {
+		"id": "redhat-cve",
+		"raws": [
+			"vuls-data-raw-redhat-cve/2024/CVE-2024-1102.json"
+		]
+	}
+}

--- a/detector/vuls2/testdata/fixtures/enrich/redhat-cve/datasource.json
+++ b/detector/vuls2/testdata/fixtures/enrich/redhat-cve/datasource.json
@@ -1,0 +1,11 @@
+{
+    "id": "redhat-cve",
+    "name": "RedHat Security Data API",
+    "raw": [
+        {
+            "url": "ghcr.io/vulsio/vuls-data-db:vuls-data-raw-redhat-cve",
+            "commit": "0000000000000000000000000000000000000000",
+            "date": "2025-01-01T00:00:00Z"
+        }
+    ]
+}

--- a/detector/vuls2/vendor.go
+++ b/detector/vuls2/vendor.go
@@ -584,7 +584,7 @@ func advisoryReference(e ecosystemTypes.Ecosystem, s sourceTypes.SourceID, da mo
 
 func cveContentSourceLink(ccType models.CveContentType, v vulnerabilityTypes.Vulnerability) string {
 	switch ccType {
-	case models.RedHat:
+	case models.RedHat, models.RedHatAPI:
 		return fmt.Sprintf("https://access.redhat.com/security/cve/%s", v.Content.ID)
 	case models.Oracle:
 		return fmt.Sprintf("https://linux.oracle.com/cve/%s.html", v.Content.ID)
@@ -985,4 +985,69 @@ func toVuls0Confidence(e ecosystemTypes.Ecosystem, s sourceTypes.SourceID) model
 			SortOrder:       100,
 		}
 	}
+}
+
+// enrichCveContentType maps a sourceID to a CveContentType for enrichment data.
+// Returns models.Unknown for source IDs that are not enrichment targets.
+func enrichCveContentType(s sourceTypes.SourceID) models.CveContentType {
+	switch s {
+	case sourceTypes.RedHatCVE:
+		return models.RedHatAPI
+	default:
+		return models.Unknown
+	}
+}
+
+// enrichCvss extracts CVSS scores from severity data without ecosystem-specific handling.
+func enrichCvss(ss []severityTypes.Severity) (v2.CVSSv2, v31.CVSSv31, v40.CVSSv40) {
+	var (
+		cvss2  v2.CVSSv2
+		cvss3  v31.CVSSv31
+		cvss4  v40.CVSSv40
+		vendor string
+	)
+
+	for _, s := range ss {
+		switch s.Type {
+		case severityTypes.SeverityTypeVendor:
+			if s.Vendor != nil {
+				vendor = *s.Vendor
+			}
+		case severityTypes.SeverityTypeCVSSv2:
+			if cvss2.Vector == "" && s.CVSSv2 != nil {
+				cvss2 = *s.CVSSv2
+			}
+		case severityTypes.SeverityTypeCVSSv30:
+			if cvss3.Vector == "" && s.CVSSv30 != nil {
+				cvss3 = v31.CVSSv31{
+					Vector:       s.CVSSv30.Vector,
+					BaseScore:    s.CVSSv30.BaseScore,
+					BaseSeverity: s.CVSSv30.BaseSeverity,
+				}
+			}
+		case severityTypes.SeverityTypeCVSSv31:
+			if !strings.HasPrefix(cvss3.Vector, "CVSS:3.1/") && s.CVSSv31 != nil {
+				cvss3 = *s.CVSSv31
+			}
+		case severityTypes.SeverityTypeCVSSv40:
+			if cvss4.Vector == "" && s.CVSSv40 != nil {
+				cvss4 = *s.CVSSv40
+			}
+		default:
+		}
+	}
+
+	if vendor != "" {
+		if cvss2.Vector != "" {
+			cvss2.NVDBaseSeverity = vendor
+		}
+		if cvss3.Vector != "" {
+			cvss3.BaseSeverity = vendor
+		}
+		if cvss4.Vector != "" {
+			cvss4.Severity = vendor
+		}
+	}
+
+	return cvss2, cvss3, cvss4
 }

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -3,6 +3,7 @@ package vuls2
 import (
 	"cmp"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"maps"
@@ -25,6 +26,7 @@ import (
 	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
 	severityVendorTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/vendor"
+	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
 	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
 	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls2/pkg/db/session"
@@ -90,6 +92,10 @@ func Detect(r *models.ScanResult, vuls2Conf config.Vuls2Conf, noProgress bool) e
 	vulnInfos, err := postConvert(vuls2Scanned, vuls2Detected)
 	if err != nil {
 		return xerrors.Errorf("Failed to post convert. err: %w", err)
+	}
+
+	if err := enrich(sesh, vulnInfos); err != nil {
+		return xerrors.Errorf("Failed to enrich vulnerability data. err: %w", err)
 	}
 
 	for cveID, vi := range vulnInfos {
@@ -1153,4 +1159,80 @@ func toReference(ref string) models.Reference {
 			Source: "MISC",
 		}
 	}
+}
+
+// enrich adds vulnerability data from all sources (including non-detecting sources)
+// to the already-detected VulnInfos. This replaces gost.FillCVEsWithRedHat and also
+// provides cross-source enrichment (e.g., RedHat CVE data for Debian-detected CVEs).
+func enrich(sesh *session.Session, vim models.VulnInfos) error {
+	for cveID, vi := range vim {
+		vm, err := sesh.Storage().GetVulnerability(vulnerabilityContentTypes.VulnerabilityID(cveID))
+		if err != nil {
+			if errors.Is(err, dbTypes.ErrNotFoundVulnerability) {
+				continue
+			}
+			return xerrors.Errorf("Failed to get vulnerability. CVE-ID: %s, err: %w", cveID, err)
+		}
+
+		for sourceID, rootMap := range vm {
+			cctype := enrichCveContentType(sourceID)
+			if cctype == models.Unknown {
+				continue
+			}
+			if _, ok := vi.CveContents[cctype]; ok {
+				continue
+			}
+
+			for _, vulns := range rootMap {
+				for _, v := range vulns {
+					cvss2, cvss3, cvss40 := enrichCvss(v.Content.Severity)
+
+					var rs models.References
+					for _, r := range v.Content.References {
+						rs = append(rs, toReference(r.URL))
+					}
+
+					cc := models.CveContent{
+						Type:           cctype,
+						CveID:          cveID,
+						Title:          v.Content.Title,
+						Summary:        v.Content.Description,
+						Cvss2Score:     cvss2.BaseScore,
+						Cvss2Vector:    cvss2.Vector,
+						Cvss2Severity:  cvss2.NVDBaseSeverity,
+						Cvss3Score:     cvss3.BaseScore,
+						Cvss3Vector:    cvss3.Vector,
+						Cvss3Severity:  cvss3.BaseSeverity,
+						Cvss40Score:    cvss40.Score,
+						Cvss40Vector:   cvss40.Vector,
+						Cvss40Severity: cvss40.Severity,
+						SourceLink:     cveContentSourceLink(cctype, v),
+						References:     rs,
+						CweIDs: func() []string {
+							var cs []string //nolint:prealloc
+							for _, cwe := range v.Content.CWE {
+								cs = append(cs, cwe.CWE...)
+							}
+							return cs
+						}(),
+						Published: func() time.Time {
+							if v.Content.Published != nil {
+								return *v.Content.Published
+							}
+							return time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
+						}(),
+						LastModified: func() time.Time {
+							if v.Content.Modified != nil {
+								return *v.Content.Modified
+							}
+							return time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
+						}(),
+					}
+					vi.CveContents[cctype] = append(vi.CveContents[cctype], cc)
+				}
+			}
+		}
+		vim[cveID] = vi
+	}
+	return nil
 }

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -3,6 +3,7 @@ package vuls2_test
 import (
 	"cmp"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -34,6 +35,7 @@ import (
 	vulnerabilityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability"
 	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
 	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls2/pkg/db/session"
 	dbTypes "github.com/MaineK00n/vuls2/pkg/db/session/types"
 	detectTypes "github.com/MaineK00n/vuls2/pkg/detect/types"
 	scanTypes "github.com/MaineK00n/vuls2/pkg/scan/types"
@@ -41,6 +43,7 @@ import (
 	gocmpopts "github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/future-architect/vuls/detector/vuls2"
+	testutil "github.com/future-architect/vuls/detector/vuls2/internal/test"
 	"github.com/future-architect/vuls/models"
 )
 
@@ -9008,6 +9011,176 @@ func Test_pruneCriteria(t *testing.T) {
 			}
 			if diff := gocmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("pruneCriteria() mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_enrich(t *testing.T) {
+	type args struct {
+		vim models.VulnInfos
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    models.VulnInfos
+		wantErr bool
+	}{
+		{
+			name: "enrich with redhat-cve data",
+			args: args{
+				vim: models.VulnInfos{
+					"CVE-2024-1102": models.VulnInfo{
+						CveID: "CVE-2024-1102",
+						CveContents: models.CveContents{
+							models.RedHat: []models.CveContent{
+								{
+									Type:  models.RedHat,
+									CveID: "CVE-2024-1102",
+									Title: "from-oval",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: models.VulnInfos{
+				"CVE-2024-1102": models.VulnInfo{
+					CveID: "CVE-2024-1102",
+					CveContents: models.CveContents{
+						models.RedHat: []models.CveContent{
+							{
+								Type:  models.RedHat,
+								CveID: "CVE-2024-1102",
+								Title: "from-oval",
+							},
+						},
+						models.RedHatAPI: []models.CveContent{
+							{
+								Type:          models.RedHatAPI,
+								CveID:         "CVE-2024-1102",
+								Title:         "jberet: jberet-core logging database credentials",
+								Summary:       "A vulnerability was found in jberet-core logging. An exception in 'dbProperties' might display user credentials such as the username and password for the database-connection.\nA vulnerability was found in jberet-core logging. An exception in 'dbProperties' might display user credentials such as the username and password for the database-connection.",
+								Cvss3Score:    6.5,
+								Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+								Cvss3Severity: "Moderate",
+								SourceLink:    "https://access.redhat.com/security/cve/CVE-2024-1102",
+								CweIDs:        []string{"CWE-523"},
+								References: models.References{
+									{Link: "https://bugzilla.redhat.com/show_bug.cgi?id=2262060", Source: "REDHAT", RefID: "2262060"},
+									{Link: "https://github.com/jberet/jsr352/issues/452", Source: "MISC"},
+									{Link: "https://nvd.nist.gov/vuln/detail/CVE-2024-1102", Source: "NVD", RefID: "CVE-2024-1102"},
+									{Link: "https://www.cve.org/CVERecord?id=CVE-2024-1102", Source: "CVE", RefID: "CVE-2024-1102"},
+								},
+								Published:    time.Date(2024, 1, 29, 0, 0, 0, 0, time.UTC),
+								LastModified: time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "CVE not found in DB leaves VulnInfo unchanged",
+			args: args{
+				vim: models.VulnInfos{
+					"CVE-9999-0001": models.VulnInfo{
+						CveID: "CVE-9999-0001",
+						CveContents: models.CveContents{
+							models.RedHat: []models.CveContent{
+								{
+									Type:  models.RedHat,
+									CveID: "CVE-9999-0001",
+									Title: "original",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: models.VulnInfos{
+				"CVE-9999-0001": models.VulnInfo{
+					CveID: "CVE-9999-0001",
+					CveContents: models.CveContents{
+						models.RedHat: []models.CveContent{
+							{
+								Type:  models.RedHat,
+								CveID: "CVE-9999-0001",
+								Title: "original",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "skip if RedHatAPI already present",
+			args: args{
+				vim: models.VulnInfos{
+					"CVE-2024-1102": models.VulnInfo{
+						CveID: "CVE-2024-1102",
+						CveContents: models.CveContents{
+							models.RedHatAPI: []models.CveContent{
+								{
+									Type:  models.RedHatAPI,
+									CveID: "CVE-2024-1102",
+									Title: "already-enriched",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: models.VulnInfos{
+				"CVE-2024-1102": models.VulnInfo{
+					CveID: "CVE-2024-1102",
+					CveContents: models.CveContents{
+						models.RedHatAPI: []models.CveContent{
+							{
+								Type:  models.RedHatAPI,
+								CveID: "CVE-2024-1102",
+								Title: "already-enriched",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "empty VulnInfos",
+			args: args{
+				vim: models.VulnInfos{},
+			},
+			want: models.VulnInfos{},
+		},
+	}
+
+	c := session.Config{Type: "boltdb", Path: filepath.Join(t.TempDir(), "enrich-test.db")}
+	if err := testutil.PopulateDB(c, "testdata/fixtures/enrich"); err != nil {
+		t.Fatalf("PopulateDB() err: %v", err)
+	}
+
+	sesh, err := c.New()
+	if err != nil {
+		t.Fatalf("session.Config.New() err: %v", err)
+	}
+	if err := sesh.Storage().Open(); err != nil {
+		t.Fatalf("Storage().Open() err: %v", err)
+	}
+	defer sesh.Storage().Close()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := vuls2.Enrich(sesh, tt.args.vim); (err != nil) != tt.wantErr {
+				t.Errorf("enrich() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			diff, err := compareVulnInfos(tt.args.vim, tt.want)
+			if err != nil {
+				t.Errorf("enrich() compareVulnInfos() error = %v", err)
+			}
+			if diff != "" {
+				t.Errorf("enrich() mismatch (-got +want):\n%s", diff)
 			}
 		})
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/detector"
-	"github.com/future-architect/vuls/gost"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
 	"github.com/future-architect/vuls/reporter"
@@ -66,12 +65,6 @@ func (h VulsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		logging.Log.Errorf("Failed to detect Pkg CVE: %+v", err)
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return
-	}
-
-	logging.Log.Infof("Fill CVE detailed with gost")
-	if err := gost.FillCVEsWithRedHat(&r, config.Conf.Gost, config.Conf.LogOpts); err != nil {
-		logging.Log.Errorf("Failed to fill with gost: %+v", err)
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 	}
 
 	logging.Log.Infof("Fill CVE detailed with CVE-DB")


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

Add enrich() to detector/vuls2 that queries vulnerability data by CVE ID across all sources via GetVulnerability(), enabling cross-source enrichment (e.g., RedHat CVE data for Debian-detected CVEs).

- Add enrich(), enrichCveContentType(), enrichCvss() in detector/vuls2
- Call enrich() after postConvert() in vuls2.Detect()
- Remove gost.FillCVEsWithRedHat() calls from detector and server
- Add RedHatAPI to cveContentSourceLink()

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

unit test

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

- https://github.com/vulsio/vuls-data-db/pull/123
- https://github.com/vulsio/vuls-data-db/pull/124