### PR TITLE
perf(detector): derive verified-product suppression from the detection result

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,7 +41,6 @@ updates:
         patterns:
           - "github.com/MaineK00n/vuls-data-update"
           - "github.com/MaineK00n/vuls2"
-          - "github.com/vulsio/go-cve-dictionary"
       trivy:
         patterns:
           - "github.com/aquasecurity/trivy"
@@ -53,7 +52,6 @@ updates:
         exclude-patterns:
           - "github.com/MaineK00n/vuls-data-update"
           - "github.com/MaineK00n/vuls2"
-          - "github.com/vulsio/go-cve-dictionary"
           - "github.com/aquasecurity/trivy"
           - "github.com/aquasecurity/trivy-db"
           - "github.com/aquasecurity/trivy-java-db"

--- a/detector/vuls2/export_test.go
+++ b/detector/vuls2/export_test.go
@@ -12,6 +12,8 @@ var (
 
 	WalkCPECriteria      = walkCPECriteria
 	MergeIntoScannedCves = mergeIntoScannedCves
+
+	CollectVerifiedProducts = collectVerifiedProducts
 )
 
 type Source source

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -131,12 +131,7 @@ func detectWith(r *models.ScanResult, vuls2Scanned scanTypes.ScanResult, fsToOri
 		return xerrors.Errorf("Failed to detect. err: %w", err)
 	}
 
-	// Defined-product sets for the verified sources, derived from the detection
-	// result for CVEs detected via a suppressed CPE source (VulnCheck / JVN).
-	// Drives the suppression in walkCPECriteria.
-	verifiedProductsByRoot := collectVerifiedProducts(vuls2Detected)
-
-	vulnInfos, err := postConvert(vuls2Scanned, vuls2Detected, fsToOriginalCPE, noJVNCPEs, verifiedProductsByRoot)
+	vulnInfos, err := postConvert(vuls2Scanned, vuls2Detected, fsToOriginalCPE, noJVNCPEs)
 	if err != nil {
 		return xerrors.Errorf("Failed to post convert. err: %w", err)
 	}
@@ -637,10 +632,13 @@ func appendMissing(dst, src []string) []string {
 // VulnInfo.CpeURIs so the report shows the user-supplied CPE rather than
 // the internal FS-with-wildcards form. Nil / missing keys fall back to
 // the FS string as-is.
-func postConvert(scanned scanTypes.ScanResult, detected detectTypes.DetectResult, fsToOriginalCPE map[string][]string, noJVNCPEs map[string]struct{}, verifiedProductsByRoot map[dataTypes.RootID]map[string]map[string]struct{}) (models.VulnInfos, error) {
+func postConvert(scanned scanTypes.ScanResult, detected detectTypes.DetectResult, fsToOriginalCPE map[string][]string, noJVNCPEs map[string]struct{}) (models.VulnInfos, error) {
 	m := make(map[source]sourceData)
 
-	if err := walkVulnerabilityDetections(m, scanned, detected.Detected, noJVNCPEs, verifiedProductsByRoot); err != nil {
+	// collectVerifiedProducts derives, per suppressed-source root, the products
+	// the verified sources define for each CVE; walkCPECriteria uses it to
+	// suppress VulnCheck / JVN matches already covered by a verified source.
+	if err := walkVulnerabilityDetections(m, scanned, detected.Detected, noJVNCPEs, collectVerifiedProducts(detected)); err != nil {
 		return nil, xerrors.Errorf("Failed to walk detections. err: %w", err)
 	}
 

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -1221,9 +1221,7 @@ func collectVerifiedProducts(detected detectTypes.DetectResult) map[dataTypes.Ro
 	// detected root.
 	verifiedByCVE := make(map[string]map[string]struct{})
 	for _, v := range detected.Detected {
-		// Allocated lazily: a root with no verified CPE source (the common
-		// case) contributes nothing and never touches the map.
-		var set map[string]struct{}
+		set := make(map[string]struct{})
 		for _, d := range v.Detections {
 			if d.Ecosystem != ecosystemTypes.EcosystemTypeCPE {
 				continue
@@ -1231,9 +1229,6 @@ func collectVerifiedProducts(detected detectTypes.DetectResult) map[dataTypes.Ro
 			for sourceID, fconds := range d.Contents {
 				if !slices.Contains(verifiedCPESources, sourceID) {
 					continue
-				}
-				if set == nil {
-					set = make(map[string]struct{})
 				}
 				for _, fcond := range fconds {
 					collectDefinedCPEProducts(fcond.Criteria, set)

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -131,13 +131,10 @@ func detectWith(r *models.ScanResult, vuls2Scanned scanTypes.ScanResult, fsToOri
 		return xerrors.Errorf("Failed to detect. err: %w", err)
 	}
 
-	// Defined-product sets for the verified sources, fetched per RootID for
-	// CVEs detected via a suppressed CPE source (VulnCheck / JVN). Drives the
-	// suppression in walkCPECriteria.
-	verifiedProductsByRoot, err := collectVerifiedProducts(sesh, vuls2Detected)
-	if err != nil {
-		return xerrors.Errorf("Failed to collect verified products. err: %w", err)
-	}
+	// Defined-product sets for the verified sources, derived from the detection
+	// result for CVEs detected via a suppressed CPE source (VulnCheck / JVN).
+	// Drives the suppression in walkCPECriteria.
+	verifiedProductsByRoot := collectVerifiedProducts(vuls2Detected)
 
 	vulnInfos, err := postConvert(vuls2Scanned, vuls2Detected, fsToOriginalCPE, noJVNCPEs, verifiedProductsByRoot)
 	if err != nil {
@@ -1202,50 +1199,63 @@ func hasSuppressedCPESource(v detectTypes.VulnerabilityData) bool {
 	return false
 }
 
+// isVerifiedCPESource reports whether a CPE-ecosystem source is one whose
+// defined products suppress a VulnCheck / JVN match (NVD / Fortinet / Cisco /
+// PaloAlto). The complement of isSuppressedCPESource among CPE sources.
+func isVerifiedCPESource(sourceID sourceTypes.SourceID) bool {
+	return slices.Contains(verifiedCPESources, sourceID)
+}
+
 // collectVerifiedProducts builds, per RootID that has a suppressed CPE source,
-// the set of part:vendor:product the verified sources DEFINE for that CVE. It
-// reproduces go-cve-dictionary's isCpeURIAlsoDefinedInVerifiedDataSource, which
-// consults cve.Nvds / cve.Fortinets / ... — every CPE the verified sources list
-// for the CVE, regardless of whether its version matched the scan.
+// the set of part:vendor:product the verified sources (NVD / Fortinet / Cisco /
+// PaloAlto) DEFINE for each of the root's CVEs — the input to walkCPECriteria's
+// suppression, reproducing go-cve-dictionary's isCpeURIAlsoDefinedInVerifiedDataSource
+// (every CPE the verified sources list for the CVE, regardless of whether its
+// version matched the scan). The map is keyed by the suppressed source's RootID,
+// then by constituent CVE ID, so a multi-CVE root keeps each CVE's product set
+// separate (a verified product for one CVE must not suppress a sibling).
 //
-// The lookup is keyed by CVE ID, not RootID: a suppressed source can sit under
-// a different root than the verified sources (e.g. JVN under a JVNDB-* root
-// while NVD is under the CVE root), so the verified data is gathered across all
-// roots that alias the CVE via GetVulnerabilityDataByVulnerabilityID. Results
-// are cached per CVE so VulnCheck and JVN detections of the same CVE share one
-// bolt read. The returned map is keyed by the suppressed source's RootID, then
-// by constituent CVE ID, so a multi-CVE root keeps each CVE's verified product
-// set separate (a verified product for one CVE must not suppress a sibling).
-func collectVerifiedProducts(sesh *session.Session, detected detectTypes.DetectResult) (map[dataTypes.RootID]map[string]map[string]struct{}, error) {
-	cache := make(map[string]map[string]struct{})
-	productsFor := func(cveID string) (map[string]struct{}, error) {
-		if set, ok := cache[cveID]; ok {
-			return set, nil
-		}
-		vd, err := sesh.GetVulnerabilityDataByVulnerabilityID(vulnerabilityContentTypes.VulnerabilityID(cveID), dbTypes.Filter{
-			Contents:    []dbTypes.FilterContentType{dbTypes.FilterContentTypeDetections},
-			DataSources: verifiedCPESources,
-		})
-		if err != nil {
-			return nil, xerrors.Errorf("Failed to get vulnerability data by vulnerability ID. CVE-ID: %s, err: %w", cveID, err)
-		}
+// It is derived entirely from the in-memory detection result — no per-CVE DB
+// re-fetch. cpe.Detect finds candidate roots through a part:vendor:product index
+// (version-agnostic) and util.Detect returns EVERY source's full criteria for
+// each such root unconditionally, so a verified source's defined products are
+// already present in detected[root].Contents. A verified root absent from the
+// result can only define products that were not scanned (else the index would
+// have surfaced it), and suppress() only ever looks up scanned products, so the
+// result is identical to a by-CVE-ID fetch for suppression purposes.
+func collectVerifiedProducts(detected detectTypes.DetectResult) map[dataTypes.RootID]map[string]map[string]struct{} {
+	// Pass 1: union the verified sources' defined products per CVE across every
+	// detected root.
+	verifiedByCVE := make(map[string]map[string]struct{})
+	for _, v := range detected.Detected {
 		set := make(map[string]struct{})
-		for _, d := range vd.Detections {
+		for _, d := range v.Detections {
 			if d.Ecosystem != ecosystemTypes.EcosystemTypeCPE {
 				continue
 			}
-			for _, srcMap := range d.Contents {
-				for _, conds := range srcMap {
-					for _, cond := range conds {
-						collectDefinedCPEProducts(cond.Criteria, set)
-					}
+			for sourceID, fconds := range d.Contents {
+				if !isVerifiedCPESource(sourceID) {
+					continue
+				}
+				for _, fcond := range fconds {
+					collectDefinedCPEProducts(fcond.Criteria, set)
 				}
 			}
 		}
-		cache[cveID] = set
-		return set, nil
+		if len(set) == 0 {
+			continue
+		}
+		for _, cveID := range cveIDsOf(v) {
+			m, ok := verifiedByCVE[cveID]
+			if !ok {
+				m = make(map[string]struct{})
+				verifiedByCVE[cveID] = m
+			}
+			maps.Copy(m, set)
+		}
 	}
 
+	// Pass 2: attach the per-CVE product set to each suppressed-source root.
 	out := make(map[dataTypes.RootID]map[string]map[string]struct{})
 	for _, v := range detected.Detected {
 		if !hasSuppressedCPESource(v) {
@@ -1253,11 +1263,7 @@ func collectVerifiedProducts(sesh *session.Session, detected detectTypes.DetectR
 		}
 		byCVE := make(map[string]map[string]struct{})
 		for _, cveID := range cveIDsOf(v) {
-			set, err := productsFor(cveID)
-			if err != nil {
-				return nil, xerrors.Errorf("Failed to get verified products. CVE-ID: %s, err: %w", cveID, err)
-			}
-			if len(set) > 0 {
+			if set, ok := verifiedByCVE[cveID]; ok {
 				byCVE[cveID] = set
 			}
 		}
@@ -1265,7 +1271,7 @@ func collectVerifiedProducts(sesh *session.Session, detected detectTypes.DetectR
 			out[v.ID] = byCVE
 		}
 	}
-	return out, nil
+	return out
 }
 
 // cveIDsOf returns the CVE IDs carried by a detection's vulnerability content.
@@ -1287,11 +1293,17 @@ func cveIDsOf(v detectTypes.VulnerabilityData) []string {
 // the part:vendor:product key of every CPE criterion — its primary CPE and any
 // CPEMatches — regardless of the Vulnerable flag (go-cve-dictionary's defined
 // set is likewise unfiltered).
-func collectDefinedCPEProducts(c criteriaTypes.Criteria, set map[string]struct{}) {
+// collectDefinedCPEProducts walks a FilteredCriteria and adds every CPE
+// criterion's defined part:vendor:product (the criterion's own CPE and its
+// CPEMatches) to set. cond.Accept keeps the full criterion — including
+// non-matching ones — under FilteredCriterion.Criterion, so this sees every
+// defined product regardless of whether the scanned CPE's version matched.
+func collectDefinedCPEProducts(c criteriaTypes.FilteredCriteria, set map[string]struct{}) {
 	for _, child := range c.Criterias {
 		collectDefinedCPEProducts(child, set)
 	}
-	for _, cn := range c.Criterions {
+	for _, fcn := range c.Criterions {
+		cn := fcn.Criterion
 		if cn.Type != criterionTypes.CriterionTypeCPE || cn.CPE == nil {
 			continue
 		}

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -1199,13 +1199,6 @@ func hasSuppressedCPESource(v detectTypes.VulnerabilityData) bool {
 	return false
 }
 
-// isVerifiedCPESource reports whether a CPE-ecosystem source is one whose
-// defined products suppress a VulnCheck / JVN match (NVD / Fortinet / Cisco /
-// PaloAlto). The complement of isSuppressedCPESource among CPE sources.
-func isVerifiedCPESource(sourceID sourceTypes.SourceID) bool {
-	return slices.Contains(verifiedCPESources, sourceID)
-}
-
 // collectVerifiedProducts builds, per RootID that has a suppressed CPE source,
 // the set of part:vendor:product the verified sources (NVD / Fortinet / Cisco /
 // PaloAlto) DEFINE for each of the root's CVEs — the input to walkCPECriteria's
@@ -1236,7 +1229,7 @@ func collectVerifiedProducts(detected detectTypes.DetectResult) map[dataTypes.Ro
 				continue
 			}
 			for sourceID, fconds := range d.Contents {
-				if !isVerifiedCPESource(sourceID) {
+				if !slices.Contains(verifiedCPESources, sourceID) {
 					continue
 				}
 				if set == nil {

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -1289,10 +1289,6 @@ func cveIDsOf(v detectTypes.VulnerabilityData) []string {
 	return slices.Collect(maps.Keys(ids))
 }
 
-// collectDefinedCPEProducts walks a (raw, unfiltered) criteria tree and records
-// the part:vendor:product key of every CPE criterion — its primary CPE and any
-// CPEMatches — regardless of the Vulnerable flag (go-cve-dictionary's defined
-// set is likewise unfiltered).
 // collectDefinedCPEProducts walks a FilteredCriteria and adds every CPE
 // criterion's defined part:vendor:product (the criterion's own CPE and its
 // CPEMatches) to set. cond.Accept keeps the full criterion — including

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -1228,7 +1228,9 @@ func collectVerifiedProducts(detected detectTypes.DetectResult) map[dataTypes.Ro
 	// detected root.
 	verifiedByCVE := make(map[string]map[string]struct{})
 	for _, v := range detected.Detected {
-		set := make(map[string]struct{})
+		// Allocated lazily: a root with no verified CPE source (the common
+		// case) contributes nothing and never touches the map.
+		var set map[string]struct{}
 		for _, d := range v.Detections {
 			if d.Ecosystem != ecosystemTypes.EcosystemTypeCPE {
 				continue
@@ -1236,6 +1238,9 @@ func collectVerifiedProducts(detected detectTypes.DetectResult) map[dataTypes.Ro
 			for sourceID, fconds := range d.Contents {
 				if !isVerifiedCPESource(sourceID) {
 					continue
+				}
+				if set == nil {
+					set = make(map[string]struct{})
 				}
 				for _, fcond := range fconds {
 					collectDefinedCPEProducts(fcond.Criteria, set)

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -1292,14 +1292,13 @@ func collectDefinedCPEProducts(c criteriaTypes.FilteredCriteria, set map[string]
 		collectDefinedCPEProducts(child, set)
 	}
 	for _, fcn := range c.Criterions {
-		cn := fcn.Criterion
-		if cn.Type != criterionTypes.CriterionTypeCPE || cn.CPE == nil {
+		if fcn.Criterion.Type != criterionTypes.CriterionTypeCPE || fcn.Criterion.CPE == nil {
 			continue
 		}
-		if key, ok := cpeProductKey(string(cn.CPE.CPE)); ok {
+		if key, ok := cpeProductKey(string(fcn.Criterion.CPE.CPE)); ok {
 			set[key] = struct{}{}
 		}
-		for _, m := range cn.CPE.CPEMatches {
+		for _, m := range fcn.Criterion.CPE.CPEMatches {
 			if key, ok := cpeProductKey(string(m)); ok {
 				set[key] = struct{}{}
 			}

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -711,6 +711,7 @@ func Test_postConvert(t *testing.T) {
 		scanned         scanTypes.ScanResult
 		detected        detectTypes.DetectResult
 		fsToOriginalCPE map[string][]string
+		noJVNCPEs       map[string]struct{}
 	}
 	tests := []struct {
 		name    string
@@ -11354,6 +11355,120 @@ func Test_postConvert(t *testing.T) {
 			},
 		},
 		{
+			// Same JVN detection as the case above, but the scanned CPE is
+			// marked UseJVN:false (in noJVNCPEs). walkCPECriteria's suppress()
+			// drops the match for JVN sources, so — with no other source — the
+			// CVE disappears from the result entirely. Locks the noJVNCPEs
+			// wiring through postConvert (its per-CPE behaviour is unit-tested
+			// in Test_walkCPECriteria).
+			name: "cpe jvn exact accept but CPE in noJVNCPEs -> suppressed, no VulnInfo",
+			args: args{
+				scanned: scanTypes.ScanResult{
+					CPE: []string{
+						"cpe:2.3:a:vendor:product:0.0.0:*:*:*:*:*:*:*",
+					},
+				},
+				fsToOriginalCPE: map[string][]string{
+					"cpe:2.3:a:vendor:product:0.0.0:*:*:*:*:*:*:*": {"cpe:/a:vendor:product:0.0.0"},
+				},
+				noJVNCPEs: map[string]struct{}{
+					"cpe:2.3:a:vendor:product:0.0.0:*:*:*:*:*:*:*": {},
+				},
+				detected: detectTypes.DetectResult{
+					Detected: []detectTypes.VulnerabilityData{
+						{
+							ID: "JVNDB-2024-000456",
+							Advisories: []dbTypes.VulnerabilityDataAdvisory{
+								{
+									ID: "CVE-2024-30001",
+									Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]advisoryTypes.Advisory{
+										sourceTypes.JVNFeedRSS: {
+											dataTypes.RootID("JVNDB-2024-000456"): []advisoryTypes.Advisory{
+												{
+													Content: advisoryContentTypes.Content{
+														ID:          "JVNDB-2024-000456",
+														Title:       "advisory title",
+														Description: "advisory description",
+														Published:   new(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)),
+													},
+													Segments: []segmentTypes.Segment{
+														{
+															Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+								{
+									ID: "CVE-2024-30001",
+									Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+										sourceTypes.JVNFeedRSS: {
+											dataTypes.RootID("JVNDB-2024-000456"): {
+												{
+													Content: vulnerabilityContentTypes.Content{
+														ID:          "CVE-2024-30001",
+														Title:       "title",
+														Description: "description",
+														References: []referenceTypes.Reference{
+															{
+																URL: "https://jvn.jp/vu/JVNVU90009999/index.html",
+															},
+														},
+														Published: new(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+													},
+													Segments: []segmentTypes.Segment{
+														{
+															Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Detections: []detectTypes.VulnerabilityDataDetection{
+								{
+									Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+									Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+										sourceTypes.JVNFeedRSS: {
+											{
+												Criteria: criteriaTypes.FilteredCriteria{
+													Operator: criteriaTypes.CriteriaOperatorTypeOR,
+													Criterions: []criterionTypes.FilteredCriterion{
+														{
+															Criterion: criterionTypes.Criterion{
+																Type: criterionTypes.CriterionTypeCPE,
+																CPE: new(ccTypes.Criterion{
+																	Vulnerable: true,
+																	FixStatus: new(vcFixStatusTypes.FixStatus{
+																		Class: vcFixStatusTypes.ClassUnknown,
+																	}),
+																	CPE: ccTypes.CPE("cpe:2.3:a:vendor:product:0.0.0:*:*:*:*:*:*:*"),
+																}),
+															},
+															Accepts: criterionTypes.AcceptQueries{
+																CPE: criterionTypes.CPEAccepts{Exact: []int{0}},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: models.VulnInfos{},
+		},
+		{
 			// A multi-CVE JVN root: one advisory and one CPE detection block
 			// shared by CVE-2024-30001 and CVE-2024-30002. A verified source
 			// defines a:vendor:product only for CVE-2024-30001, so the per-CVE
@@ -11587,7 +11702,7 @@ func Test_postConvert(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := vuls2.PostConvert(tt.args.scanned, tt.args.detected, tt.args.fsToOriginalCPE, nil)
+			got, err := vuls2.PostConvert(tt.args.scanned, tt.args.detected, tt.args.fsToOriginalCPE, tt.args.noJVNCPEs)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("postConvert() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -13792,7 +13792,8 @@ func Test_collectVerifiedProducts(t *testing.T) {
 		{
 			// A multi-CVE suppressed root must keep each CVE's verified product
 			// separate: prodx (defined only for CVE-2024-000A) must not suppress
-			// CVE-2024-000B and vice versa.
+			// CVE-2024-000B and vice versa. JVN's JVNDB-* root is the realistic
+			// multi-CVE carrier here — VulnCheck / NVD are rooted per CVE ID.
 			name: "multi-CVE suppressed root keeps per-CVE product sets separate",
 			detected: detectTypes.DetectResult{
 				Detected: []detectTypes.VulnerabilityData{
@@ -13869,12 +13870,12 @@ func Test_collectVerifiedProducts(t *testing.T) {
 						},
 					},
 					{
-						ID: "VC-multi",
+						ID: "JVNDB-2024-000099",
 						Detections: []detectTypes.VulnerabilityDataDetection{
 							{
 								Ecosystem: ecosystemTypes.EcosystemTypeCPE,
 								Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
-									sourceTypes.VulnCheckNISTNVD2: {
+									sourceTypes.JVNFeedRSS: {
 										{
 											Criteria: criteriaTypes.FilteredCriteria{
 												Operator: criteriaTypes.CriteriaOperatorTypeOR,
@@ -13901,8 +13902,8 @@ func Test_collectVerifiedProducts(t *testing.T) {
 						Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
 							{
 								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
-									sourceTypes.VulnCheckNISTNVD2: {
-										"VC-multi": {
+									sourceTypes.JVNFeedRSS: {
+										"JVNDB-2024-000099": {
 											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-000A"}},
 											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-000B"}},
 										},
@@ -13914,7 +13915,7 @@ func Test_collectVerifiedProducts(t *testing.T) {
 				},
 			},
 			want: map[dataTypes.RootID]map[string]map[string]struct{}{
-				"VC-multi": {
+				"JVNDB-2024-000099": {
 					"CVE-2024-000A": {"a:vendor:prodx": {}},
 					"CVE-2024-000B": {"a:vendor:prody": {}},
 				},

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -13469,75 +13469,6 @@ func Test_enrichCTI(t *testing.T) {
 }
 
 func Test_collectVerifiedProducts(t *testing.T) {
-	// cpeCond builds a CPE FilteredCondition whose OR criteria carries one CPE
-	// criterion per string. collectVerifiedProducts reads only Criterion.CPE
-	// (never Accepts), so the accepted-query indices are left empty.
-	cpeCond := func(cpes ...string) conditionTypes.FilteredCondition {
-		crits := make([]criterionTypes.FilteredCriterion, 0, len(cpes))
-		for _, c := range cpes {
-			crits = append(crits, criterionTypes.FilteredCriterion{
-				Criterion: criterionTypes.Criterion{
-					Type: criterionTypes.CriterionTypeCPE,
-					CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE(c)}),
-				},
-			})
-		}
-		return conditionTypes.FilteredCondition{
-			Criteria: criteriaTypes.FilteredCriteria{
-				Operator:   criteriaTypes.CriteriaOperatorTypeOR,
-				Criterions: crits,
-			},
-		}
-	}
-	// cpeCondMatches builds a single CPE criterion with a primary CPE plus
-	// CPEMatches — the version-variant form verified sources emit.
-	cpeCondMatches := func(primary string, matches ...string) conditionTypes.FilteredCondition {
-		ms := make([]ccTypes.CPE, 0, len(matches))
-		for _, m := range matches {
-			ms = append(ms, ccTypes.CPE(m))
-		}
-		return conditionTypes.FilteredCondition{
-			Criteria: criteriaTypes.FilteredCriteria{
-				Operator: criteriaTypes.CriteriaOperatorTypeOR,
-				Criterions: []criterionTypes.FilteredCriterion{{
-					Criterion: criterionTypes.Criterion{
-						Type: criterionTypes.CriterionTypeCPE,
-						CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE(primary), CPEMatches: ms}),
-					},
-				}},
-			},
-		}
-	}
-	// cpeDetection wraps CPE-ecosystem contents in a detection.
-	cpeDetection := func(contents map[sourceTypes.SourceID][]conditionTypes.FilteredCondition) detectTypes.VulnerabilityDataDetection {
-		return detectTypes.VulnerabilityDataDetection{
-			Ecosystem: ecosystemTypes.EcosystemTypeCPE,
-			Contents:  contents,
-		}
-	}
-	// vulns makes a root carry the given CVE IDs the way cveIDsOf reads them:
-	// under the root's own ID in the vulnerability content map.
-	vulns := func(rootID dataTypes.RootID, cveIDs ...string) []dbTypes.VulnerabilityDataVulnerability {
-		vs := make([]vulnerabilityTypes.Vulnerability, 0, len(cveIDs))
-		for _, id := range cveIDs {
-			vs = append(vs, vulnerabilityTypes.Vulnerability{
-				Content: vulnerabilityContentTypes.Content{ID: vulnerabilityContentTypes.VulnerabilityID(id)},
-			})
-		}
-		return []dbTypes.VulnerabilityDataVulnerability{{
-			Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
-				sourceTypes.NVDAPICVE: {rootID: vs},
-			},
-		}}
-	}
-	set := func(keys ...string) map[string]struct{} {
-		m := make(map[string]struct{}, len(keys))
-		for _, k := range keys {
-			m[k] = struct{}{}
-		}
-		return m
-	}
-
 	tests := []struct {
 		name     string
 		detected detectTypes.DetectResult
@@ -13549,19 +13480,64 @@ func Test_collectVerifiedProducts(t *testing.T) {
 			// root's CVE.
 			name: "same root: verified NVD product derived for suppressed VulnCheck",
 			detected: detectTypes.DetectResult{
-				Detected: []detectTypes.VulnerabilityData{{
-					ID: "CVE-2024-0001",
-					Detections: []detectTypes.VulnerabilityDataDetection{
-						cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
-							sourceTypes.NVDAPICVE:         {cpeCond("cpe:2.3:a:vendora:product1:*:*:*:*:*:*:*:*")},
-							sourceTypes.VulnCheckNISTNVD2: {cpeCond("cpe:2.3:a:vendora:product1:*:*:*:*:*:*:*:*")},
-						}),
+				Detected: []detectTypes.VulnerabilityData{
+					{
+						ID: "CVE-2024-0001",
+						Detections: []detectTypes.VulnerabilityDataDetection{
+							{
+								Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+								Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+									sourceTypes.NVDAPICVE: {
+										{
+											Criteria: criteriaTypes.FilteredCriteria{
+												Operator: criteriaTypes.CriteriaOperatorTypeOR,
+												Criterions: []criterionTypes.FilteredCriterion{
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE("cpe:2.3:a:vendora:product1:*:*:*:*:*:*:*:*")}),
+														},
+													},
+												},
+											},
+										},
+									},
+									sourceTypes.VulnCheckNISTNVD2: {
+										{
+											Criteria: criteriaTypes.FilteredCriteria{
+												Operator: criteriaTypes.CriteriaOperatorTypeOR,
+												Criterions: []criterionTypes.FilteredCriterion{
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE("cpe:2.3:a:vendora:product1:*:*:*:*:*:*:*:*")}),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+							{
+								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+									sourceTypes.NVDAPICVE: {
+										"CVE-2024-0001": {
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-0001"}},
+										},
+									},
+								},
+							},
+						},
 					},
-					Vulnerabilities: vulns("CVE-2024-0001", "CVE-2024-0001"),
-				}},
+				},
 			},
 			want: map[dataTypes.RootID]map[string]map[string]struct{}{
-				"CVE-2024-0001": {"CVE-2024-0001": set("a:vendora:product1")},
+				"CVE-2024-0001": {
+					"CVE-2024-0001": {"a:vendora:product1": {}},
+				},
 			},
 		},
 		{
@@ -13575,70 +13551,211 @@ func Test_collectVerifiedProducts(t *testing.T) {
 					{
 						ID: "CVE-2024-0002",
 						Detections: []detectTypes.VulnerabilityDataDetection{
-							cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
-								sourceTypes.NVDAPICVE: {cpeCond("cpe:2.3:a:vendorb:product2:*:*:*:*:*:*:*:*")},
-							}),
+							{
+								Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+								Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+									sourceTypes.NVDAPICVE: {
+										{
+											Criteria: criteriaTypes.FilteredCriteria{
+												Operator: criteriaTypes.CriteriaOperatorTypeOR,
+												Criterions: []criterionTypes.FilteredCriterion{
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE("cpe:2.3:a:vendorb:product2:*:*:*:*:*:*:*:*")}),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
-						Vulnerabilities: vulns("CVE-2024-0002", "CVE-2024-0002"),
+						Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+							{
+								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+									sourceTypes.NVDAPICVE: {
+										"CVE-2024-0002": {
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-0002"}},
+										},
+									},
+								},
+							},
+						},
 					},
 					{
 						ID: "JVNDB-2024-000002",
 						Detections: []detectTypes.VulnerabilityDataDetection{
-							cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
-								sourceTypes.JVNFeedDetail: {cpeCond("cpe:2.3:a:vendorb:product2:*:*:*:*:*:*:*:*")},
-							}),
+							{
+								Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+								Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+									sourceTypes.JVNFeedDetail: {
+										{
+											Criteria: criteriaTypes.FilteredCriteria{
+												Operator: criteriaTypes.CriteriaOperatorTypeOR,
+												Criterions: []criterionTypes.FilteredCriterion{
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE("cpe:2.3:a:vendorb:product2:*:*:*:*:*:*:*:*")}),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
-						Vulnerabilities: vulns("JVNDB-2024-000002", "CVE-2024-0002"),
+						Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+							{
+								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+									sourceTypes.JVNFeedDetail: {
+										"JVNDB-2024-000002": {
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-0002"}},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
 			want: map[dataTypes.RootID]map[string]map[string]struct{}{
-				"JVNDB-2024-000002": {"CVE-2024-0002": set("a:vendorb:product2")},
+				"JVNDB-2024-000002": {
+					"CVE-2024-0002": {"a:vendorb:product2": {}},
+				},
 			},
 		},
 		{
 			// A multi-CVE suppressed root must keep each CVE's verified product
-			// separate: prodx (defined only for CVE-A) must not suppress CVE-B
-			// and vice versa.
+			// separate: prodx (defined only for CVE-2024-000A) must not suppress
+			// CVE-2024-000B and vice versa.
 			name: "multi-CVE suppressed root keeps per-CVE product sets separate",
 			detected: detectTypes.DetectResult{
 				Detected: []detectTypes.VulnerabilityData{
 					{
 						ID: "CVE-2024-000A",
 						Detections: []detectTypes.VulnerabilityDataDetection{
-							cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
-								sourceTypes.NVDAPICVE: {cpeCond("cpe:2.3:a:vendor:prodx:*:*:*:*:*:*:*:*")},
-							}),
+							{
+								Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+								Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+									sourceTypes.NVDAPICVE: {
+										{
+											Criteria: criteriaTypes.FilteredCriteria{
+												Operator: criteriaTypes.CriteriaOperatorTypeOR,
+												Criterions: []criterionTypes.FilteredCriterion{
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE("cpe:2.3:a:vendor:prodx:*:*:*:*:*:*:*:*")}),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
-						Vulnerabilities: vulns("CVE-2024-000A", "CVE-2024-000A"),
+						Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+							{
+								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+									sourceTypes.NVDAPICVE: {
+										"CVE-2024-000A": {
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-000A"}},
+										},
+									},
+								},
+							},
+						},
 					},
 					{
 						ID: "CVE-2024-000B",
 						Detections: []detectTypes.VulnerabilityDataDetection{
-							cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
-								sourceTypes.NVDAPICVE: {cpeCond("cpe:2.3:a:vendor:prody:*:*:*:*:*:*:*:*")},
-							}),
+							{
+								Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+								Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+									sourceTypes.NVDAPICVE: {
+										{
+											Criteria: criteriaTypes.FilteredCriteria{
+												Operator: criteriaTypes.CriteriaOperatorTypeOR,
+												Criterions: []criterionTypes.FilteredCriterion{
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE("cpe:2.3:a:vendor:prody:*:*:*:*:*:*:*:*")}),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
-						Vulnerabilities: vulns("CVE-2024-000B", "CVE-2024-000B"),
+						Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+							{
+								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+									sourceTypes.NVDAPICVE: {
+										"CVE-2024-000B": {
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-000B"}},
+										},
+									},
+								},
+							},
+						},
 					},
 					{
 						ID: "VC-multi",
 						Detections: []detectTypes.VulnerabilityDataDetection{
-							cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
-								sourceTypes.VulnCheckNISTNVD2: {cpeCond(
-									"cpe:2.3:a:vendor:prodx:*:*:*:*:*:*:*:*",
-									"cpe:2.3:a:vendor:prody:*:*:*:*:*:*:*:*",
-								)},
-							}),
+							{
+								Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+								Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+									sourceTypes.VulnCheckNISTNVD2: {
+										{
+											Criteria: criteriaTypes.FilteredCriteria{
+												Operator: criteriaTypes.CriteriaOperatorTypeOR,
+												Criterions: []criterionTypes.FilteredCriterion{
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE("cpe:2.3:a:vendor:prodx:*:*:*:*:*:*:*:*")}),
+														},
+													},
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE("cpe:2.3:a:vendor:prody:*:*:*:*:*:*:*:*")}),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
-						Vulnerabilities: vulns("VC-multi", "CVE-2024-000A", "CVE-2024-000B"),
+						Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+							{
+								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+									sourceTypes.VulnCheckNISTNVD2: {
+										"VC-multi": {
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-000A"}},
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-000B"}},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
 			want: map[dataTypes.RootID]map[string]map[string]struct{}{
 				"VC-multi": {
-					"CVE-2024-000A": set("a:vendor:prodx"),
-					"CVE-2024-000B": set("a:vendor:prody"),
+					"CVE-2024-000A": {"a:vendor:prodx": {}},
+					"CVE-2024-000B": {"a:vendor:prody": {}},
 				},
 			},
 		},
@@ -13647,15 +13764,44 @@ func Test_collectVerifiedProducts(t *testing.T) {
 			// no entry (nothing to suppress).
 			name: "suppressed root with no verified product yields no entry",
 			detected: detectTypes.DetectResult{
-				Detected: []detectTypes.VulnerabilityData{{
-					ID: "VC-only",
-					Detections: []detectTypes.VulnerabilityDataDetection{
-						cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
-							sourceTypes.VulnCheckNISTNVD2: {cpeCond("cpe:2.3:a:vendor:prodz:*:*:*:*:*:*:*:*")},
-						}),
+				Detected: []detectTypes.VulnerabilityData{
+					{
+						ID: "VC-only",
+						Detections: []detectTypes.VulnerabilityDataDetection{
+							{
+								Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+								Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+									sourceTypes.VulnCheckNISTNVD2: {
+										{
+											Criteria: criteriaTypes.FilteredCriteria{
+												Operator: criteriaTypes.CriteriaOperatorTypeOR,
+												Criterions: []criterionTypes.FilteredCriterion{
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE("cpe:2.3:a:vendor:prodz:*:*:*:*:*:*:*:*")}),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+							{
+								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+									sourceTypes.VulnCheckNISTNVD2: {
+										"VC-only": {
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-0004"}},
+										},
+									},
+								},
+							},
+						},
 					},
-					Vulnerabilities: vulns("VC-only", "CVE-2024-0004"),
-				}},
+				},
 			},
 			want: nil,
 		},
@@ -13665,28 +13811,91 @@ func Test_collectVerifiedProducts(t *testing.T) {
 			// detection in a non-CPE ecosystem is ignored.
 			name: "CPEMatches fold to the product key; non-CPE ecosystem ignored",
 			detected: detectTypes.DetectResult{
-				Detected: []detectTypes.VulnerabilityData{{
-					ID: "CVE-2024-0005",
-					Detections: []detectTypes.VulnerabilityDataDetection{
-						cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
-							sourceTypes.NVDAPICVE: {cpeCondMatches(
-								"cpe:2.3:a:vendor:prodp:*:*:*:*:*:*:*:*",
-								"cpe:2.3:a:vendor:prodp:1.0:*:*:*:*:*:*:*",
-							)},
-							sourceTypes.VulnCheckNISTNVD2: {cpeCond("cpe:2.3:a:vendor:prodp:*:*:*:*:*:*:*:*")},
-						}),
-						{
-							Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
-							Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
-								sourceTypes.NVDAPICVE: {cpeCond("cpe:2.3:a:vendor:ignored:*:*:*:*:*:*:*:*")},
+				Detected: []detectTypes.VulnerabilityData{
+					{
+						ID: "CVE-2024-0005",
+						Detections: []detectTypes.VulnerabilityDataDetection{
+							{
+								Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+								Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+									sourceTypes.NVDAPICVE: {
+										{
+											Criteria: criteriaTypes.FilteredCriteria{
+												Operator: criteriaTypes.CriteriaOperatorTypeOR,
+												Criterions: []criterionTypes.FilteredCriterion{
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE: new(ccTypes.Criterion{
+																CPE: ccTypes.CPE("cpe:2.3:a:vendor:prodp:*:*:*:*:*:*:*:*"),
+																CPEMatches: []ccTypes.CPE{
+																	ccTypes.CPE("cpe:2.3:a:vendor:prodp:1.0:*:*:*:*:*:*:*"),
+																},
+															}),
+														},
+													},
+												},
+											},
+										},
+									},
+									sourceTypes.VulnCheckNISTNVD2: {
+										{
+											Criteria: criteriaTypes.FilteredCriteria{
+												Operator: criteriaTypes.CriteriaOperatorTypeOR,
+												Criterions: []criterionTypes.FilteredCriterion{
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE("cpe:2.3:a:vendor:prodp:*:*:*:*:*:*:*:*")}),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								// Non-CPE ecosystem: even a verified source here is
+								// ignored by collectVerifiedProducts.
+								Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+								Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+									sourceTypes.NVDAPICVE: {
+										{
+											Criteria: criteriaTypes.FilteredCriteria{
+												Operator: criteriaTypes.CriteriaOperatorTypeOR,
+												Criterions: []criterionTypes.FilteredCriterion{
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE("cpe:2.3:a:vendor:ignored:*:*:*:*:*:*:*:*")}),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+							{
+								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+									sourceTypes.NVDAPICVE: {
+										"CVE-2024-0005": {
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-0005"}},
+										},
+									},
+								},
 							},
 						},
 					},
-					Vulnerabilities: vulns("CVE-2024-0005", "CVE-2024-0005"),
-				}},
+				},
 			},
 			want: map[dataTypes.RootID]map[string]map[string]struct{}{
-				"CVE-2024-0005": {"CVE-2024-0005": set("a:vendor:prodp")},
+				"CVE-2024-0005": {
+					"CVE-2024-0005": {"a:vendor:prodp": {}},
+				},
 			},
 		},
 		{
@@ -13694,19 +13903,64 @@ func Test_collectVerifiedProducts(t *testing.T) {
 			// only NVD's prodp is derived, not VulnCheck's prodw.
 			name: "suppressed source's own products are not treated as verified",
 			detected: detectTypes.DetectResult{
-				Detected: []detectTypes.VulnerabilityData{{
-					ID: "CVE-2024-0006",
-					Detections: []detectTypes.VulnerabilityDataDetection{
-						cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
-							sourceTypes.NVDAPICVE:         {cpeCond("cpe:2.3:a:vendor:prodp:*:*:*:*:*:*:*:*")},
-							sourceTypes.VulnCheckNISTNVD2: {cpeCond("cpe:2.3:a:vendor:prodw:*:*:*:*:*:*:*:*")},
-						}),
+				Detected: []detectTypes.VulnerabilityData{
+					{
+						ID: "CVE-2024-0006",
+						Detections: []detectTypes.VulnerabilityDataDetection{
+							{
+								Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+								Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+									sourceTypes.NVDAPICVE: {
+										{
+											Criteria: criteriaTypes.FilteredCriteria{
+												Operator: criteriaTypes.CriteriaOperatorTypeOR,
+												Criterions: []criterionTypes.FilteredCriterion{
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE("cpe:2.3:a:vendor:prodp:*:*:*:*:*:*:*:*")}),
+														},
+													},
+												},
+											},
+										},
+									},
+									sourceTypes.VulnCheckNISTNVD2: {
+										{
+											Criteria: criteriaTypes.FilteredCriteria{
+												Operator: criteriaTypes.CriteriaOperatorTypeOR,
+												Criterions: []criterionTypes.FilteredCriterion{
+													{
+														Criterion: criterionTypes.Criterion{
+															Type: criterionTypes.CriterionTypeCPE,
+															CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE("cpe:2.3:a:vendor:prodw:*:*:*:*:*:*:*:*")}),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+							{
+								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+									sourceTypes.NVDAPICVE: {
+										"CVE-2024-0006": {
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-0006"}},
+										},
+									},
+								},
+							},
+						},
 					},
-					Vulnerabilities: vulns("CVE-2024-0006", "CVE-2024-0006"),
-				}},
+				},
 			},
 			want: map[dataTypes.RootID]map[string]map[string]struct{}{
-				"CVE-2024-0006": {"CVE-2024-0006": set("a:vendor:prodp")},
+				"CVE-2024-0006": {
+					"CVE-2024-0006": {"a:vendor:prodp": {}},
+				},
 			},
 		},
 	}

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -13791,14 +13791,14 @@ func Test_collectVerifiedProducts(t *testing.T) {
 		},
 		{
 			// A multi-CVE suppressed root must keep each CVE's verified product
-			// separate: prodx (defined only for CVE-2024-000A) must not suppress
-			// CVE-2024-000B and vice versa. JVN's JVNDB-* root is the realistic
+			// separate: prodx (defined only for CVE-2024-0011) must not suppress
+			// CVE-2024-0012 and vice versa. JVN's JVNDB-* root is the realistic
 			// multi-CVE carrier here — VulnCheck / NVD are rooted per CVE ID.
 			name: "multi-CVE suppressed root keeps per-CVE product sets separate",
 			detected: detectTypes.DetectResult{
 				Detected: []detectTypes.VulnerabilityData{
 					{
-						ID: "CVE-2024-000A",
+						ID: "CVE-2024-0011",
 						Detections: []detectTypes.VulnerabilityDataDetection{
 							{
 								Ecosystem: ecosystemTypes.EcosystemTypeCPE,
@@ -13825,8 +13825,8 @@ func Test_collectVerifiedProducts(t *testing.T) {
 							{
 								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
 									sourceTypes.NVDAPICVE: {
-										"CVE-2024-000A": {
-											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-000A"}},
+										"CVE-2024-0011": {
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-0011"}},
 										},
 									},
 								},
@@ -13834,7 +13834,7 @@ func Test_collectVerifiedProducts(t *testing.T) {
 						},
 					},
 					{
-						ID: "CVE-2024-000B",
+						ID: "CVE-2024-0012",
 						Detections: []detectTypes.VulnerabilityDataDetection{
 							{
 								Ecosystem: ecosystemTypes.EcosystemTypeCPE,
@@ -13861,8 +13861,8 @@ func Test_collectVerifiedProducts(t *testing.T) {
 							{
 								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
 									sourceTypes.NVDAPICVE: {
-										"CVE-2024-000B": {
-											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-000B"}},
+										"CVE-2024-0012": {
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-0012"}},
 										},
 									},
 								},
@@ -13904,8 +13904,8 @@ func Test_collectVerifiedProducts(t *testing.T) {
 								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
 									sourceTypes.JVNFeedRSS: {
 										"JVNDB-2024-000099": {
-											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-000A"}},
-											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-000B"}},
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-0011"}},
+											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-0012"}},
 										},
 									},
 								},
@@ -13916,8 +13916,8 @@ func Test_collectVerifiedProducts(t *testing.T) {
 			},
 			want: map[dataTypes.RootID]map[string]map[string]struct{}{
 				"JVNDB-2024-000099": {
-					"CVE-2024-000A": {"a:vendor:prodx": {}},
-					"CVE-2024-000B": {"a:vendor:prody": {}},
+					"CVE-2024-0011": {"a:vendor:prodx": {}},
+					"CVE-2024-0012": {"a:vendor:prody": {}},
 				},
 			},
 		},
@@ -13928,7 +13928,7 @@ func Test_collectVerifiedProducts(t *testing.T) {
 			detected: detectTypes.DetectResult{
 				Detected: []detectTypes.VulnerabilityData{
 					{
-						ID: "VC-only",
+						ID: "CVE-2024-0004",
 						Detections: []detectTypes.VulnerabilityDataDetection{
 							{
 								Ecosystem: ecosystemTypes.EcosystemTypeCPE,
@@ -13955,7 +13955,7 @@ func Test_collectVerifiedProducts(t *testing.T) {
 							{
 								Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
 									sourceTypes.VulnCheckNISTNVD2: {
-										"VC-only": {
+										"CVE-2024-0004": {
 											{Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-0004"}},
 										},
 									},

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -711,7 +711,6 @@ func Test_postConvert(t *testing.T) {
 		scanned         scanTypes.ScanResult
 		detected        detectTypes.DetectResult
 		fsToOriginalCPE map[string][]string
-		verified        map[dataTypes.RootID]map[string]map[string]struct{}
 	}
 	tests := []struct {
 		name    string
@@ -11371,13 +11370,60 @@ func Test_postConvert(t *testing.T) {
 				fsToOriginalCPE: map[string][]string{
 					"cpe:2.3:a:vendor:product:0.0.0:*:*:*:*:*:*:*": {"cpe:/a:vendor:product:0.0.0"},
 				},
-				verified: map[dataTypes.RootID]map[string]map[string]struct{}{
-					"JVNDB-2024-000456": {
-						"CVE-2024-30001": {"a:vendor:product": {}},
-					},
-				},
 				detected: detectTypes.DetectResult{
 					Detected: []detectTypes.VulnerabilityData{
+						{
+							// Verified (NVD) root defining a:vendor:product for
+							// CVE-2024-30001 only. Its CPE is unmatched (empty
+							// Accepts) so it yields no VulnInfo of its own, but
+							// collectVerifiedProducts still derives the product,
+							// which suppresses JVN's CVE-2024-30001 match.
+							ID: "CVE-2024-30001",
+							Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+								{
+									ID: "CVE-2024-30001",
+									Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+										sourceTypes.NVDAPICVE: {
+											dataTypes.RootID("CVE-2024-30001"): {
+												{
+													Content: vulnerabilityContentTypes.Content{ID: "CVE-2024-30001"},
+													Segments: []segmentTypes.Segment{
+														{Ecosystem: ecosystemTypes.EcosystemTypeCPE},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Detections: []detectTypes.VulnerabilityDataDetection{
+								{
+									Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+									Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+										sourceTypes.NVDAPICVE: {
+											{
+												Criteria: criteriaTypes.FilteredCriteria{
+													Operator: criteriaTypes.CriteriaOperatorTypeOR,
+													Criterions: []criterionTypes.FilteredCriterion{
+														{
+															Criterion: criterionTypes.Criterion{
+																Type: criterionTypes.CriterionTypeCPE,
+																CPE: new(ccTypes.Criterion{
+																	Vulnerable: true,
+																	CPE:        ccTypes.CPE("cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*"),
+																}),
+															},
+															// Empty Accepts: unmatched by the scan.
+															Accepts: criterionTypes.AcceptQueries{},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 						{
 							ID: "JVNDB-2024-000456",
 							Advisories: []dbTypes.VulnerabilityDataAdvisory{
@@ -11541,7 +11587,7 @@ func Test_postConvert(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := vuls2.PostConvert(tt.args.scanned, tt.args.detected, tt.args.fsToOriginalCPE, nil, tt.args.verified)
+			got, err := vuls2.PostConvert(tt.args.scanned, tt.args.detected, tt.args.fsToOriginalCPE, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("postConvert() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -13467,3 +13467,256 @@ func Test_enrichCTI(t *testing.T) {
 		})
 	}
 }
+
+func Test_collectVerifiedProducts(t *testing.T) {
+	// cpeCond builds a CPE FilteredCondition whose OR criteria carries one CPE
+	// criterion per string. collectVerifiedProducts reads only Criterion.CPE
+	// (never Accepts), so the accepted-query indices are left empty.
+	cpeCond := func(cpes ...string) conditionTypes.FilteredCondition {
+		crits := make([]criterionTypes.FilteredCriterion, 0, len(cpes))
+		for _, c := range cpes {
+			crits = append(crits, criterionTypes.FilteredCriterion{
+				Criterion: criterionTypes.Criterion{
+					Type: criterionTypes.CriterionTypeCPE,
+					CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE(c)}),
+				},
+			})
+		}
+		return conditionTypes.FilteredCondition{
+			Criteria: criteriaTypes.FilteredCriteria{
+				Operator:   criteriaTypes.CriteriaOperatorTypeOR,
+				Criterions: crits,
+			},
+		}
+	}
+	// cpeCondMatches builds a single CPE criterion with a primary CPE plus
+	// CPEMatches — the version-variant form verified sources emit.
+	cpeCondMatches := func(primary string, matches ...string) conditionTypes.FilteredCondition {
+		ms := make([]ccTypes.CPE, 0, len(matches))
+		for _, m := range matches {
+			ms = append(ms, ccTypes.CPE(m))
+		}
+		return conditionTypes.FilteredCondition{
+			Criteria: criteriaTypes.FilteredCriteria{
+				Operator: criteriaTypes.CriteriaOperatorTypeOR,
+				Criterions: []criterionTypes.FilteredCriterion{{
+					Criterion: criterionTypes.Criterion{
+						Type: criterionTypes.CriterionTypeCPE,
+						CPE:  new(ccTypes.Criterion{CPE: ccTypes.CPE(primary), CPEMatches: ms}),
+					},
+				}},
+			},
+		}
+	}
+	// cpeDetection wraps CPE-ecosystem contents in a detection.
+	cpeDetection := func(contents map[sourceTypes.SourceID][]conditionTypes.FilteredCondition) detectTypes.VulnerabilityDataDetection {
+		return detectTypes.VulnerabilityDataDetection{
+			Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+			Contents:  contents,
+		}
+	}
+	// vulns makes a root carry the given CVE IDs the way cveIDsOf reads them:
+	// under the root's own ID in the vulnerability content map.
+	vulns := func(rootID dataTypes.RootID, cveIDs ...string) []dbTypes.VulnerabilityDataVulnerability {
+		vs := make([]vulnerabilityTypes.Vulnerability, 0, len(cveIDs))
+		for _, id := range cveIDs {
+			vs = append(vs, vulnerabilityTypes.Vulnerability{
+				Content: vulnerabilityContentTypes.Content{ID: vulnerabilityContentTypes.VulnerabilityID(id)},
+			})
+		}
+		return []dbTypes.VulnerabilityDataVulnerability{{
+			Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+				sourceTypes.NVDAPICVE: {rootID: vs},
+			},
+		}}
+	}
+	set := func(keys ...string) map[string]struct{} {
+		m := make(map[string]struct{}, len(keys))
+		for _, k := range keys {
+			m[k] = struct{}{}
+		}
+		return m
+	}
+
+	tests := []struct {
+		name     string
+		detected detectTypes.DetectResult
+		want     map[dataTypes.RootID]map[string]map[string]struct{}
+	}{
+		{
+			// NVD (verified) and VulnCheck (suppressed) sit under the same CVE
+			// root and define the same product: the product is derived for the
+			// root's CVE.
+			name: "same root: verified NVD product derived for suppressed VulnCheck",
+			detected: detectTypes.DetectResult{
+				Detected: []detectTypes.VulnerabilityData{{
+					ID: "CVE-2024-0001",
+					Detections: []detectTypes.VulnerabilityDataDetection{
+						cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+							sourceTypes.NVDAPICVE:         {cpeCond("cpe:2.3:a:vendora:product1:*:*:*:*:*:*:*:*")},
+							sourceTypes.VulnCheckNISTNVD2: {cpeCond("cpe:2.3:a:vendora:product1:*:*:*:*:*:*:*:*")},
+						}),
+					},
+					Vulnerabilities: vulns("CVE-2024-0001", "CVE-2024-0001"),
+				}},
+			},
+			want: map[dataTypes.RootID]map[string]map[string]struct{}{
+				"CVE-2024-0001": {"CVE-2024-0001": set("a:vendora:product1")},
+			},
+		},
+		{
+			// The verified source (NVD) and the suppressed source (JVN) alias
+			// the same CVE under different roots — NVD under the CVE root, JVN
+			// under a JVNDB-* root. The derived set is keyed to the suppressed
+			// root via the shared CVE ID; the verified-only root is absent.
+			name: "cross-root: NVD under CVE root feeds JVN under JVNDB root",
+			detected: detectTypes.DetectResult{
+				Detected: []detectTypes.VulnerabilityData{
+					{
+						ID: "CVE-2024-0002",
+						Detections: []detectTypes.VulnerabilityDataDetection{
+							cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+								sourceTypes.NVDAPICVE: {cpeCond("cpe:2.3:a:vendorb:product2:*:*:*:*:*:*:*:*")},
+							}),
+						},
+						Vulnerabilities: vulns("CVE-2024-0002", "CVE-2024-0002"),
+					},
+					{
+						ID: "JVNDB-2024-000002",
+						Detections: []detectTypes.VulnerabilityDataDetection{
+							cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+								sourceTypes.JVNFeedDetail: {cpeCond("cpe:2.3:a:vendorb:product2:*:*:*:*:*:*:*:*")},
+							}),
+						},
+						Vulnerabilities: vulns("JVNDB-2024-000002", "CVE-2024-0002"),
+					},
+				},
+			},
+			want: map[dataTypes.RootID]map[string]map[string]struct{}{
+				"JVNDB-2024-000002": {"CVE-2024-0002": set("a:vendorb:product2")},
+			},
+		},
+		{
+			// A multi-CVE suppressed root must keep each CVE's verified product
+			// separate: prodx (defined only for CVE-A) must not suppress CVE-B
+			// and vice versa.
+			name: "multi-CVE suppressed root keeps per-CVE product sets separate",
+			detected: detectTypes.DetectResult{
+				Detected: []detectTypes.VulnerabilityData{
+					{
+						ID: "CVE-2024-000A",
+						Detections: []detectTypes.VulnerabilityDataDetection{
+							cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+								sourceTypes.NVDAPICVE: {cpeCond("cpe:2.3:a:vendor:prodx:*:*:*:*:*:*:*:*")},
+							}),
+						},
+						Vulnerabilities: vulns("CVE-2024-000A", "CVE-2024-000A"),
+					},
+					{
+						ID: "CVE-2024-000B",
+						Detections: []detectTypes.VulnerabilityDataDetection{
+							cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+								sourceTypes.NVDAPICVE: {cpeCond("cpe:2.3:a:vendor:prody:*:*:*:*:*:*:*:*")},
+							}),
+						},
+						Vulnerabilities: vulns("CVE-2024-000B", "CVE-2024-000B"),
+					},
+					{
+						ID: "VC-multi",
+						Detections: []detectTypes.VulnerabilityDataDetection{
+							cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+								sourceTypes.VulnCheckNISTNVD2: {cpeCond(
+									"cpe:2.3:a:vendor:prodx:*:*:*:*:*:*:*:*",
+									"cpe:2.3:a:vendor:prody:*:*:*:*:*:*:*:*",
+								)},
+							}),
+						},
+						Vulnerabilities: vulns("VC-multi", "CVE-2024-000A", "CVE-2024-000B"),
+					},
+				},
+			},
+			want: map[dataTypes.RootID]map[string]map[string]struct{}{
+				"VC-multi": {
+					"CVE-2024-000A": set("a:vendor:prodx"),
+					"CVE-2024-000B": set("a:vendor:prody"),
+				},
+			},
+		},
+		{
+			// A suppressed root whose CVE has no verified-source product yields
+			// no entry (nothing to suppress).
+			name: "suppressed root with no verified product yields no entry",
+			detected: detectTypes.DetectResult{
+				Detected: []detectTypes.VulnerabilityData{{
+					ID: "VC-only",
+					Detections: []detectTypes.VulnerabilityDataDetection{
+						cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+							sourceTypes.VulnCheckNISTNVD2: {cpeCond("cpe:2.3:a:vendor:prodz:*:*:*:*:*:*:*:*")},
+						}),
+					},
+					Vulnerabilities: vulns("VC-only", "CVE-2024-0004"),
+				}},
+			},
+			want: nil,
+		},
+		{
+			// The primary CPE and its CPEMatches (version variants of the same
+			// product) both fold to one part:vendor:product key, and a verified
+			// detection in a non-CPE ecosystem is ignored.
+			name: "CPEMatches fold to the product key; non-CPE ecosystem ignored",
+			detected: detectTypes.DetectResult{
+				Detected: []detectTypes.VulnerabilityData{{
+					ID: "CVE-2024-0005",
+					Detections: []detectTypes.VulnerabilityDataDetection{
+						cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+							sourceTypes.NVDAPICVE: {cpeCondMatches(
+								"cpe:2.3:a:vendor:prodp:*:*:*:*:*:*:*:*",
+								"cpe:2.3:a:vendor:prodp:1.0:*:*:*:*:*:*:*",
+							)},
+							sourceTypes.VulnCheckNISTNVD2: {cpeCond("cpe:2.3:a:vendor:prodp:*:*:*:*:*:*:*:*")},
+						}),
+						{
+							Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+							Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+								sourceTypes.NVDAPICVE: {cpeCond("cpe:2.3:a:vendor:ignored:*:*:*:*:*:*:*:*")},
+							},
+						},
+					},
+					Vulnerabilities: vulns("CVE-2024-0005", "CVE-2024-0005"),
+				}},
+			},
+			want: map[dataTypes.RootID]map[string]map[string]struct{}{
+				"CVE-2024-0005": {"CVE-2024-0005": set("a:vendor:prodp")},
+			},
+		},
+		{
+			// A suppressed source's own products must NOT be treated as verified:
+			// only NVD's prodp is derived, not VulnCheck's prodw.
+			name: "suppressed source's own products are not treated as verified",
+			detected: detectTypes.DetectResult{
+				Detected: []detectTypes.VulnerabilityData{{
+					ID: "CVE-2024-0006",
+					Detections: []detectTypes.VulnerabilityDataDetection{
+						cpeDetection(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+							sourceTypes.NVDAPICVE:         {cpeCond("cpe:2.3:a:vendor:prodp:*:*:*:*:*:*:*:*")},
+							sourceTypes.VulnCheckNISTNVD2: {cpeCond("cpe:2.3:a:vendor:prodw:*:*:*:*:*:*:*:*")},
+						}),
+					},
+					Vulnerabilities: vulns("CVE-2024-0006", "CVE-2024-0006"),
+				}},
+			},
+			want: map[dataTypes.RootID]map[string]map[string]struct{}{
+				"CVE-2024-0006": {"CVE-2024-0006": set("a:vendor:prodp")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := vuls2.CollectVerifiedProducts(tt.detected)
+			if diff := gocmp.Diff(tt.want, got, gocmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("collectVerifiedProducts() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stacked on #2590 (depends on `collectVerifiedProducts`, introduced there). Base will retarget to `master` once #2590 merges.

## Problem

`collectVerifiedProducts` (the verified-source suppression mirroring go-cve-dictionary's `isCpeURIAlsoDefinedInVerifiedDataSource`) re-fetched each detected VulnCheck/JVN CVE's verified-source data with a per-CVE `GetVulnerabilityDataByVulnerabilityID`. On a pathological kernel-as-CPE scan (`cpe:/o:linux:linux_kernel:6.1` → 7268 CVEs) this dominates `DetectCPEs` — ~36s of a ~42s warm run (did not finish within 2 min cold).

## Why the re-fetch is redundant

`cpe.Detect` → `util.Detect` finds candidate roots through a `part:vendor:product` index (version-agnostic) and returns **every source's full criteria** for each such root **unconditionally** (`FilteredCriterion` keeps the underlying `Criterion`, so non-matching definitions survive), so the verified sources' defined products are already present in the in-memory detection result. A verified root absent from the result can only define products that were **not scanned** (else the index would have surfaced it), and `suppress()` only looks up scanned products — so the derived set is identical for suppression purposes.

## Change

- `collectVerifiedProducts` drops its `*session.Session` and derives the set from `detected` in two passes (union verified-source defined products per CVE, then attach to suppressed roots).
- `collectDefinedCPEProducts` now walks a `FilteredCriteria` via `FilteredCriterion.Criterion`.
- new `isVerifiedCPESource` predicate.

## Result (measured, same DB)

| phase | before | after |
|---|---|---|
| `collectVerifiedProducts` | ~36s | **~1.3s** (I/O-free, cache-independent) |
| `DetectCPEs` total (warm) | ~42s | **~8.6s** |
| `DetectCPEs` (cold) | >120s | ~21s |
| detection output | 7268 CVEs / 1162 VulnCheck / 109 JVN | **identical** |

## Verification

- build (normal / `-tags scanner ./detector/...` / `GOOS=windows`), `go vet`, `gofmt`, `go test ./detector/...`, golangci-lint (0 issues) green.
- Detection output identical before/after on the kernel-as-CPE smoke (same CVE / VulnCheck / JVN counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
