### PR TITLE
feat(detector/vuls2): thread RedHat CVE Mitigation into VulnInfo

### DIFF
--- a/detector/vuls2/testdata/fixtures/enrich/redhat-cve/data/CVE-2024-1102.json
+++ b/detector/vuls2/testdata/fixtures/enrich/redhat-cve/data/CVE-2024-1102.json
@@ -52,6 +52,12 @@
 						"url": "https://www.cve.org/CVERecord?id=CVE-2024-1102"
 					}
 				],
+				"mitigations": [
+					{
+						"source": "secalert@redhat.com",
+						"description": "Mitigation for this issue is either not available or the currently available options don't meet the Red Hat Product Security criteria."
+					}
+				],
 				"published": "2024-01-29T00:00:00Z"
 			}
 		}

--- a/detector/vuls2/vendor.go
+++ b/detector/vuls2/vendor.go
@@ -1112,6 +1112,18 @@ func enrichRedHatCVE(vi *models.VulnInfo, rootMap map[dataTypes.RootID][]vulnera
 				rs = append(rs, toReference(r.URL))
 			}
 
+			sourceLink := cveContentSourceLink(models.RedHatAPI, v)
+			for _, m := range v.Content.Mitigations {
+				if m.Description == "" {
+					continue
+				}
+				vi.Mitigations = append(vi.Mitigations, models.Mitigation{
+					CveContentType: models.RedHatAPI,
+					Mitigation:     m.Description,
+					URL:            sourceLink,
+				})
+			}
+
 			vi.CveContents[models.RedHatAPI] = append(vi.CveContents[models.RedHatAPI], models.CveContent{
 				Type:           models.RedHatAPI,
 				CveID:          string(v.Content.ID),
@@ -1126,7 +1138,7 @@ func enrichRedHatCVE(vi *models.VulnInfo, rootMap map[dataTypes.RootID][]vulnera
 				Cvss40Score:    cvss40.Score,
 				Cvss40Vector:   cvss40.Vector,
 				Cvss40Severity: cvss40.Severity,
-				SourceLink:     cveContentSourceLink(models.RedHatAPI, v),
+				SourceLink:     sourceLink,
 				References:     rs,
 				CweIDs: func() []string {
 					var cs []string //nolint:prealloc

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -755,10 +755,34 @@ func walkVulnerabilityDatas(m map[source]sourceData, vds []detectTypes.Vulnerabi
 								}
 							}
 
+							sourceLink := cveContentSourceLink(cctype, v)
+							var ms []models.Mitigation
+							for _, rr := range v.Content.Mitigations {
+								if rr.Description == "" {
+									continue
+								}
+								ms = append(ms, models.Mitigation{
+									CveContentType: cctype,
+									Mitigation:     rr.Description,
+									URL:            sourceLink,
+								})
+							}
+							for _, rr := range v.Content.Workarounds {
+								if rr.Description == "" {
+									continue
+								}
+								ms = append(ms, models.Mitigation{
+									CveContentType: cctype,
+									Mitigation:     rr.Description,
+									URL:            sourceLink,
+								})
+							}
+
 							return models.VulnInfo{
 								CveID:            string(v.Content.ID),
 								Confidences:      models.Confidences{toVuls0Confidence(src.Segment.Ecosystem, src.SourceID)},
 								DistroAdvisories: fdas,
+								Mitigations:      ms,
 								CveContents: models.NewCveContents(models.CveContent{
 									Type:           cctype,
 									CveID:          string(v.Content.ID),
@@ -773,7 +797,7 @@ func walkVulnerabilityDatas(m map[source]sourceData, vds []detectTypes.Vulnerabi
 									Cvss40Score:    cvss40.Score,
 									Cvss40Vector:   cvss40.Vector,
 									Cvss40Severity: cvss40.Severity,
-									SourceLink:     cveContentSourceLink(cctype, v),
+									SourceLink:     sourceLink,
 									References:     rs,
 									CweIDs: func() []string {
 										var cs []string

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -755,34 +755,10 @@ func walkVulnerabilityDatas(m map[source]sourceData, vds []detectTypes.Vulnerabi
 								}
 							}
 
-							sourceLink := cveContentSourceLink(cctype, v)
-							var ms []models.Mitigation
-							for _, rr := range v.Content.Mitigations {
-								if rr.Description == "" {
-									continue
-								}
-								ms = append(ms, models.Mitigation{
-									CveContentType: cctype,
-									Mitigation:     rr.Description,
-									URL:            sourceLink,
-								})
-							}
-							for _, rr := range v.Content.Workarounds {
-								if rr.Description == "" {
-									continue
-								}
-								ms = append(ms, models.Mitigation{
-									CveContentType: cctype,
-									Mitigation:     rr.Description,
-									URL:            sourceLink,
-								})
-							}
-
 							return models.VulnInfo{
 								CveID:            string(v.Content.ID),
 								Confidences:      models.Confidences{toVuls0Confidence(src.Segment.Ecosystem, src.SourceID)},
 								DistroAdvisories: fdas,
-								Mitigations:      ms,
 								CveContents: models.NewCveContents(models.CveContent{
 									Type:           cctype,
 									CveID:          string(v.Content.ID),
@@ -797,7 +773,7 @@ func walkVulnerabilityDatas(m map[source]sourceData, vds []detectTypes.Vulnerabi
 									Cvss40Score:    cvss40.Score,
 									Cvss40Vector:   cvss40.Vector,
 									Cvss40Severity: cvss40.Severity,
-									SourceLink:     sourceLink,
+									SourceLink:     cveContentSourceLink(cctype, v),
 									References:     rs,
 									CweIDs: func() []string {
 										var cs []string

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -9078,6 +9078,13 @@ func Test_enrich(t *testing.T) {
 							},
 						},
 					},
+					Mitigations: []models.Mitigation{
+						{
+							CveContentType: models.RedHatAPI,
+							Mitigation:     "Mitigation for this issue is either not available or the currently available options don't meet the Red Hat Product Security criteria.",
+							URL:            "https://access.redhat.com/security/cve/CVE-2024-1102",
+						},
+					},
 				},
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/BurntSushi/toml v1.6.0
 	github.com/CycloneDX/cyclonedx-go v0.10.0
-	github.com/MaineK00n/vuls-data-update v0.0.0-20260422085454-27a5cbe1b3fc
-	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260416040322-81ce30605753
+	github.com/MaineK00n/vuls-data-update v0.0.0-20260428075914-ea21d0d8e4c9
+	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260428085730-652a7653079a
 	github.com/Ullaakut/nmap/v2 v2.2.2
 	github.com/aquasecurity/trivy v0.69.2
 	github.com/aquasecurity/trivy-db v0.0.0-20251222105351-a833f47f8f0d

--- a/go.sum
+++ b/go.sum
@@ -70,10 +70,10 @@ github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc h1:
 github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc/go.mod h1:GNf+Vhnxk8/pW56jsxAeFCBP0VCgVQlLIJ812UnAj9c=
 github.com/MaineK00n/go-paloalto-version v0.0.0-20250909032857-57479910413b h1:pDmxa1+HCq7nShTgLURMOpjKc38hYq3lrgNHqur/Nps=
 github.com/MaineK00n/go-paloalto-version v0.0.0-20250909032857-57479910413b/go.mod h1:ELOxzfAd4oAe4niMmoZlSiJwzf1DF+DjNdjsUcuqAR8=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260422085454-27a5cbe1b3fc h1:AU84WemlOE7XoB5ZIwV7L3caPPnYHcpSGupBWyILCLo=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260422085454-27a5cbe1b3fc/go.mod h1:zgZp2Gf0JQ8pPSHgDSxm+KFKf8twW+rWice7TIY7zEs=
-github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260416040322-81ce30605753 h1:SraOXYeQdog7TihZYbgdwyUc76oiMNxARWI+3NG3RPQ=
-github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260416040322-81ce30605753/go.mod h1:o02d7v5LzUDj32vt1LibE30MoO9X9yWUhmHfgAO/46I=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260428075914-ea21d0d8e4c9 h1:i9IAWrcmxhYJSTjhtINsFOAFmnfJusQQGNWIJnpkjcc=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260428075914-ea21d0d8e4c9/go.mod h1:zgZp2Gf0JQ8pPSHgDSxm+KFKf8twW+rWice7TIY7zEs=
+github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260428085730-652a7653079a h1:tQ610AsfIroZTw0CfdwHVQTAZx80oh0eiT3BpfRu7kc=
+github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260428085730-652a7653079a/go.mod h1:qkxUez6eptvA7j62OGmOtfsE/yYH+0ydqg2fNEhlEhM=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
If this Pull Request is work in progress, Add a prefix of “[WIP]” in the title.

# What did you implement:

vuls-data-update now exposes per-source Mitigations and Workarounds on extracted Vulnerability/Advisory Content (vuls-data-update#783, vuls2#366). Surface that data to vuls0 reports by populating `VulnInfo.Mitigations` from `redhat-cve` extracted Content inside `enrichRedHatCVE`, with `CveContentType=RedHatAPI` and `URL=https://access.redhat.com/security/cve/<CVE ID>` — matching v0.38.6 `gost.RedHat` behavior.

Scope is intentionally limited to `redhat-cve`. It is the only data source that historically populated `VulnInfo.Mitigations` (via `gost.RedHat`) and has now been migrated to vuls2. Other sources newly carrying mitigation/workaround data (`redhat-csaf`, `redhat-vex`, `mitre-v5`, `ubuntu-tracker`) flow through extracted Content but are not yet surfaced here. `gost.Microsoft` is untouched because Windows is not yet on vuls2.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Extended the existing `Test_enrich` "enrich with redhat-cve data" case with a `mitigations` fixture entry and asserted the populated `VulnInfo.Mitigations`.

`go build ./...` and `go test ./...` both pass.

# Checklist:
You don't have to satisfy all of the following.

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

# Reference

- [vuls-data-update#783](https://github.com/MaineK00n/vuls-data-update/pull/783)
- [vuls2#366](https://github.com/MaineK00n/vuls2/pull/366)