### PR TITLE
feat(detector): add DataSources filter to enrich function

### DIFF
--- a/detector/vuls2/testdata/fixtures/enrich/mitre-v5/data/CVE-2023-44487.json
+++ b/detector/vuls2/testdata/fixtures/enrich/mitre-v5/data/CVE-2023-44487.json
@@ -1,0 +1,36 @@
+{
+	"id": "CVE-2023-44487",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-44487",
+				"title": "HTTP/2 Rapid Reset Attack",
+				"description": "The HTTP/2 protocol allows a denial of service (server resource consumption) because request cancellation can reset many streams quickly, as exploited in the wild in August through October 2023.",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "cve@mitre.org",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+							"base_score": 7.5,
+							"base_severity": "HIGH"
+						}
+					}
+				],
+				"references": [
+					{
+						"source": "cve@mitre.org",
+						"url": "https://www.cve.org/CVERecord?id=CVE-2023-44487"
+					}
+				],
+				"published": "2023-10-10T00:00:00Z"
+			}
+		}
+	],
+	"data_source": {
+		"id": "mitre-v5",
+		"raws": [
+			"fixtures/CVE-2023-44487.json"
+		]
+	}
+}

--- a/detector/vuls2/testdata/fixtures/enrich/mitre-v5/data/CVE-2024-1102.json
+++ b/detector/vuls2/testdata/fixtures/enrich/mitre-v5/data/CVE-2024-1102.json
@@ -1,0 +1,18 @@
+{
+	"id": "CVE-2024-1102",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-1102",
+				"title": "jberet: jberet-core logging database credentials (from mitre-v5)",
+				"description": "This data should be filtered out by the DataSources filter and never reach enrichVulnerabilities."
+			}
+		}
+	],
+	"data_source": {
+		"id": "mitre-v5",
+		"raws": [
+			"fixtures/CVE-2024-1102.json"
+		]
+	}
+}

--- a/detector/vuls2/testdata/fixtures/enrich/mitre-v5/datasource.json
+++ b/detector/vuls2/testdata/fixtures/enrich/mitre-v5/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "mitre-v5",
+	"name": "MITRE CVE v5"
+}

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -1201,7 +1201,7 @@ func toReference(ref string) models.Reference {
 	}
 }
 
-// enrich adds vulnerability data from all sources (including non-detecting sources)
+// enrich adds vulnerability data from specific enrichment sources (KEV, RedHat CVE)
 // to the already-detected VulnInfos. This replaces gost.FillCVEsWithRedHat and also
 // provides cross-source enrichment (e.g., RedHat CVE data for Debian-detected CVEs).
 func enrich(sesh *session.Session, vim models.VulnInfos) error {
@@ -1210,6 +1210,13 @@ func enrich(sesh *session.Session, vim models.VulnInfos) error {
 			Contents: []dbTypes.FilterContentType{
 				dbTypes.FilterContentTypeAdvisories,
 				dbTypes.FilterContentTypeVulnerabilities,
+			},
+			DataSources: []sourceTypes.SourceID{
+				sourceTypes.CISAKEV,
+				sourceTypes.ENISAKEV,
+				sourceTypes.Metasploit,
+				sourceTypes.RedHatCVE,
+				sourceTypes.VulnCheckKEV,
 			},
 		})
 		if err != nil {

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -9295,6 +9295,22 @@ func Test_enrich(t *testing.T) {
 			},
 			want: models.VulnInfos{},
 		},
+		{
+			name: "datasource not in enrich filter is filtered out",
+			args: args{
+				vim: models.VulnInfos{
+					"CVE-2023-44487": models.VulnInfo{
+						CveID: "CVE-2023-44487",
+					},
+				},
+			},
+			want: models.VulnInfos{
+				"CVE-2023-44487": models.VulnInfo{
+					CveID:       "CVE-2023-44487",
+					CveContents: models.CveContents{},
+				},
+			},
+		},
 	}
 
 	c := session.Config{Type: "boltdb", Path: filepath.Join(t.TempDir(), "enrich-test.db")}

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/BurntSushi/toml v1.6.0
 	github.com/CycloneDX/cyclonedx-go v0.10.0
-	github.com/MaineK00n/vuls-data-update v0.0.0-20260415043012-19efba9dab97
-	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260309062902-6fa3e81762d9
+	github.com/MaineK00n/vuls-data-update v0.0.0-20260415100620-ce86ca1a408d
+	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260416040322-81ce30605753
 	github.com/Ullaakut/nmap/v2 v2.2.2
 	github.com/aquasecurity/trivy v0.69.2
 	github.com/aquasecurity/trivy-db v0.0.0-20251222105351-a833f47f8f0d

--- a/go.sum
+++ b/go.sum
@@ -70,10 +70,10 @@ github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc h1:
 github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc/go.mod h1:GNf+Vhnxk8/pW56jsxAeFCBP0VCgVQlLIJ812UnAj9c=
 github.com/MaineK00n/go-paloalto-version v0.0.0-20250909032857-57479910413b h1:pDmxa1+HCq7nShTgLURMOpjKc38hYq3lrgNHqur/Nps=
 github.com/MaineK00n/go-paloalto-version v0.0.0-20250909032857-57479910413b/go.mod h1:ELOxzfAd4oAe4niMmoZlSiJwzf1DF+DjNdjsUcuqAR8=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260415043012-19efba9dab97 h1:d47BSg9Gi+ZyTTZn6Fkh2O4juZS7LKBG+iAlvigbVlU=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260415043012-19efba9dab97/go.mod h1:3bTaNbc4WrdAWFbo9kCtdbvMz10i72XGpa8U1fGMzOE=
-github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260309062902-6fa3e81762d9 h1:soWhB4NG12vsdy7N+LFxeVu5vS2YrHAuae+O/ZqPKqM=
-github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260309062902-6fa3e81762d9/go.mod h1:Px7Z7+l1+WrZlhfVRRKW2rSZ8CqS4ZW6wb5/BsPCvBs=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260415100620-ce86ca1a408d h1:QdfZfoz8rJSZmlM9t9LSjqq7WmQdFe7aRPZTni14eSI=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260415100620-ce86ca1a408d/go.mod h1:3bTaNbc4WrdAWFbo9kCtdbvMz10i72XGpa8U1fGMzOE=
+github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260416040322-81ce30605753 h1:SraOXYeQdog7TihZYbgdwyUc76oiMNxARWI+3NG3RPQ=
+github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260416040322-81ce30605753/go.mod h1:o02d7v5LzUDj32vt1LibE30MoO9X9yWUhmHfgAO/46I=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

   Specify the DataSources used by enrich (CISA KEV, ENISA KEV,
   RedHat CVE, VulnCheck KEV) in the filter passed to
   GetVulnerabilityDataByVulnerabilityID, so that only relevant
   sources are fetched.

   Also add a test case with mitre-v5 fixture data to verify that
   non-enrich DataSources are correctly filtered out.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

unit test

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

- https://github.com/MaineK00n/vuls2/pull/353
