### PR TITLE
fix(detector/vuls2): skip advisory fallback for ignored vulns

### DIFF
--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -659,6 +659,7 @@ func walkVulnerabilityDatas(m map[source]sourceData, vds []detectTypes.Vulnerabi
 			}
 		}
 
+		srcsWithVulns := make(map[source]struct{})
 		for _, vdv := range vd.Vulnerabilities {
 			for sid, rm := range vdv.Contents {
 				if rm == nil {
@@ -675,6 +676,8 @@ func walkVulnerabilityDatas(m map[source]sourceData, vds []detectTypes.Vulnerabi
 						if _, ok := m[src]; !ok {
 							continue
 						}
+
+						srcsWithVulns[src] = struct{}{}
 
 						if ignoreVulnerability(src.Segment.Ecosystem, v, am[src]) {
 							continue
@@ -762,6 +765,15 @@ func walkVulnerabilityDatas(m map[source]sourceData, vds []detectTypes.Vulnerabi
 					}
 				}
 			}
+		}
+
+		// Remove sources that had vulnerabilities from the advisory map.
+		// The advisory fallback below creates VulnInfo from advisory IDs only when
+		// no vulnerabilities exist for a source. Without this deletion, sources whose
+		// vulnerabilities were all dropped by ignoreVulnerability would incorrectly
+		// fall through to advisory-based VulnInfo creation.
+		for src := range srcsWithVulns {
+			delete(am, src)
 		}
 
 		for src, das := range am {

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -8235,6 +8235,133 @@ func Test_postConvert(t *testing.T) {
 			want: models.VulnInfos{},
 		},
 		{
+			name: "redhat: all vulnerabilities ignored should not fallback to advisory",
+			args: args{
+				scanned: scanTypes.ScanResult{
+					OSPackages: []scanTypes.OSPackage{
+						{
+							Name:    "package1",
+							Epoch:   new(0),
+							Version: "0.0.0",
+							Release: "0.el9",
+							Arch:    "x86_64",
+							SrcName: "package",
+						},
+					},
+				},
+				detected: detectTypes.DetectResult{
+					Detected: []detectTypes.VulnerabilityData{
+						{
+							ID: "RHSA-2025:0001",
+							Advisories: []dbTypes.VulnerabilityDataAdvisory{
+								{
+									ID: "RHSA-2025:0001",
+									Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]advisoryTypes.Advisory{
+										sourceTypes.RedHatOVALv2: {
+											dataTypes.RootID("RHSA-2025:0001"): []advisoryTypes.Advisory{
+												{
+													Content: advisoryContentTypes.Content{
+														ID:          "RHSA-2025:0001",
+														Title:       "title",
+														Description: "description",
+														Published:   new(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+													},
+													Segments: []segmentTypes.Segment{
+														{
+															Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+															Tag:       segmentTypes.DetectionTag("rhel-9-including-unpatched"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+								{
+									ID: "CVE-2025-0001",
+									Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+										sourceTypes.RedHatOVALv2: {
+											dataTypes.RootID("RHSA-2025:0001"): []vulnerabilityTypes.Vulnerability{
+												{
+													Content: vulnerabilityContentTypes.Content{
+														ID:          "CVE-2025-0001",
+														Title:       "title",
+														Description: "** REJECT ** This CVE has been rejected.",
+														References: []referenceTypes.Reference{
+															{
+																URL: "https://access.redhat.com/security/cve/CVE-2025-0001",
+															},
+														},
+														Published: new(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+													},
+													Segments: []segmentTypes.Segment{
+														{
+															Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+															Tag:       segmentTypes.DetectionTag("rhel-9-including-unpatched"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Detections: []detectTypes.VulnerabilityDataDetection{
+								{
+									Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+									Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+										sourceTypes.RedHatOVALv2: {
+											{
+												Criteria: criteriaTypes.FilteredCriteria{
+													Operator: criteriaTypes.CriteriaOperatorTypeOR,
+													Criterions: []criterionTypes.FilteredCriterion{
+														{
+															Criterion: criterionTypes.Criterion{
+																Type: criterionTypes.CriterionTypeVersion,
+																Version: new(versioncriterionTypes.Criterion{
+																	Vulnerable: true,
+																	FixStatus: new(vcFixStatusTypes.FixStatus{
+																		Class: vcFixStatusTypes.ClassFixed,
+																	}),
+																	Package: vcPackageTypes.Package{
+																		Type: vcPackageTypes.PackageTypeBinary,
+																		Binary: &vcBinaryPackageTypes.Package{
+																			Name:          "package1",
+																			Architectures: []string{"aarch64", "x86_64"},
+																		},
+																	},
+																	Affected: &vcAffectedTypes.Affected{
+																		Type: vcAffectedRangeTypes.RangeTypeRPM,
+																		Range: []vcAffectedRangeTypes.Range{
+																			{
+																				LessThan: "0.0.0-1.el9",
+																			},
+																		},
+																		Fixed: []string{"0.0.0-1.el9"},
+																	},
+																}),
+															},
+															Accepts: criterionTypes.AcceptQueries{
+																Version: []int{0},
+															},
+														},
+													},
+												},
+												Tag: segmentTypes.DetectionTag("rhel-9-including-unpatched"),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: models.VulnInfos{},
+		},
+		{
 			name: "debian: advisory without vulnerability",
 			args: args{
 				scanned: scanTypes.ScanResult{


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

When all vulnerabilities for a source were dropped by ignoreVulnerability, the advisory fallback incorrectly created VulnInfo using the advisory ID. Remove such sources from the advisory map after processing vulnerabilities so the fallback only applies when no vulnerabilities exist at all.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

by unit test

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

