### PR TITLE
fix(detector): remove old vuls2 db before fetching to avoid doubling disk usage

### DIFF
--- a/detector/vuls2/db.go
+++ b/detector/vuls2/db.go
@@ -22,6 +22,10 @@ var (
 		wd, _ := os.Getwd()
 		return filepath.Join(wd, "vuls.db")
 	}()
+
+	// fetchDB fetches the vuls2 db into the configured path. It is a package-level
+	// variable so that tests can replace the network fetch with a stub.
+	fetchDB = fetch.Fetch
 )
 
 func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, error) {
@@ -42,7 +46,7 @@ func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, 
 			return nil, xerrors.Errorf("Failed to remove old vuls2 db before fetching. path: %s, err: %w", vuls2Conf.Path, err)
 		}
 		logging.Log.Infof("Fetching vuls2 db. repository: %s", vuls2Conf.Repository)
-		if err := fetch.Fetch(fetch.WithRepository(vuls2Conf.Repository), fetch.WithDBPath(vuls2Conf.Path), fetch.WithNoProgress(noProgress)); err != nil {
+		if err := fetchDB(fetch.WithRepository(vuls2Conf.Repository), fetch.WithDBPath(vuls2Conf.Path), fetch.WithNoProgress(noProgress)); err != nil {
 			return nil, xerrors.Errorf("Failed to fetch vuls2 db. err: %w", err)
 		}
 	}

--- a/detector/vuls2/db.go
+++ b/detector/vuls2/db.go
@@ -31,6 +31,16 @@ func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, 
 	}
 
 	if willDownload {
+		// Remove the existing db before fetching. fetch.Fetch downloads into a temp
+		// file alongside vuls2Conf.Path and renames it over the old db at the end, so
+		// keeping the old db around would temporarily double the disk usage. The old
+		// db is never reused on this path: shouldDownload has already read its metadata
+		// above, and if the fetch fails vuls2.Detect fails without reading the db while
+		// the next run re-downloads (the db is now absent, and even if it remained its
+		// metadata is unchanged so shouldDownload stays true).
+		if err := os.Remove(vuls2Conf.Path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, xerrors.Errorf("Failed to remove old vuls2 db before fetching. path: %s, err: %w", vuls2Conf.Path, err)
+		}
 		logging.Log.Infof("Fetching vuls2 db. repository: %s", vuls2Conf.Repository)
 		if err := fetch.Fetch(fetch.WithRepository(vuls2Conf.Repository), fetch.WithDBPath(vuls2Conf.Path), fetch.WithNoProgress(noProgress)); err != nil {
 			return nil, xerrors.Errorf("Failed to fetch vuls2 db. err: %w", err)

--- a/detector/vuls2/db_test.go
+++ b/detector/vuls2/db_test.go
@@ -1,6 +1,8 @@
 package vuls2_test
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -8,6 +10,7 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/MaineK00n/vuls2/pkg/db/fetch"
 	"github.com/MaineK00n/vuls2/pkg/db/session"
 	"github.com/MaineK00n/vuls2/pkg/db/session/types"
 	"github.com/future-architect/vuls/config"
@@ -148,6 +151,46 @@ func Test_shouldDownload(t *testing.T) {
 		})
 	}
 
+}
+
+func Test_newDBConfig_removesOldDBBeforeFetch(t *testing.T) {
+	d := t.TempDir()
+	path := filepath.Join(d, "vuls.db")
+
+	// Pre-create a stale db so that shouldDownload returns true (willDownload).
+	if err := putMetadata(types.Metadata{
+		LastModified:  *parse("2024-01-02T00:00:00Z"),
+		Downloaded:    parse("2024-01-02T00:00:00Z"),
+		SchemaVersion: schemaVersionBoltDB(t),
+	}, path); err != nil {
+		t.Fatalf("putMetadata (old db) err = %v", err)
+	}
+
+	var called, removedBeforeFetch bool
+	restore := vuls2.SetFetchDB(func(_ ...fetch.Option) error {
+		called = true
+		// The old db must already be gone by the time fetch runs.
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			removedBeforeFetch = true
+		}
+		// Simulate a successful fetch by writing a fresh, valid db at the path.
+		return putMetadata(types.Metadata{
+			LastModified:  *parse("2024-01-02T00:00:00Z"),
+			Downloaded:    parse("2024-01-02T00:00:00Z"),
+			SchemaVersion: schemaVersionBoltDB(t),
+		}, path)
+	})
+	defer restore()
+
+	if _, err := vuls2.NewDBConfig(config.Vuls2Conf{Path: path}, true); err != nil {
+		t.Fatalf("NewDBConfig() err = %v", err)
+	}
+	if !called {
+		t.Fatal("fetchDB was not called")
+	}
+	if !removedBeforeFetch {
+		t.Error("old db was not removed before fetch")
+	}
 }
 
 func putMetadata(metadata types.Metadata, path string) error {

--- a/detector/vuls2/db_test.go
+++ b/detector/vuls2/db_test.go
@@ -158,9 +158,11 @@ func Test_newDBConfig_removesOldDBBeforeFetch(t *testing.T) {
 	path := filepath.Join(d, "vuls.db")
 
 	// Pre-create a stale db so that shouldDownload returns true (willDownload).
+	// Use a time relative to now since newDBConfig compares against time.Now().
+	stale := time.Now().Add(-8 * time.Hour)
 	if err := putMetadata(types.Metadata{
-		LastModified:  *parse("2024-01-02T00:00:00Z"),
-		Downloaded:    parse("2024-01-02T00:00:00Z"),
+		LastModified:  stale,
+		Downloaded:    &stale,
 		SchemaVersion: schemaVersionBoltDB(t),
 	}, path); err != nil {
 		t.Fatalf("putMetadata (old db) err = %v", err)
@@ -174,9 +176,10 @@ func Test_newDBConfig_removesOldDBBeforeFetch(t *testing.T) {
 			removedBeforeFetch = true
 		}
 		// Simulate a successful fetch by writing a fresh, valid db at the path.
+		fresh := time.Now()
 		return putMetadata(types.Metadata{
-			LastModified:  *parse("2024-01-02T00:00:00Z"),
-			Downloaded:    parse("2024-01-02T00:00:00Z"),
+			LastModified:  fresh,
+			Downloaded:    &fresh,
 			SchemaVersion: schemaVersionBoltDB(t),
 		}, path)
 	})

--- a/detector/vuls2/export_test.go
+++ b/detector/vuls2/export_test.go
@@ -1,7 +1,10 @@
 package vuls2
 
+import "github.com/MaineK00n/vuls2/pkg/db/fetch"
+
 var (
 	ShouldDownload = shouldDownload
+	NewDBConfig    = newDBConfig
 
 	PreConvert    = preConvert
 	PostConvert   = postConvert
@@ -10,3 +13,11 @@ var (
 )
 
 type Source source
+
+// SetFetchDB replaces the package-level db fetch function with f and returns a
+// function that restores the original.
+func SetFetchDB(f func(...fetch.Option) error) func() {
+	orig := fetchDB
+	fetchDB = f
+	return func() { fetchDB = orig }
+}


### PR DESCRIPTION
## What

When the vuls2 db needs updating, `fetch.Fetch` downloads the new db into a temp file alongside the existing db and `os.Rename`s it over the old one at the end. During the download the old db and the temp file coexist, temporarily doubling disk usage. This removes the old db right before fetching so the peak stays at roughly one db.

## Why this is safe

On the download path (`willDownload == true`) the old db is never reused:

- `shouldDownload` has already read the old db's metadata *before* the fetch, so the deletion does not affect the download decision.
- If the fetch fails, `newDBConfig` returns the error and `vuls2.Detect` / `EnrichVulnInfos` fail without ever reading the db — there is no fallback to the stale db on this path.
- The next run re-downloads regardless: the db is now absent, and even if it had remained, its metadata is unchanged (the `Downloaded` timestamp is only updated on the temp db just before the successful rename), so `shouldDownload` stays `true` until a fetch succeeds.

`os.Remove` tolerates `os.ErrNotExist` to keep the first-download case (no existing db) working.

## Note

This slightly changes behavior across runs that toggle `SkipUpdate`: previously a failed fetch left a stale db that a later `SkipUpdate: true` run would reuse; now that run errors with "not found, cannot skip update". The deletion only ever runs under `SkipUpdate: false`, and surfacing a clear error is preferable to silently detecting against stale data.

## Test

`go build` / `go vet` / `go test ./detector/vuls2/` all pass.

## Manual test (`vuls report`)

Ran `vuls report` against a real scan result (`integration/data/results/rhel_90.json`, redhat 9.0) with a minimal `[vuls2] path=...` config. The actual nightly vuls2 db is **~6.5 GB**, so the old+temp coexistence would peak at ~13 GB without this change.

> Note: `vuls report` overwrites the scan-result JSON with detected CVEs, so re-runs hit "No need to refresh" and skip detection. Tests 2/3 use `-refresh-cve` to force `vuls2.Detect` to actually run and reach the db-update logic.

| # | Scenario | Result |
|---|----------|--------|
| 1 | **db file absent** | Downloads the db (6.5 GB created), report completes (exit 0, CVE list printed). |
| 2 | **db present, not stale** | No `Fetching vuls2 db` log → no download; detection runs (`7126 CVEs are detected with vuls2`), exit 0; db inode/size/mtime unchanged. |
| 3 | **db present, stale** | `Fetching vuls2 db` logged → db updated (~2m41s); detection runs (7126 CVEs), exit 0; metadata refreshed (`Downloaded` and `LastModified` updated to the new download). |

For test 3, a 0.5 s-interval watcher over the db directory (823 samples) confirmed the core behavior of this change:

- The old db is removed at the start of the update and stays **absent** until completion (628/823 samples), while the temp file (`vuls2.db.<rand>`) grows from 43 MB → 6.5 GB.
- Example sample mid-update: `main=ABSENT tmp=[vuls2.db.3222269602(6938046464)]` — old db gone, temp present.
- **Samples with both the old db present AND a temp file: 0** → the two 6.5 GB copies never coexist; peak disk stays at ~6.5 GB instead of ~13 GB.
- After completion the temp is renamed into place and no temp file is left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
