### PR TITLE
fix(detector): sort previous JSON dirs in descending order for diff

### DIFF
--- a/detector/util.go
+++ b/detector/util.go
@@ -3,6 +3,7 @@
 package detector
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -235,7 +236,9 @@ func ListValidJSONDirs(resultsDir string) (dirs []string, err error) {
 			}
 		}
 	}
-	slices.Sort(dirs)
+	slices.SortFunc(dirs, func(a, b string) int {
+		return -cmp.Compare(a, b)
+	})
 	return
 }
 

--- a/detector/util_test.go
+++ b/detector/util_test.go
@@ -1,0 +1,63 @@
+//go:build !scanner
+
+package detector
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestListValidJSONDirs_SortedDescending(t *testing.T) {
+	root := t.TempDir()
+
+	names := []string{
+		"2026-04-24T08-22-31+0000",
+		"2026-04-25T08-27-25+0000",
+		"2026-04-25T17-52-14+0000",
+		"2026-04-25T18-20-55+0000",
+		"2026-04-25T19-48-34+0000",
+		"2026-04-27T13-02-05+0000",
+		"2026-04-28T12-56-45+0000",
+		"2026-04-29T12-57-26+0000",
+		"2026-04-30T12-57-38+0000",
+		"2026-05-01T12-57-29+0000",
+		"2026-05-01T15-17-13+0000",
+		"2026-05-01T15-33-21+0000",
+		"not-a-timestamp",
+	}
+	for _, n := range names {
+		if err := os.Mkdir(filepath.Join(root, n), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", n, err)
+		}
+	}
+
+	got, err := ListValidJSONDirs(root)
+	if err != nil {
+		t.Fatalf("ListValidJSONDirs: %v", err)
+	}
+
+	want := []string{
+		filepath.Join(root, "2026-05-01T15-33-21+0000"),
+		filepath.Join(root, "2026-05-01T15-17-13+0000"),
+		filepath.Join(root, "2026-05-01T12-57-29+0000"),
+		filepath.Join(root, "2026-04-30T12-57-38+0000"),
+		filepath.Join(root, "2026-04-29T12-57-26+0000"),
+		filepath.Join(root, "2026-04-28T12-56-45+0000"),
+		filepath.Join(root, "2026-04-27T13-02-05+0000"),
+		filepath.Join(root, "2026-04-25T19-48-34+0000"),
+		filepath.Join(root, "2026-04-25T18-20-55+0000"),
+		filepath.Join(root, "2026-04-25T17-52-14+0000"),
+		filepath.Join(root, "2026-04-25T08-27-25+0000"),
+		filepath.Join(root, "2026-04-24T08-22-31+0000"),
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("len(got)=%d want=%d\ngot=%v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("dirs[%d] = %s, want %s", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [#2536](https://github.com/future-architect/vuls/discussions/2536) — `report --diff-plus` keeps re-sending the same unfixed alerts because it compares the current scan against an ancient one (the second-oldest result dir) instead of the most recent previous scan.

## Root cause

`detector.ListValidJSONDirs` sorts ascending, so `dirs[0]` is the **oldest** dir. `loadPrevious` then iterates `dirs[1:]` and breaks on the first matching JSON, which makes it pick the **second-oldest** as "previous". The function's own doc comment says the opposite ("recent directories are at the head"), and the sibling `reporter.ListValidJSONDirs` sorts descending.

This is a regression from #2415 (Go 1.26 bump), where the original

```go
sort.Slice(dirs, func(i, j int) bool { return dirs[j] < dirs[i] })  // descending
```

was modernized to

```go
slices.Sort(dirs)  // ascending — wrong direction
```

## Fix

Match `reporter/util.go`'s descending sort:

```go
slices.SortFunc(dirs, func(a, b string) int {
    return -cmp.Compare(a, b)
})
```

## Verification — before / after

Added `TestListValidJSONDirs_SortedDescending` that recreates the directory list from the discussion and asserts `dirs[0]` is the newest. Running the same test against master vs. this branch:

**Before (on master, broken sort):**

```
=== RUN   TestListValidJSONDirs_SortedDescending
    util_test.go:60: dirs[0] = .../2026-04-24T08-22-31+0000, want .../2026-05-01T15-33-21+0000
    util_test.go:60: dirs[1] = .../2026-04-25T08-27-25+0000, want .../2026-05-01T15-17-13+0000
    util_test.go:60: dirs[2] = .../2026-04-25T17-52-14+0000, want .../2026-05-01T12-57-29+0000
    ... (every position wrong, fully reversed)
    util_test.go:60: dirs[11] = .../2026-05-01T15-33-21+0000, want .../2026-04-24T08-22-31+0000
--- FAIL: TestListValidJSONDirs_SortedDescending (0.01s)
FAIL    github.com/future-architect/vuls/detector
```

Note that `dirs[1] = 2026-04-25T08-27-25+0000` — **exactly** the path the discussion reporter saw in `Previous json found: ...`.

**After (this branch):**

```
=== RUN   TestListValidJSONDirs_SortedDescending
--- PASS: TestListValidJSONDirs_SortedDescending (0.00s)
PASS
ok      github.com/future-architect/vuls/detector       0.032s
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./detector/ -run TestListValidJSONDirs_SortedDescending -v` — PASS on this branch, FAIL on master (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## References
- https://github.com/future-architect/vuls/pull/2425