### PR TITLE
fix(detector/vuls2): share opened db session across server requests

### DIFF
--- a/detector/vuls2/db.go
+++ b/detector/vuls2/db.go
@@ -3,6 +3,7 @@ package vuls2
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -24,7 +25,34 @@ var (
 	}()
 )
 
-func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, error) {
+var (
+	sessionMu     sync.Mutex
+	cachedSession *session.Session
+	cachedPath    string
+)
+
+// getSession returns a shared, opened vuls2 db session. The session is opened
+// lazily on the first call and reused by subsequent callers so that concurrent
+// users (e.g. `vuls server` handling parallel HTTP requests) do not repeatedly
+// invoke bolt.Open(), which would otherwise serialize on BoltDB's OS-level file
+// lock and cause severe latency under load.
+//
+// CloseSession should be called at process shutdown to release the file handle.
+func getSession(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Session, error) {
+	sessionMu.Lock()
+	defer sessionMu.Unlock()
+
+	if cachedSession != nil && cachedPath == vuls2Conf.Path {
+		return cachedSession, nil
+	}
+
+	if cachedSession != nil {
+		_ = cachedSession.Storage().Close()
+		cachedSession.Cache().Close()
+		cachedSession = nil
+		cachedPath = ""
+	}
+
 	willDownload, err := shouldDownload(vuls2Conf, time.Now())
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to check whether to download vuls2 db. err: %w", err)
@@ -38,40 +66,68 @@ func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, 
 	}
 
 	sesh, err := (&session.Config{
-		Type:    "boltdb",
-		Path:    vuls2Conf.Path,
-		Options: session.StorageOptions{BoltDB: &bolt.Options{ReadOnly: true}},
+		Type:      "boltdb",
+		Path:      vuls2Conf.Path,
+		Options:   session.StorageOptions{BoltDB: &bolt.Options{ReadOnly: true}},
+		WithCache: true,
 	}).New()
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to new vuls2 db connection. path: %s, err: %w", vuls2Conf.Path, err)
 	}
 
 	if err := sesh.Storage().Open(); err != nil {
+		sesh.Cache().Close()
 		return nil, xerrors.Errorf("Failed to open vuls2 db. path: %s, err: %w", vuls2Conf.Path, err)
 	}
-	defer sesh.Storage().Close()
 
 	metadata, err := sesh.Storage().GetMetadata()
 	if err != nil {
+		_ = sesh.Storage().Close()
+		sesh.Cache().Close()
 		return nil, xerrors.Errorf("Failed to get vuls2 db metadata. path: %s, err: %w", vuls2Conf.Path, err)
 	}
 	if metadata == nil {
+		_ = sesh.Storage().Close()
+		sesh.Cache().Close()
 		return nil, xerrors.Errorf("unexpected vuls2 db metadata. metadata: nil, path: %s", vuls2Conf.Path)
 	}
 	sv, err := session.SchemaVersion("boltdb")
 	if err != nil {
+		_ = sesh.Storage().Close()
+		sesh.Cache().Close()
 		return nil, xerrors.Errorf("Failed to get schema version. err: %w", err)
 	}
 	if metadata.SchemaVersion != sv {
-		return nil, xerrors.Errorf("vuls2 db schema version mismatch. expected: %d, actual: %d", session.SchemaVersion, metadata.SchemaVersion)
+		_ = sesh.Storage().Close()
+		sesh.Cache().Close()
+		return nil, xerrors.Errorf("vuls2 db schema version mismatch. expected: %d, actual: %d", sv, metadata.SchemaVersion)
 	}
 
-	return &session.Config{
-		Type:      "boltdb",
-		Path:      vuls2Conf.Path,
-		Options:   session.StorageOptions{BoltDB: &bolt.Options{ReadOnly: true}},
-		WithCache: true,
-	}, nil
+	cachedSession = sesh
+	cachedPath = vuls2Conf.Path
+	return sesh, nil
+}
+
+// CloseSession releases the cached vuls2 db session. Safe to call when no
+// session has ever been opened, and idempotent across repeated calls.
+// Intended to be deferred at process shutdown (e.g. `vuls server`).
+func CloseSession() error {
+	sessionMu.Lock()
+	defer sessionMu.Unlock()
+
+	if cachedSession == nil {
+		return nil
+	}
+	sesh := cachedSession
+	cachedSession = nil
+	cachedPath = ""
+
+	if err := sesh.Storage().Close(); err != nil {
+		sesh.Cache().Close()
+		return xerrors.Errorf("Failed to close vuls2 db storage. err: %w", err)
+	}
+	sesh.Cache().Close()
+	return nil
 }
 
 func shouldDownload(vuls2Conf config.Vuls2Conf, now time.Time) (bool, error) {

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -59,22 +59,10 @@ func Detect(r *models.ScanResult, vuls2Conf config.Vuls2Conf, noProgress bool) e
 		vuls2Conf.Path = DefaultPath
 	}
 
-	dbConfig, err := newDBConfig(vuls2Conf, noProgress)
+	sesh, err := getSession(vuls2Conf, noProgress)
 	if err != nil {
-		return xerrors.Errorf("Failed to get new db connection. err: %w", err)
+		return xerrors.Errorf("Failed to get vuls2 db session. err: %w", err)
 	}
-
-	sesh, err := dbConfig.New()
-	if err != nil {
-		return xerrors.Errorf("Failed to new db session. err: %w", err)
-	}
-
-	defer sesh.Cache().Close()
-
-	if err := sesh.Storage().Open(); err != nil {
-		return xerrors.Errorf("Failed to open db. err: %w", err)
-	}
-	defer sesh.Storage().Close()
 
 	metadata, err := sesh.Storage().GetMetadata()
 	if err != nil {
@@ -138,22 +126,10 @@ func EnrichVulnInfos(r *models.ScanResult, vuls2Conf config.Vuls2Conf, noProgres
 		vuls2Conf.Path = DefaultPath
 	}
 
-	dbConfig, err := newDBConfig(vuls2Conf, noProgress)
+	sesh, err := getSession(vuls2Conf, noProgress)
 	if err != nil {
-		return xerrors.Errorf("Failed to get new db connection. err: %w", err)
+		return xerrors.Errorf("Failed to get vuls2 db session. err: %w", err)
 	}
-
-	sesh, err := dbConfig.New()
-	if err != nil {
-		return xerrors.Errorf("Failed to new db session. err: %w", err)
-	}
-
-	defer sesh.Cache().Close()
-
-	if err := sesh.Storage().Open(); err != nil {
-		return xerrors.Errorf("Failed to open db. err: %w", err)
-	}
-	defer sesh.Storage().Close()
 
 	if err := enrich(sesh, r.ScannedCves); err != nil {
 		return xerrors.Errorf("Failed to enrich vulnerability data. err: %w", err)

--- a/subcmds/server.go
+++ b/subcmds/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/detector"
+	"github.com/future-architect/vuls/detector/vuls2"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/server"
 )
@@ -120,6 +121,11 @@ func (p *ServerCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...any) subcom
 		logging.Log.Errorf("Failed to validate DBs. err: %+v", err)
 		return subcommands.ExitFailure
 	}
+	defer func() {
+		if err := vuls2.CloseSession(); err != nil {
+			logging.Log.Errorf("Failed to close vuls2 db session. err: %+v", err)
+		}
+	}()
 
 	http.Handle("/vuls", server.VulsHandler{
 		ToLocalFile: p.toLocalFile,


### PR DESCRIPTION
## Summary
- Fixes #2542 — concurrent requests to `vuls server` with the vuls2 BoltDB backend hung for several minutes once concurrency reached ~4-5.
- Each HTTP request opened the BoltDB file up to four times (twice in `newDBConfig` validation, plus the caller's session in both `Detect` and `EnrichVulnInfos`). Every open acquires the OS-level file lock and rebuilds the `WithCache: true` session cache, so concurrent requests serialized against each other.
- Open the vuls2 db session lazily on first use, validate metadata once, and share the same opened session across subsequent callers. The cached session is released at server shutdown via the new `vuls2.CloseSession`.

## Why only vuls2
`go-cve-dictionary` and `gost` follow the same per-request open/close pattern, but their backends sidestep the cost (Redis / HTTP / SQLite3-with-WAL / RDBMS connection pools), so the issue does not manifest in practice. vuls2 is BoltDB-only and additionally re-initializes a `WithCache: true` cache per open, making the per-request pattern a real bottleneck — hence the targeted fix here.

When `cveDict`/`gost` are eventually folded into vuls2 (à la `go-msfdb` / `go-exploitdb`), the natural follow-up is to expose the session as an explicit argument and remove the package-level cache; today's internal `getSession` does not lock that direction in.

## Trade-offs / notes
- Long-running servers with `SkipUpdate = false` will hold the db opened at startup for the lifetime of the process. This matches today's effective behavior (the per-request opens still saw only the snapshot they validated against) and is consistent with the existing recommendation to use `SkipUpdate = true` in server mode.
- `CloseSession` is invoked from `subcmds/server.go` via `defer`. Process termination by signal will not run the defer, but the OS releases the BoltDB file lock on exit anyway — adding a signal handler is out of scope for this fix.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./detector/vuls2/... ./subcmds/... ./server/...`
- [x] `go test ./detector/vuls2/...`
- [ ] Manual: run `vuls server` against a real vuls2 db, fire concurrent requests (e.g. `seq 1 8 | xargs -P8 -I{} curl -X POST ...`) and confirm response time stays roughly linear in payload size rather than blowing up with concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)