### PR TITLE
fix(detector/library): regenerate PURL after JAR SHA1 canonicalization

### DIFF
--- a/detector/library.go
+++ b/detector/library.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/detector/library"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
+	"github.com/aquasecurity/trivy/pkg/purl"
 	"github.com/aquasecurity/trivy/pkg/types"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/samber/lo"
@@ -225,6 +226,14 @@ func (d *libraryDetector) improveJARInfo() error {
 		foundLib := foundProps.Package()
 		l.Name = foundLib.Name
 		l.Version = foundLib.Version
+		// PURL was originally derived from Trivy's pre-resolution Name (e.g.
+		// "commons-lang3" without groupId when MANIFEST.MF lacked it), so it
+		// stays groupId-less unless we regenerate it from the SHA1-resolved
+		// "groupId:artifactId" form. Keep the previous PURL when regeneration
+		// fails so we never write back an empty value.
+		if canonical := canonicalMavenPURL(foundLib); canonical != "" {
+			l.PURL = canonical
+		}
 		libs = append(libs, l)
 	}
 
@@ -232,6 +241,17 @@ func (d *libraryDetector) improveJARInfo() error {
 		return fmt.Sprintf("%s::%s::%s", lib.Name, lib.Version, lib.FilePath)
 	})
 	return nil
+}
+
+// canonicalMavenPURL builds a Maven purl from a Trivy Java DB-resolved
+// Package whose Name is in "groupId:artifactId" form. Returns "" when the
+// purl cannot be re-encoded (caller keeps the existing value in that case).
+func canonicalMavenPURL(pkg ftypes.Package) string {
+	p, err := purl.New(ftypes.Jar, types.Metadata{}, pkg)
+	if err != nil || p == nil {
+		return ""
+	}
+	return p.Unwrap().ToString()
 }
 
 func (d libraryDetector) convertFanalToVuln(tvulns []types.DetectedVulnerability) (vulns []models.VulnInfo) {

--- a/detector/library.go
+++ b/detector/library.go
@@ -240,8 +240,17 @@ func (d *libraryDetector) improveJARInfo() error {
 
 // canonicalMavenPURL builds a Maven purl from a Trivy Java DB-resolved
 // Package whose Name is in "groupId:artifactId" form. Returns "" when the
-// purl cannot be re-encoded (caller keeps the existing value in that case).
+// Name does not match that shape or the purl cannot be re-encoded
+// (caller keeps the existing value in that case).
 func canonicalMavenPURL(pkg ftypes.Package) string {
+	// Reject any Name that is not "groupId:artifactId" with both halves
+	// non-empty, otherwise we may overwrite an existing PURL with another
+	// non-canonical value (e.g. Java DB row with empty GroupID would
+	// expand to ":artifactId" → "pkg:maven//artifactId@..." here).
+	group, artifact, ok := strings.Cut(pkg.Name, ":")
+	if !ok || group == "" || artifact == "" {
+		return ""
+	}
 	p, err := purl.New(ftypes.Jar, types.Metadata{}, pkg)
 	if err != nil {
 		logging.Log.Debugf("Failed to build canonical Maven purl for %s: %+v", pkg.Name, err)

--- a/detector/library.go
+++ b/detector/library.go
@@ -226,11 +226,6 @@ func (d *libraryDetector) improveJARInfo() error {
 		foundLib := foundProps.Package()
 		l.Name = foundLib.Name
 		l.Version = foundLib.Version
-		// PURL was originally derived from Trivy's pre-resolution Name (e.g.
-		// "commons-lang3" without groupId when MANIFEST.MF lacked it), so it
-		// stays groupId-less unless we regenerate it from the SHA1-resolved
-		// "groupId:artifactId" form. Keep the previous PURL when regeneration
-		// fails so we never write back an empty value.
 		if canonical := canonicalMavenPURL(foundLib); canonical != "" {
 			l.PURL = canonical
 		}

--- a/detector/library.go
+++ b/detector/library.go
@@ -243,7 +243,11 @@ func (d *libraryDetector) improveJARInfo() error {
 // purl cannot be re-encoded (caller keeps the existing value in that case).
 func canonicalMavenPURL(pkg ftypes.Package) string {
 	p, err := purl.New(ftypes.Jar, types.Metadata{}, pkg)
-	if err != nil || p == nil {
+	if err != nil {
+		logging.Log.Debugf("Failed to build canonical Maven purl for %s: %+v", pkg.Name, err)
+		return ""
+	}
+	if p == nil {
 		return ""
 	}
 	return p.Unwrap().ToString()

--- a/detector/library_test.go
+++ b/detector/library_test.go
@@ -46,6 +46,40 @@ func Test_canonicalMavenPURL(t *testing.T) {
 			},
 			want: "pkg:maven/com.example/example@1.0%2Bbuild.1",
 		},
+		// Defensive guards: caller must keep its existing PURL when input
+		// does not look like a canonical "groupId:artifactId" pair.
+		{
+			name: "Name with no colon (groupId-less Trivy fallback) returns empty",
+			pkg: ftypes.Package{
+				Name:    "log4j-core",
+				Version: "2.14.1",
+			},
+			want: "",
+		},
+		{
+			name: "Name with empty groupId returns empty",
+			pkg: ftypes.Package{
+				Name:    ":log4j-core",
+				Version: "2.14.1",
+			},
+			want: "",
+		},
+		{
+			name: "Name with empty artifactId returns empty",
+			pkg: ftypes.Package{
+				Name:    "org.apache.logging.log4j:",
+				Version: "2.14.1",
+			},
+			want: "",
+		},
+		{
+			name: "empty Name returns empty",
+			pkg: ftypes.Package{
+				Name:    "",
+				Version: "2.14.1",
+			},
+			want: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/detector/library_test.go
+++ b/detector/library_test.go
@@ -1,0 +1,59 @@
+//go:build !scanner
+
+package detector
+
+import (
+	"testing"
+
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
+)
+
+func Test_canonicalMavenPURL(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  ftypes.Package
+		want string
+	}{
+		{
+			name: "groupId:artifactId resolves to namespace/name purl",
+			pkg: ftypes.Package{
+				Name:    "org.apache.logging.log4j:log4j-core",
+				Version: "2.14.1",
+			},
+			want: "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+		},
+		{
+			name: "Trivy Java DB result with multi-segment groupId",
+			pkg: ftypes.Package{
+				Name:    "org.springframework.boot:spring-boot-starter-jdbc",
+				Version: "2.5.0",
+			},
+			want: "pkg:maven/org.springframework.boot/spring-boot-starter-jdbc@2.5.0",
+		},
+		{
+			name: "groupId == artifactId (legitimate Maven 1 coords)",
+			pkg: ftypes.Package{
+				Name:    "antlr:antlr",
+				Version: "2.7.7",
+			},
+			want: "pkg:maven/antlr/antlr@2.7.7",
+		},
+		{
+			name: "version string with `+` build-metadata is purl-encoded",
+			pkg: ftypes.Package{
+				Name:    "com.example:example",
+				Version: "1.0+build.1",
+			},
+			want: "pkg:maven/com.example/example@1.0%2Bbuild.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := canonicalMavenPURL(tt.pkg)
+			if got != tt.want {
+				t.Errorf("canonicalMavenPURL(%+v) = %q, want %q", tt.pkg, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`detector/library.go` `improveJARInfo()` resolves a JAR's SHA1 against the Trivy Java DB and overwrites `Library.Name` and `Library.Version` with the canonical `groupId:artifactId` / version returned by `jar.Properties.Package()`. **It never updates `Library.PURL`.**

`Library.PURL` is initially set in `scanner/library.go` `newPURL(app.Type, types.Metadata{}, lib)` — derived from Trivy's *pre-resolution* `Name`. When Trivy can read groupId from `pom.properties` or `META-INF/MANIFEST.MF`, the initial purl is correct. **But when those metadata sources are absent, Trivy falls back to emitting the JAR filename's artifactId as `Package.Name`**, producing an initial `pkg:maven/<artifactId>@<version>` (groupId-less and malformed under purl-spec for Maven).

After `improveJARInfo` resolves the SHA1 the in-memory `Library` ends up inconsistent:

```go
Library{
    Name:    "org.apache.commons:commons-lang3",        // ✅ canonical
    Version: "3.12.0",                                  // ✅ canonical
    PURL:    "pkg:maven/commons-lang3@3.12.0",          // ❌ stale, missing groupId
    Digest:  "sha1:...",
}
```

This stale `PURL` is what gets serialized into `ScanResult.LibraryScanners[].Libs[].PURL` and propagates to every downstream consumer that trusts purl over name (e.g. `futurevuls-backend` `ServerSoftware.purl`, OSS catalog enrichment pipelines that lookup by purl such as deps.dev / Maven Central). Detection-by-CVE keeps working because that path matches on `Name` + `Version`, but anything purl-keyed is broken.

## Fix

Regenerate `Library.PURL` from the resolved `Package` via Trivy's own `purl.New(ftypes.Jar, …)` (whose `purlType(ftypes.Jar) = packageurl.TypeMaven` then runs `parseMaven` to split `"groupId:artifactId"` into namespace + name). Keep the previous purl when regeneration fails so we never write back an empty value.

A small `canonicalMavenPURL` helper isolates the Trivy `purl` wrapping for unit testing without dragging in the JavaDB client.

```go
foundLib := foundProps.Package()
l.Name = foundLib.Name
l.Version = foundLib.Version
+if canonical := canonicalMavenPURL(foundLib); canonical != "" {
+    l.PURL = canonical
+}
libs = append(libs, l)
```

## Test plan

- New `Test_canonicalMavenPURL` table covers:
  - Standard `groupId:artifactId` → `pkg:maven/<group>/<artifact>@<version>`
  - Multi-segment groupId (e.g. `org.springframework.boot`)
  - Legitimate Maven 1 `groupId == artifactId` coords (e.g. `antlr/antlr`)
  - Version with `+` build-metadata correctly purl-encoded as `%2B`
- `go test ./detector/...` passes
- `go vet ./...` clean

## Observed downstream impact

This bug surfaced while debugging high failure rates in an OSS catalog populate pipeline that consumes ScanResult-derived PURLs:

> Maven failure rate **49.1%** — analysis showed 35.2% of failures are groupId-less `pkg:maven/<artifactId>` PURLs that the catalog's external resolvers (deps.dev, Maven Central) cannot match.

A fraction of those originate from Trivy SBOM emission upstream of Vuls, but the rest enter the catalog through Vuls's own ScanResult JSON because of this inconsistency. After this fix, JARs that Vuls successfully resolves via Java DB will export a canonical `pkg:maven/<group>/<artifact>@<version>` to downstream consumers.

## Notes

- No behavioral change for libraries with empty `Digest` (those still pass through untouched per the existing `pom.properties` comment).
- No behavioral change when the SHA1 lookup fails (`jar.ArtifactNotFoundErr` path still preserves the original library).
- No behavioral change for non-JAR scanners — `improveJARInfo` is only invoked when `d.scanner.Type == ftypes.Jar`.