### PR TITLE
Set minimum TLS version for SMTP email client

### DIFF
--- a/reporter/email.go
+++ b/reporter/email.go
@@ -99,13 +99,18 @@ type emailSender struct {
 	conf config.SMTPConf
 }
 
+func newSMTPClientTLSConfig(emailConf config.SMTPConf) *tls.Config {
+	return &tls.Config{
+		ServerName:         emailConf.SMTPAddr,
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: emailConf.TLSInsecureSkipVerify,
+	}
+}
+
 func (e *emailSender) sendMail(smtpServerAddr, message string) (err error) {
 	var auth sasl.Client
 	emailConf := e.conf
-	tlsConfig := &tls.Config{
-		ServerName:         emailConf.SMTPAddr,
-		InsecureSkipVerify: emailConf.TLSInsecureSkipVerify,
-	}
+	tlsConfig := newSMTPClientTLSConfig(emailConf)
 
 	var c *smtp.Client
 	switch emailConf.TLSMode {

--- a/reporter/email_test.go
+++ b/reporter/email_test.go
@@ -1,0 +1,27 @@
+package reporter
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/future-architect/vuls/config"
+)
+
+func TestNewSMTPClientTLSConfigUsesModernMinimumTLSVersion(t *testing.T) {
+	conf := config.SMTPConf{
+		SMTPAddr:              "smtp.example.com",
+		TLSInsecureSkipVerify: true,
+	}
+
+	tlsConfig := newSMTPClientTLSConfig(conf)
+
+	if tlsConfig.ServerName != conf.SMTPAddr {
+		t.Fatalf("unexpected ServerName: got %q, want %q", tlsConfig.ServerName, conf.SMTPAddr)
+	}
+	if tlsConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("unexpected MinVersion: got %x, want %x", tlsConfig.MinVersion, tls.VersionTLS12)
+	}
+	if !tlsConfig.InsecureSkipVerify {
+		t.Fatal("expected configured TLSInsecureSkipVerify value to be preserved")
+	}
+}


### PR DESCRIPTION
## What

This hardens the SMTP email reporter TLS client configuration by setting `MinVersion: tls.VersionTLS12` while preserving the existing `tlsInsecureSkipVerify` option added for configurable compatibility.

This addresses the remaining TLS configuration concern in #1513: the SMTP reporter had an explicit `tls.Config`, but did not set a minimum protocol version.

## Validation

- `go test ./reporter`
- `git diff --check`

## Transparency

This PR was prepared with OpenAI/Codex assistance and manually reviewed before submission.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1513: Potentially bad TLS connection settings](https://oss.issuehunt.io/repos/54808920/issues/1513)
---
</details>
<!-- /Issuehunt content-->