### PR TITLE
test(detector/vuls2): rename enrich fixture mitre-v5 to mitre-cve-v5

### DIFF
--- a/detector/vuls2/testdata/fixtures/enrich/mitre-cve-v5/data/CVE-2023-44487.json
+++ b/detector/vuls2/testdata/fixtures/enrich/mitre-cve-v5/data/CVE-2023-44487.json
@@ -28,7 +28,7 @@
 		}
 	],
 	"data_source": {
-		"id": "mitre-v5",
+		"id": "mitre-cve-v5",
 		"raws": [
 			"fixtures/CVE-2023-44487.json"
 		]

--- a/detector/vuls2/testdata/fixtures/enrich/mitre-cve-v5/data/CVE-2024-1102.json
+++ b/detector/vuls2/testdata/fixtures/enrich/mitre-cve-v5/data/CVE-2024-1102.json
@@ -4,13 +4,13 @@
 		{
 			"content": {
 				"id": "CVE-2024-1102",
-				"title": "jberet: jberet-core logging database credentials (from mitre-v5)",
+				"title": "jberet: jberet-core logging database credentials (from mitre-cve-v5)",
 				"description": "This data should be filtered out by the DataSources filter and never reach enrichVulnerabilities."
 			}
 		}
 	],
 	"data_source": {
-		"id": "mitre-v5",
+		"id": "mitre-cve-v5",
 		"raws": [
 			"fixtures/CVE-2024-1102.json"
 		]

--- a/detector/vuls2/testdata/fixtures/enrich/mitre-cve-v5/datasource.json
+++ b/detector/vuls2/testdata/fixtures/enrich/mitre-cve-v5/datasource.json
@@ -1,4 +1,4 @@
 {
-	"id": "mitre-v5",
+	"id": "mitre-cve-v5",
 	"name": "MITRE CVE v5"
 }


### PR DESCRIPTION
## What
Rename the enrich test fixture's MITRE CVE v5 data source id (and its directory) from `mitre-v5` to `mitre-cve-v5`, following the upstream rename in `vuls-data-update` (MaineK00n/vuls-data-update#846, now merged) and the matching pipeline change in vulsio/vuls-data-db#170.

- `detector/vuls2/testdata/fixtures/enrich/mitre-v5/` → `.../mitre-cve-v5/` (`git mv`, history preserved)
- `datasource.json` id, the two `data/**` ids, and the `(from mitre-v5)` title string updated to `mitre-cve-v5`

## Why
The source id `mitre-v5` was renamed to `mitre-cve-v5` upstream. This fixture is the *"datasource not in enrich filter is filtered out"* case in `Test_enrich`, so behavior is unchanged — this is a consistency fix only (no production code references the literal).

## Testing
`GOEXPERIMENT=jsonv2 go test ./detector/vuls2/ -run Test_enrich` passes (run with `GOWORK=off` to use pinned deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)