### PR TITLE
feat(contrib/trivy): preserve JAR Digest in Library conversion

### DIFF
--- a/contrib/trivy/pkg/converter.go
+++ b/contrib/trivy/pkg/converter.go
@@ -263,6 +263,7 @@ func Convert(results types.Results, artifactType ftypes.ArtifactType, artifactNa
 					Version:  p.Version,
 					PURL:     getPURL(p),
 					FilePath: p.FilePath,
+					Digest:   string(p.Digest),
 					Dev:      p.Dev,
 				})
 				libraryScannerPaths[lockfilePath] = libScanner

--- a/contrib/trivy/pkg/converter_test.go
+++ b/contrib/trivy/pkg/converter_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 	gocmp "github.com/google/go-cmp/cmp"
 	gocmpopts "github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/package-url/packageurl-go"
 
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/types"
@@ -881,6 +882,61 @@ func TestConvert(t *testing.T) {
 						BinaryNames: []string{"libssl3t64"},
 					},
 				},
+			},
+		},
+		{
+			// Trivy emits Package.Digest (sha1) for JAR files; the converter
+			// must thread it through to models.Library.Digest so downstream
+			// consumers can reuse the SHA-1 (e.g. for Maven Central
+			// canonicalization or supply-chain verification).
+			name: "JAR digest is preserved into models.Library",
+			args: args{
+				results: types.Results{
+					{
+						Target: "Java",
+						Class:  types.ClassLangPkg,
+						Type:   ftypes.Jar,
+						Packages: []ftypes.Package{
+							{
+								Name:    "org.apache.logging.log4j:log4j-core",
+								Version: "2.14.1",
+								Identifier: ftypes.PkgIdentifier{
+									PURL: &packageurl.PackageURL{
+										Type:      packageurl.TypeMaven,
+										Namespace: "org.apache.logging.log4j",
+										Name:      "log4j-core",
+										Version:   "2.14.1",
+									},
+								},
+								FilePath: "app/log4j-core-2.14.1.jar",
+								Digest:   "sha1:ce8a86a3f50a4304749828ce68e7478cafbc8039",
+							},
+						},
+					},
+				},
+				artifactType: ftypes.TypeContainerImage,
+				artifactName: "test:latest",
+			},
+			want: &models.ScanResult{
+				JSONVersion: models.JSONVersion,
+				ScannedCves: models.VulnInfos{},
+				LibraryScanners: models.LibraryScanners{
+					models.LibraryScanner{
+						Type:         ftypes.Jar,
+						LockfilePath: "/app/log4j-core-2.14.1.jar",
+						Libs: []models.Library{
+							{
+								Name:     "org.apache.logging.log4j:log4j-core",
+								Version:  "2.14.1",
+								PURL:     "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+								FilePath: "app/log4j-core-2.14.1.jar",
+								Digest:   "sha1:ce8a86a3f50a4304749828ce68e7478cafbc8039",
+							},
+						},
+					},
+				},
+				Packages:    models.Packages{},
+				SrcPackages: models.SrcPackages{},
 			},
 		},
 	}


### PR DESCRIPTION
## Problem

`contrib/trivy/pkg/converter.go` converts Trivy native JSON into Vuls's `models.ScanResult`. For language packages (`types.ClassLangPkg`), it constructs `models.Library` from each input `ftypes.Package`:

```go
libScanner.Libs = append(libScanner.Libs, models.Library{
    Name:     p.Name,
    Version:  p.Version,
    PURL:     getPURL(p),
    FilePath: p.FilePath,
    Dev:      p.Dev,
    // p.Digest is dropped
})
```

Trivy's java jar analyzer (`pkg/fanal/analyzer/language/java/jar/jar.go`) sets `ftypes.Package.Digest` to the JAR's SHA-1 hash (`"sha1:<hex>"`) when scanning JAR files. The native Vuls LibraryScanner path already preserves this on `models.Library.Digest` at `scanner/library.go`:

```go
libs = append(libs, models.Library{
    ...
    Digest:   string(lib.Digest),
    ...
})
```

The contrib converter was the last hop that **received the Digest in its input but discarded it**. Any consumer that takes Vuls's ScanResult JSON via the `trivy-to-vuls` route (rather than the native LibraryScanner path) loses access to the hash.

## Why it matters

JAR SHA-1 has multiple downstream uses, all currently disabled for `trivy-to-vuls`-derived ScanResult JSON:

1. **Maven Central canonicalization** — `https://search.maven.org/solrsearch/select?q=1:<sha1>` deterministically resolves a SHA-1 to `(groupId, artifactId, version)`. Useful when an input PURL came in groupId-less from a different SBOM tool that the consumer is correlating against.
2. **Tamper detection** — comparing observed SHA-1 with the Maven Central record verifies the JAR hasn't been re-packaged.
3. **De-duplication / artifact identity** — same JAR bytes across hosts/images can be canonicalized.

The Vuls LibraryScanner path supports all of these because it preserves Digest. The `trivy-to-vuls` path silently doesn't.

## Fix

One field on the `models.Library` struct literal:

```go
libScanner.Libs = append(libScanner.Libs, models.Library{
    Name:     p.Name,
    Version:  p.Version,
    PURL:     getPURL(p),
    FilePath: p.FilePath,
+   Digest:   string(p.Digest),
    Dev:      p.Dev,
})
```

The vulnerability-derived `Library` construction at line 167-172 has no Digest source on `types.DetectedVulnerability` and is left unchanged; the `flatten and unique libraries` loop at line 277 deduplicates by `Name+Version`, so when the same library appears in both `Vulnerabilities` and `Packages`, the Package-derived entry (with Digest) wins.

## Test

New `TestConvert/JAR_digest_is_preserved_into_models.Library` exercises `ClassLangPkg` with a `log4j-core` package carrying a representative SHA-1 and asserts the digest flows through to the output `Library`.

`go test ./contrib/...` and `go vet ./contrib/...` pass.

## Compatibility

- No behavioral change for non-JAR scanners — Trivy doesn't set `Package.Digest` for npm/gem/pypi/etc., so `string("") == ""` and `Library.Digest` stays empty.
- No change for callers that don't read `Library.Digest` — the field already existed; this only populates it.

## Related

- Companion PR for the native LibraryScanner path bug: future-architect/vuls#2533 (`improveJARInfo` updates Name/Version but not PURL after SHA-1 canonicalization).
- Downstream tracking: vuls-saas/futurevuls-backend#1748 (consumes both Vuls ScanResult paths and SBOM-direct paths; needs DB columns and decoder logic to actually use the Digest).