### PR TITLE
fix(detector): enrich all detected CVEs, not only vuls2-detected ones

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -195,6 +195,10 @@ func Detect(rs []models.ScanResult, dir string) ([]models.ScanResult, error) {
 			return nil, xerrors.Errorf("Failed to detect WordPress Cves: %w", err)
 		}
 
+		if err := vuls2.EnrichVulnInfos(&r, config.Conf.Vuls2, config.Conf.NoProgress); err != nil {
+			return nil, xerrors.Errorf("Failed to enrich vulnerability data with vuls2: %w", err)
+		}
+
 		if err := FillCvesWithGoCVEDictionary(&r, config.Conf.CveDict, config.Conf.LogOpts); err != nil {
 			return nil, xerrors.Errorf("Failed to fill with CVE: %w", err)
 		}

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -94,10 +94,6 @@ func Detect(r *models.ScanResult, vuls2Conf config.Vuls2Conf, noProgress bool) e
 		return xerrors.Errorf("Failed to post convert. err: %w", err)
 	}
 
-	if err := enrich(sesh, vulnInfos); err != nil {
-		return xerrors.Errorf("Failed to enrich vulnerability data. err: %w", err)
-	}
-
 	for cveID, vi := range vulnInfos {
 		viBase, found := r.ScannedCves[cveID]
 		if !found {
@@ -118,6 +114,50 @@ func Detect(r *models.ScanResult, vuls2Conf config.Vuls2Conf, noProgress bool) e
 	}
 
 	logging.Log.Infof("%s: %d CVEs are detected with vuls2", r.FormatServerName(), len(vulnInfos))
+
+	return nil
+}
+
+// EnrichVulnInfos enriches all ScannedCves in the ScanResult with additional vulnerability data
+// (e.g., Red Hat API) from the vuls2 database.
+// This should be called after all detection paths have completed.
+func EnrichVulnInfos(r *models.ScanResult, vuls2Conf config.Vuls2Conf, noProgress bool) error {
+	if len(r.ScannedCves) == 0 {
+		return nil
+	}
+
+	if vuls2Conf.Repository == "" {
+		sv, err := session.SchemaVersion("boltdb")
+		if err != nil {
+			return xerrors.Errorf("Failed to get schema version. err: %w", err)
+		}
+
+		vuls2Conf.Repository = fmt.Sprintf("%s:%d", defaultRegistory, sv)
+	}
+	if vuls2Conf.Path == "" {
+		vuls2Conf.Path = DefaultPath
+	}
+
+	dbConfig, err := newDBConfig(vuls2Conf, noProgress)
+	if err != nil {
+		return xerrors.Errorf("Failed to get new db connection. err: %w", err)
+	}
+
+	sesh, err := dbConfig.New()
+	if err != nil {
+		return xerrors.Errorf("Failed to new db session. err: %w", err)
+	}
+
+	defer sesh.Cache().Close()
+
+	if err := sesh.Storage().Open(); err != nil {
+		return xerrors.Errorf("Failed to open db. err: %w", err)
+	}
+	defer sesh.Storage().Close()
+
+	if err := enrich(sesh, r.ScannedCves); err != nil {
+		return xerrors.Errorf("Failed to enrich vulnerability data. err: %w", err)
+	}
 
 	return nil
 }
@@ -1174,6 +1214,10 @@ func enrich(sesh *session.Session, vim models.VulnInfos) error {
 			return xerrors.Errorf("Failed to get vulnerability. CVE-ID: %s, err: %w", cveID, err)
 		}
 
+		if vi.CveContents == nil {
+			vi.CveContents = models.NewCveContents()
+		}
+
 		for sourceID, rootMap := range vm {
 			cctype := enrichCveContentType(sourceID)
 			if cctype == models.Unknown {
@@ -1192,7 +1236,7 @@ func enrich(sesh *session.Session, vim models.VulnInfos) error {
 						rs = append(rs, toReference(r.URL))
 					}
 
-					cc := models.CveContent{
+					vi.CveContents[cctype] = append(vi.CveContents[cctype], models.CveContent{
 						Type:           cctype,
 						CveID:          cveID,
 						Title:          v.Content.Title,
@@ -1227,8 +1271,7 @@ func enrich(sesh *session.Session, vim models.VulnInfos) error {
 							}
 							return time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
 						}(),
-					}
-					vi.CveContents[cctype] = append(vi.CveContents[cctype], cc)
+					})
 				}
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/detector"
+	"github.com/future-architect/vuls/detector/vuls2"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/models"
 	"github.com/future-architect/vuls/reporter"
@@ -63,6 +64,12 @@ func (h VulsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if err := detector.DetectPkgCves(&r, config.Conf.Gost, config.Conf.Vuls2, config.Conf.LogOpts, config.Conf.NoProgress); err != nil {
 		logging.Log.Errorf("Failed to detect Pkg CVE: %+v", err)
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	if err := vuls2.EnrichVulnInfos(&r, config.Conf.Vuls2, config.Conf.NoProgress); err != nil {
+		logging.Log.Errorf("Failed to enrich vulnerability data with vuls2: %+v", err)
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return
 	}


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

 Previously, enrich() was only called inside vuls2.Detect(), so CVEs
 detected via gost (Windows), CPE URIs, libraries, and WordPress were
 never enriched with additional vulnerability data (e.g., Red Hat API).

 Extract enrichment into a new public EnrichVulnInfos() function and
 call it in detector.Detect() after all detection paths have completed.

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
## setup
```console
$ cat << EOS > config.toml
version = "v2"

[default]

[servers]

[servers.pseudo]
type = "pseudo"
scanMode           = ["fast"]
scanModules        = ["lockfile"]
lockfiles = [
    "/home/vuls/integration/data/lockfile/Cargo.lock",
]
EOS

$ vuls scan
```

## before
```console
$ vuls report
$ jq -r '.scannedCves."CVE-2021-45710".cveContents.redhat_api' results/2026-04-14T18-31-29+0900/pseudo.json
(empty)
```

## after
```console
$ vuls report --refresh-cve
$ jq -r '.scannedCves."CVE-2021-45710".cveContents.redhat_api' results/2026-04-14T18-31-29+0900/pseudo.json
[
  {
    "type": "redhat_api",
    "cveID": "CVE-2021-45710",
    "title": "tokio: Race leads to panic in oneshot::Sender::send()",
    "summary": "An issue was discovered in the tokio crate before 1.8.4, and 1.9.x through 1.13.x before 1.13.1, for Rust. In certain circumstances involving a closed oneshot channel, there is a data race and memory corruption.\nA flaw was found in the tokio crate for Rust. In circumstances involving a closed oneshot channel, there is a data race and memory corruption issue.",
    "cvss2Score": 0,
    "cvss2Vector": "",
    "cvss2Severity": "",
    "cvss3Score": 7.3,
    "cvss3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
    "cvss3Severity": "Low",
    "cvss40Score": 0,
    "cvss40Vector": "",
    "cvss40Severity": "",
    "sourceLink": "https://access.redhat.com/security/cve/CVE-2021-45710",
    "references": [
      {
        "link": "https://bugzilla.redhat.com/show_bug.cgi?id=2143519",
        "source": "REDHAT",
        "refID": "2143519"
      },
      {
        "link": "https://nvd.nist.gov/vuln/detail/CVE-2021-45710",
        "source": "NVD",
        "refID": "CVE-2021-45710"
      },
      {
        "link": "https://raw.githubusercontent.com/rustsec/advisory-db/main/crates/tokio/RUSTSEC-2021-0124.md",
        "source": "MISC"
      },
      {
        "link": "https://rustsec.org/advisories/RUSTSEC-2021-0124.html",
        "source": "MISC"
      },
      {
        "link": "https://www.cve.org/CVERecord?id=CVE-2021-45710",
        "source": "CVE",
        "refID": "CVE-2021-45710"
      }
    ],
    "cweIDs": [
      "CWE-362"
    ],
    "published": "2021-12-27T00:00:00Z",
    "lastModified": "1000-01-01T00:00:00Z"
  }
]
```

# Checklist:
You don't have to satisfy all of the following.

- [ ] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

