### PR TITLE
feat(scanner): support disablerepo option for yum/dnf

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -243,9 +243,10 @@ type ServerInfo struct {
 	IgnorePkgsRegexp   []string                    `toml:"ignorePkgsRegexp,omitempty" json:"ignorePkgsRegexp,omitempty"`
 	UUIDs              map[string]string           `toml:"uuids,omitempty" json:"uuids,omitempty"`
 	Memo               string                      `toml:"memo,omitempty" json:"memo,omitempty"`
-	Enablerepo         []string                    `toml:"enablerepo,omitempty" json:"enablerepo,omitempty"` // For CentOS, Alma, Rocky, RHEL, Amazon
-	Optional           map[string]any              `toml:"optional,omitempty" json:"optional,omitempty"`     // Optional key-value set that will be outputted to JSON
-	Lockfiles          []string                    `toml:"lockfiles,omitempty" json:"lockfiles,omitempty"`   // ie) path/to/package-lock.json
+	Enablerepo         []string                    `toml:"enablerepo,omitempty" json:"enablerepo,omitempty"`   // For CentOS, Alma, Rocky, RHEL, Amazon, Fedora
+	Disablerepo        []string                    `toml:"disablerepo,omitempty" json:"disablerepo,omitempty"` // For CentOS, Alma, Rocky, RHEL, Amazon, Fedora
+	Optional           map[string]any              `toml:"optional,omitempty" json:"optional,omitempty"`       // Optional key-value set that will be outputted to JSON
+	Lockfiles          []string                    `toml:"lockfiles,omitempty" json:"lockfiles,omitempty"`     // ie) path/to/package-lock.json
 	FindLock           bool                        `toml:"findLock,omitempty" json:"findLock,omitempty"`
 	FindLockDirs       []string                    `toml:"findLockDirs,omitempty" json:"findLockDirs,omitempty"`
 	Type               string                      `toml:"type,omitempty" json:"type,omitempty"` // "pseudo" or ""

--- a/config/tomlloader.go
+++ b/config/tomlloader.go
@@ -124,6 +124,10 @@ func (c TOMLLoader) Load(pathToToml string) error {
 			}
 		}
 
+		if len(server.Disablerepo) == 0 {
+			server.Disablerepo = Conf.Default.Disablerepo
+		}
+
 		if server.PortScan.ScannerBinPath != "" {
 			server.PortScan.IsUseExternalScanner = true
 		}

--- a/saas/uuid.go
+++ b/saas/uuid.go
@@ -191,6 +191,10 @@ func cleanForTOMLEncoding(server config.ServerInfo, def config.ServerInfo) confi
 		server.Enablerepo = nil
 	}
 
+	if reflect.DeepEqual(server.Disablerepo, def.Disablerepo) {
+		server.Disablerepo = nil
+	}
+
 	for k, v := range def.Optional {
 		if vv, ok := server.Optional[k]; ok && v == vv {
 			delete(server.Optional, k)

--- a/scanner/redhatbase.go
+++ b/scanner/redhatbase.go
@@ -788,6 +788,9 @@ func (o *redhatBase) scanUpdatablePackages() (models.Packages, error) {
 	for _, repo := range o.getServerInfo().Enablerepo {
 		cmd += " --enablerepo=" + repo
 	}
+	for _, repo := range o.getServerInfo().Disablerepo {
+		cmd += " --disablerepo=" + repo
+	}
 
 	r := o.exec(util.PrependProxyEnv(cmd), o.sudo.repoquery())
 	if !r.isSuccess() {

--- a/subcmds/discover.go
+++ b/subcmds/discover.go
@@ -205,6 +205,8 @@ func printConfigToml(ips []string) (err error) {
 #containerType      = "docker" #or "lxd" or "lxc" default: docker
 #containersIncluded = ["${running}"]
 #containersExcluded = ["container_name_a"]
+#enablerepo         = ["base", "updates"] # For RHEL-family. Currently only "base" and "updates" are allowed
+#disablerepo        = ["epel"] # For RHEL-family
 
 # https://vuls.io/docs/en/config.toml.html#servers-section
 [servers]
@@ -231,6 +233,8 @@ host                = "{{$ip}}"
 #containerType      = "docker" #or "lxd" or "lxc" default: docker
 #containersIncluded = ["${running}"]
 #containersExcluded = ["container_name_a"]
+#enablerepo         = ["base", "updates"] # For RHEL-family. Currently only "base" and "updates" are allowed
+#disablerepo        = ["epel"] # For RHEL-family
 #confidenceScoreOver = 80
 
 #[servers.{{index $names $i}}.containers.container_name_a]


### PR DESCRIPTION
## Summary
- Add `Disablerepo []string` config field, mirroring the existing `Enablerepo`, so users can pass `--disablerepo=<repo>` to `repoquery` on RHEL-family hosts (CentOS, Alma, Rocky, RHEL, Amazon, Fedora).
- Useful for excluding third-party repos (e.g. EPEL, internal mirrors) from updatable package scans without having to disable them globally on the host.
- Also adds `enablerepo` / `disablerepo` sample lines to the `discover` subcommand's `config.toml` template.

The existing `Enablerepo` `base`/`updates`-only restriction is left intact to keep this change minimal; lifting it can be a follow-up.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] On a RHEL-family host, set `disablerepo = ["epel"]` and confirm `repoquery` is invoked with `--disablerepo=epel`
- [x] `vuls discover` outputs the new sample lines in the generated `config.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)