### PR TITLE
feat(scanner): add pylock.toml detection (PEP 751)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: vulsio/integration
-        ref: 6dfd74510f5944e7c973e40d7844020d53dbb3a7
+        ref: 9b7a17582cd4f4521f71fe64757c7397a47a36c3
         path: integration
         persist-credentials: false
     - name: Set up Go 1.x

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -91,7 +91,7 @@ NOW=$(shell date '+%Y-%m-%dT%H-%M-%S%z')
 NOW_JSON_DIR := '${BASE_DIR}/$(NOW)'
 ONE_SEC_AFTER=$(shell date -d '+1 second' '+%Y-%m-%dT%H-%M-%S%z')
 ONE_SEC_AFTER_JSON_DIR := '${BASE_DIR}/$(ONE_SEC_AFTER)'
-LIBS := 'bundler' 'dart' 'elixir' 'pip' 'pipenv' 'poetry-v1' 'poetry-v2' 'uv' 'composer' 'composer-vendor-pear' 'composer-vendor-packagist' 'npm-v1' 'npm-v2' 'npm-v3' 'yarn' 'pnpm' 'pnpm-v9' 'bun' 'cargo' 'gomod' 'gosum' 'gobinary' 'jar' 'jar-wrong-name-log4j-core' 'war' 'pom' 'gradle' 'nuget-lock' 'nuget-config' 'dotnet-deps' 'dotnet-package-props' 'conan-v1' 'conan-v2' 'swift-cocoapods' 'swift-swift' 'rust-binary'
+LIBS := 'bundler' 'dart' 'elixir' 'pip' 'pipenv' 'poetry-v1' 'poetry-v2' 'pylock' 'uv' 'composer' 'composer-vendor-pear' 'composer-vendor-packagist' 'npm-v1' 'npm-v2' 'npm-v3' 'yarn' 'pnpm' 'pnpm-v9' 'bun' 'cargo' 'gomod' 'gosum' 'gobinary' 'jar' 'jar-wrong-name-log4j-core' 'war' 'pom' 'gradle' 'nuget-lock' 'nuget-config' 'dotnet-deps' 'dotnet-package-props' 'conan-v1' 'conan-v2' 'swift-cocoapods' 'swift-swift' 'rust-binary'
 
 diff:
 	# git clone git@github.com:vulsio/vulsctl.git

--- a/models/library.go
+++ b/models/library.go
@@ -68,7 +68,7 @@ var FindLockFiles = []string{
 	// php
 	ftypes.ComposerLock, ftypes.ComposerInstalledJson,
 	// python
-	ftypes.PipRequirements, ftypes.PipfileLock, ftypes.PoetryLock, ftypes.UvLock,
+	ftypes.PipRequirements, ftypes.PipfileLock, ftypes.PoetryLock, ftypes.PyLockFile, "pylock.*.toml", ftypes.UvLock,
 	// .net
 	ftypes.NuGetPkgsLock, ftypes.NuGetPkgsConfig, "*.deps.json", "*Packages.props",
 	// gomod
@@ -98,7 +98,7 @@ func (s LibraryScanner) GetLibraryKey() string {
 		return "node"
 	case ftypes.NuGet, ftypes.DotNetCore:
 		return ".net"
-	case ftypes.Pipenv, ftypes.Poetry, ftypes.Uv, ftypes.Pip, ftypes.PythonPkg:
+	case ftypes.Pip, ftypes.Pipenv, ftypes.Poetry, ftypes.PyLock, ftypes.PythonPkg, ftypes.Uv:
 		return "python"
 	case ftypes.Conan:
 		return "c"

--- a/scanner/analyze_golden_test.go
+++ b/scanner/analyze_golden_test.go
@@ -42,6 +42,7 @@ var lockfiles = []lockfileEntry{
 	{"Pipfile.lock", 0644, false},
 	{"poetry-v1/poetry.lock", 0644, false},
 	{"poetry-v2/poetry.lock", 0644, false},
+	{"pylock.toml", 0644, false},
 	{"uv.lock", 0644, false},
 
 	// Ruby

--- a/scanner/base.go
+++ b/scanner/base.go
@@ -41,6 +41,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/python/pip"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/python/pipenv"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/python/poetry"
+	"github.com/aquasecurity/trivy/pkg/dependency/parser/python/pylock"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/python/uv"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/ruby/bundler"
 	rustbinary "github.com/aquasecurity/trivy/pkg/dependency/parser/rust/binary"
@@ -779,6 +780,8 @@ func parseByType(ctx context.Context, pt parserType, filePath string, r xio.Read
 		return parseLockfile(ctx, ftypes.Pipenv, filePath, r, pipenv.NewParser())
 	case parserPoetry:
 		return parseLockfile(ctx, ftypes.Poetry, filePath, r, poetry.NewParser())
+	case parserPylock:
+		return parseLockfile(ctx, ftypes.PyLock, filePath, r, pylock.NewParser())
 	case parserUv:
 		return parseLockfile(ctx, ftypes.Uv, filePath, r, uv.NewParser())
 

--- a/scanner/dispatch.go
+++ b/scanner/dispatch.go
@@ -22,6 +22,7 @@ const (
 	parserPip            parserType = "pip"
 	parserPipenv         parserType = "pipenv"
 	parserPoetry         parserType = "poetry"
+	parserPylock         parserType = "pylock"
 	parserUv             parserType = "uv"
 	parserBundler        parserType = "bundler"
 	parserCargo          parserType = "cargo"
@@ -74,6 +75,8 @@ func detectParserType(filePath string, filemode os.FileMode) parserType {
 		return parserPipenv
 	case ftypes.PoetryLock: // poetry.lock
 		return parserPoetry
+	case ftypes.PyLockFile: // pylock.toml
+		return parserPylock
 	case ftypes.UvLock: // uv.lock
 		return parserUv
 
@@ -128,6 +131,12 @@ func detectParserType(filePath string, filemode os.FileMode) parserType {
 		return parserSwift
 	}
 
+	// PEP 751 named pylock variants (pylock.<identifier>.toml).
+	// The plain pylock.toml is handled by the exact-match switch above.
+	if isPylockNamedVariant(filepath.Base(filePath)) {
+		return parserPylock
+	}
+
 	// Suffix-based matches (case-insensitive for cross-platform compatibility)
 	lowerPath := strings.ToLower(filePath)
 	if strings.HasSuffix(lowerPath, ".deps.json") {
@@ -159,6 +168,21 @@ func detectParserType(filePath string, filemode os.FileMode) parserType {
 // containsDir checks if a filepath contains a specific directory component.
 func containsDir(filePath, dir string) bool {
 	return slices.Contains(strings.Split(filepath.ToSlash(filePath), "/"), dir)
+}
+
+// isPylockNamedVariant reports whether base is a PEP 751 named lockfile of the form
+// `pylock.<identifier>.toml`, where the identifier is non-empty and contains no dots.
+// The plain `pylock.toml` filename is not matched here; callers handle it separately.
+func isPylockNamedVariant(base string) bool {
+	identifier, ok := strings.CutPrefix(base, "pylock.")
+	if !ok {
+		return false
+	}
+	identifier, ok = strings.CutSuffix(identifier, ".toml")
+	if !ok {
+		return false
+	}
+	return identifier != "" && !strings.Contains(identifier, ".")
 }
 
 // isExecutable checks if the file is an executable binary.

--- a/scanner/dispatch_test.go
+++ b/scanner/dispatch_test.go
@@ -27,6 +27,14 @@ func TestDetectParserType(t *testing.T) {
 		{"Pipfile.lock", 0644, parserPipenv},
 		{"poetry.lock", 0644, parserPoetry},
 		{"uv.lock", 0644, parserUv},
+		{"pylock.toml", 0644, parserPylock},
+		{"app/pylock.toml", 0644, parserPylock},
+		{"pylock.uv.toml", 0644, parserPylock},    // PEP 751 named variant
+		{"pylock.dev.toml", 0644, parserPylock},   // PEP 751 named variant
+		{"pylock..toml", 0644, parserNone},        // empty identifier → invalid
+		{"pylock.foo.bar.toml", 0644, parserNone}, // identifier with a dot → invalid
+		{"my-pylock.toml", 0644, parserNone},      // no `pylock.` prefix → invalid
+		{"pylock.toml.bak", 0644, parserNone},     // wrong suffix → invalid
 
 		// === Ruby ===
 		{"Gemfile.lock", 0644, parserBundler},

--- a/scanner/testdata/golden/pylock.toml.json
+++ b/scanner/testdata/golden/pylock.toml.json
@@ -1,0 +1,153 @@
+[
+  {
+    "type": "pylock",
+    "lockfilePath": "pylock.toml",
+    "libs": [
+      {
+        "name": "alabaster",
+        "version": "1.0.0",
+        "purl": "pkg:pypi/alabaster@1.0.0"
+      },
+      {
+        "name": "babel",
+        "version": "2.18.0",
+        "purl": "pkg:pypi/babel@2.18.0"
+      },
+      {
+        "name": "blurb",
+        "version": "2.0.0",
+        "purl": "pkg:pypi/blurb@2.0.0"
+      },
+      {
+        "name": "certifi",
+        "version": "2026.4.22",
+        "purl": "pkg:pypi/certifi@2026.4.22"
+      },
+      {
+        "name": "charset-normalizer",
+        "version": "3.4.7",
+        "purl": "pkg:pypi/charset-normalizer@3.4.7"
+      },
+      {
+        "name": "colorama",
+        "version": "0.4.6",
+        "purl": "pkg:pypi/colorama@0.4.6"
+      },
+      {
+        "name": "docutils",
+        "version": "0.21.2",
+        "purl": "pkg:pypi/docutils@0.21.2"
+      },
+      {
+        "name": "idna",
+        "version": "3.13",
+        "purl": "pkg:pypi/idna@3.13"
+      },
+      {
+        "name": "imagesize",
+        "version": "1.5.0",
+        "purl": "pkg:pypi/imagesize@1.5.0"
+      },
+      {
+        "name": "jinja2",
+        "version": "3.1.4",
+        "purl": "pkg:pypi/jinja2@3.1.4"
+      },
+      {
+        "name": "linklint",
+        "version": "1.0.0",
+        "purl": "pkg:pypi/linklint@1.0.0"
+      },
+      {
+        "name": "markupsafe",
+        "version": "2.1.5",
+        "purl": "pkg:pypi/markupsafe@2.1.5"
+      },
+      {
+        "name": "packaging",
+        "version": "24.2",
+        "purl": "pkg:pypi/packaging@24.2"
+      },
+      {
+        "name": "pygments",
+        "version": "2.20.0",
+        "purl": "pkg:pypi/pygments@2.20.0"
+      },
+      {
+        "name": "python-docs-theme",
+        "version": "2026.4",
+        "purl": "pkg:pypi/python-docs-theme@2026.4"
+      },
+      {
+        "name": "requests",
+        "version": "2.31.0",
+        "purl": "pkg:pypi/requests@2.31.0"
+      },
+      {
+        "name": "roman-numerals",
+        "version": "4.1.0",
+        "purl": "pkg:pypi/roman-numerals@4.1.0"
+      },
+      {
+        "name": "roman-numerals-py",
+        "version": "4.1.0",
+        "purl": "pkg:pypi/roman-numerals-py@4.1.0"
+      },
+      {
+        "name": "snowballstemmer",
+        "version": "2.2.0",
+        "purl": "pkg:pypi/snowballstemmer@2.2.0"
+      },
+      {
+        "name": "sphinx",
+        "version": "8.2.3",
+        "purl": "pkg:pypi/sphinx@8.2.3"
+      },
+      {
+        "name": "sphinx-notfound-page",
+        "version": "1.0.4",
+        "purl": "pkg:pypi/sphinx-notfound-page@1.0.4"
+      },
+      {
+        "name": "sphinxcontrib-applehelp",
+        "version": "2.0.0",
+        "purl": "pkg:pypi/sphinxcontrib-applehelp@2.0.0"
+      },
+      {
+        "name": "sphinxcontrib-devhelp",
+        "version": "2.0.0",
+        "purl": "pkg:pypi/sphinxcontrib-devhelp@2.0.0"
+      },
+      {
+        "name": "sphinxcontrib-htmlhelp",
+        "version": "2.1.0",
+        "purl": "pkg:pypi/sphinxcontrib-htmlhelp@2.1.0"
+      },
+      {
+        "name": "sphinxcontrib-jsmath",
+        "version": "1.0.1",
+        "purl": "pkg:pypi/sphinxcontrib-jsmath@1.0.1"
+      },
+      {
+        "name": "sphinxcontrib-qthelp",
+        "version": "2.0.0",
+        "purl": "pkg:pypi/sphinxcontrib-qthelp@2.0.0"
+      },
+      {
+        "name": "sphinxcontrib-serializinghtml",
+        "version": "2.0.0",
+        "purl": "pkg:pypi/sphinxcontrib-serializinghtml@2.0.0"
+      },
+      {
+        "name": "sphinxext-opengraph",
+        "version": "0.13.0",
+        "purl": "pkg:pypi/sphinxext-opengraph@0.13.0"
+      },
+      {
+        "name": "urllib3",
+        "version": "2.2.1",
+        "purl": "pkg:pypi/urllib3@2.2.1"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

- Wire Trivy v0.70.0's pylock parser into the scanner dispatch so vuls can detect Python dependencies declared in PEP 751 `pylock.toml` files.
- Recognise both the canonical `pylock.toml` filename and the named variant `pylock.<identifier>.toml` (non-empty identifier, no dots), matching Trivy's fanal analyzer behaviour.
- Skip the `pyproject.toml`-driven direct/indirect relationship enrichment that Trivy's pylock PostAnalyzer performs, since vuls calls the dependency parsers directly and intentionally bypasses the fanal post-analyzer framework.
- Pin `requests`, `urllib3`, and `jinja2` in the integration pylock fixture to versions with published advisories so the end-to-end pipeline exercises real CVE detection through the new code path:
  - `requests` 2.31.0 — CVE-2024-35195 / GHSA-9wx4-h78v-vm56
  - `urllib3` 2.2.1 — CVE-2024-37891 / GHSA-34jh-p97f-mpxf
  - `jinja2` 3.1.4 — CVE-2024-56201 / GHSA-q2x7-8rv6-6q7h and CVE-2025-27516 / GHSA-cpwx-vrp4-4pq7

## Test plan

- [x] `go test ./scanner/...` passes. `TestDetectParserType` covers `pylock.toml`, a sub-path, the PEP 751 named variants `pylock.uv.toml` / `pylock.dev.toml`, and rejection of `pylock..toml`, `pylock.foo.bar.toml`, `my-pylock.toml`, and `pylock.toml.bak`.
- [x] `TestAnalyzeLibrary_Golden/pylock.toml` parses the integration fixture into 29 PyPI packages; golden output is checked in at `scanner/testdata/golden/pylock.toml.json`.
- [x] `make build` succeeds on the current branch.
- [ ] Integration tests: `int-config.toml` / `int-redis-config.toml` (in the bumped submodule) already include the `servers.pylock` pseudo-server; with the vulnerable pins above, the scan report should surface at least the four advisories listed in the Summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
