### PR TITLE
fix(detector/vuls2): normalize Amazon Linux release in preConvert

### DIFF
--- a/detector/vuls2/vendor.go
+++ b/detector/vuls2/vendor.go
@@ -69,6 +69,23 @@ func toVuls2Family(vuls0Family, vuls0Release string) string {
 
 func toVuls2Release(vuls0Family, vuls0Release string) string {
 	switch vuls0Family {
+	case constant.Amazon:
+		// Normalize to the Amazon Linux major version ("1", "2", "2022", "2023", ...).
+		// Older vuls scanners stored releases with a codename suffix (e.g. "2 (Karoo)",
+		// "2022 (Amazon Linux)") and Amazon Linux 1 was stored as its date-style version
+		// (e.g. "2017.09", "2018.03"). The new scanner can also produce patch-suffixed
+		// values like "2023.3.20240312". Reducing all of these to the major version here
+		// keeps scanTypes.ScanResult.Release canonical and avoids surprises like
+		// "amazon:2 (Karoo)" or "amazon:2018" appearing in the downstream ecosystem.
+		fields := strings.Fields(vuls0Release)
+		if len(fields) == 0 {
+			return vuls0Release
+		}
+		s := fields[0]
+		if _, err := time.Parse("2006.01", s); err == nil {
+			return "1"
+		}
+		return strings.Split(s, ".")[0]
 	case constant.OpenSUSE:
 		switch vuls0Release {
 		case "tumbleweed":

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -270,6 +270,201 @@ func Test_preConvert(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "amazon linux 2, old scanner with codename suffix",
+			args: args{
+				sr: &models.ScanResult{
+					ServerName: "al2",
+					Family:     "amazon",
+					Release:    "2 (Karoo)",
+					RunningKernel: models.Kernel{
+						Release: "5.10.0-amzn2.x86_64",
+					},
+					Packages: models.Packages{
+						"zlib": models.Package{
+							Name:    "zlib",
+							Version: "1.2.7",
+							Release: "19.amzn2.0.3",
+							Arch:    "x86_64",
+						},
+					},
+				},
+			},
+			want: scanTypes.ScanResult{
+				JSONVersion: 0,
+				ServerName:  "al2",
+				Family:      ecosystemTypes.Ecosystem("amazon"),
+				Release:     "2",
+
+				Kernel: scanTypes.Kernel{
+					Release: "5.10.0-amzn2.x86_64",
+				},
+				OSPackages: []scanTypes.OSPackage{
+					{
+						Name:    "zlib",
+						Version: "1.2.7",
+						Release: "19.amzn2.0.3",
+						Arch:    "x86_64",
+					},
+				},
+			},
+		},
+		{
+			name: "amazon linux 2022, old scanner with codename suffix",
+			args: args{
+				sr: &models.ScanResult{
+					ServerName: "al2022",
+					Family:     "amazon",
+					Release:    "2022 (Amazon Linux)",
+					RunningKernel: models.Kernel{
+						Release: "5.15.0-amzn2022.x86_64",
+					},
+					Packages: models.Packages{
+						"zlib": models.Package{
+							Name:    "zlib",
+							Version: "1.2.11",
+							Release: "31.amzn2022.0.3",
+							Arch:    "x86_64",
+						},
+					},
+				},
+			},
+			want: scanTypes.ScanResult{
+				JSONVersion: 0,
+				ServerName:  "al2022",
+				Family:      ecosystemTypes.Ecosystem("amazon"),
+				Release:     "2022",
+
+				Kernel: scanTypes.Kernel{
+					Release: "5.15.0-amzn2022.x86_64",
+				},
+				OSPackages: []scanTypes.OSPackage{
+					{
+						Name:    "zlib",
+						Version: "1.2.11",
+						Release: "31.amzn2022.0.3",
+						Arch:    "x86_64",
+					},
+				},
+			},
+		},
+		{
+			name: "amazon linux 2023, new scanner",
+			args: args{
+				sr: &models.ScanResult{
+					ServerName: "al2023",
+					Family:     "amazon",
+					Release:    "2023.3.20240312",
+					RunningKernel: models.Kernel{
+						Release: "6.1.0-amzn2023.x86_64",
+					},
+					Packages: models.Packages{
+						"zlib": models.Package{
+							Name:    "zlib",
+							Version: "1.2.13",
+							Release: "1.amzn2023.0.1",
+							Arch:    "x86_64",
+						},
+					},
+				},
+			},
+			want: scanTypes.ScanResult{
+				JSONVersion: 0,
+				ServerName:  "al2023",
+				Family:      ecosystemTypes.Ecosystem("amazon"),
+				Release:     "2023",
+
+				Kernel: scanTypes.Kernel{
+					Release: "6.1.0-amzn2023.x86_64",
+				},
+				OSPackages: []scanTypes.OSPackage{
+					{
+						Name:    "zlib",
+						Version: "1.2.13",
+						Release: "1.amzn2023.0.1",
+						Arch:    "x86_64",
+					},
+				},
+			},
+		},
+		{
+			name: "amazon linux 1, old scanner with date-style release",
+			args: args{
+				sr: &models.ScanResult{
+					ServerName: "al1",
+					Family:     "amazon",
+					Release:    "2018.03",
+					RunningKernel: models.Kernel{
+						Release: "4.14.0-amzn1.x86_64",
+					},
+					Packages: models.Packages{
+						"zlib": models.Package{
+							Name:    "zlib",
+							Version: "1.2.8",
+							Release: "10.32.amzn1",
+							Arch:    "x86_64",
+						},
+					},
+				},
+			},
+			want: scanTypes.ScanResult{
+				JSONVersion: 0,
+				ServerName:  "al1",
+				Family:      ecosystemTypes.Ecosystem("amazon"),
+				Release:     "1",
+
+				Kernel: scanTypes.Kernel{
+					Release: "4.14.0-amzn1.x86_64",
+				},
+				OSPackages: []scanTypes.OSPackage{
+					{
+						Name:    "zlib",
+						Version: "1.2.8",
+						Release: "10.32.amzn1",
+						Arch:    "x86_64",
+					},
+				},
+			},
+		},
+		{
+			name: "amazon linux 2, new scanner",
+			args: args{
+				sr: &models.ScanResult{
+					ServerName: "al2",
+					Family:     "amazon",
+					Release:    "2",
+					RunningKernel: models.Kernel{
+						Release: "5.10.0-amzn2.x86_64",
+					},
+					Packages: models.Packages{
+						"zlib": models.Package{
+							Name:    "zlib",
+							Version: "1.2.7",
+							Release: "19.amzn2.0.3",
+							Arch:    "x86_64",
+						},
+					},
+				},
+			},
+			want: scanTypes.ScanResult{
+				JSONVersion: 0,
+				ServerName:  "al2",
+				Family:      ecosystemTypes.Ecosystem("amazon"),
+				Release:     "2",
+
+				Kernel: scanTypes.Kernel{
+					Release: "5.10.0-amzn2.x86_64",
+				},
+				OSPackages: []scanTypes.OSPackage{
+					{
+						Name:    "zlib",
+						Version: "1.2.7",
+						Release: "19.amzn2.0.3",
+						Arch:    "x86_64",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Older vuls scanners stored Amazon Linux releases with a codename suffix (e.g. `2 (Karoo)`, `2022 (Amazon Linux)`) and Amazon Linux 1 as a date-style version (e.g. `2018.03`). When such legacy JSON was fed back through `report`, `preConvert` passed the release through unchanged, so the downstream vuls2 ecosystem became e.g. `amazon:2 (Karoo)` or `amazon:2018` and failed to match the DB (`amazon:2`, `amazon:1`).
- `toVuls2Release` for `constant.Amazon` now normalizes to the canonical major version: strip the codename suffix via `strings.Fields(release)[0]`, return `"1"` for YYYY.MM date-style values (AL1), and otherwise reduce to the major component via `strings.Split(s, ".")[0]`. Matches the existing `config.getAmazonLinuxVersion` / `scanner/amazon.go` patterns.
- Resulting `scanTypes.ScanResult.Release` after preConvert:
  - `"2 (Karoo)"` → `"2"`
  - `"2022 (Amazon Linux)"` → `"2022"`
  - `"2023.3.20240312"` (new scanner) → `"2023"`
  - `"2018.03"` / `"2017.09"` → `"1"`
  - `"2"`, `"2022"`, `"2023"` (new scanner) → unchanged

## Test plan
- [x] `go test ./detector/vuls2/...`
- [x] `go vet ./...`
- [x] Added `Test_preConvert` cases for AL2/AL2022 (old codename suffix), AL2023 (new scanner with patch), AL1 (date-style), AL2 (new scanner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)