### PR TITLE
chore(deps): bump github.com/CycloneDX/cyclonedx-go from 0.10.0 to 0.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/BurntSushi/toml v1.6.0
-	github.com/CycloneDX/cyclonedx-go v0.10.0
+	github.com/CycloneDX/cyclonedx-go v0.11.0
 	github.com/MaineK00n/vuls-data-update v0.0.0-20260630113343-f3c7f13ad814
 	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260630120316-69ab575c2ebe
 	github.com/Ullaakut/nmap/v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/CycloneDX/cyclonedx-go v0.10.0 h1:7xyklU7YD+CUyGzSFIARG18NYLsKVn4QFg04qSsu+7Y=
-github.com/CycloneDX/cyclonedx-go v0.10.0/go.mod h1:vUvbCXQsEm48OI6oOlanxstwNByXjCZ2wuleUlwGEO8=
+github.com/CycloneDX/cyclonedx-go v0.11.0 h1:GokP8FiRC+foiuwWhSSLpSD5H4hSWtGnR3wo7apkBFI=
+github.com/CycloneDX/cyclonedx-go v0.11.0/go.mod h1:vUvbCXQsEm48OI6oOlanxstwNByXjCZ2wuleUlwGEO8=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/GoogleCloudPlatform/docker-credential-gcr/v2 v2.1.32 h1:osnkVtr2sms/pE+rwAAsn0VZUAr1AAEaJYbiW3YY5Zs=

--- a/reporter/sbom/cyclonedx_test.go
+++ b/reporter/sbom/cyclonedx_test.go
@@ -32,10 +32,10 @@ func TestToCycloneDX(t *testing.T) {
 				},
 			},
 			want: &cdx.BOM{
-				XMLNS:       "http://cyclonedx.org/schema/bom/1.6",
-				JSONSchema:  "http://cyclonedx.org/schema/bom-1.6.schema.json",
+				XMLNS:       "http://cyclonedx.org/schema/bom/1.7",
+				JSONSchema:  "http://cyclonedx.org/schema/bom-1.7.schema.json",
 				BOMFormat:   "CycloneDX",
-				SpecVersion: cdx.SpecVersion1_6,
+				SpecVersion: cdx.SpecVersion1_7,
 				Version:     1,
 				Metadata: &cdx.Metadata{
 					Timestamp: "2025-01-01T00:00:00Z",
@@ -76,10 +76,10 @@ func TestToCycloneDX(t *testing.T) {
 				ReportedRevision: "build-20260311_001506_6827f2d",
 			},
 			want: &cdx.BOM{
-				XMLNS:       "http://cyclonedx.org/schema/bom/1.6",
-				JSONSchema:  "http://cyclonedx.org/schema/bom-1.6.schema.json",
+				XMLNS:       "http://cyclonedx.org/schema/bom/1.7",
+				JSONSchema:  "http://cyclonedx.org/schema/bom-1.7.schema.json",
 				BOMFormat:   "CycloneDX",
-				SpecVersion: cdx.SpecVersion1_6,
+				SpecVersion: cdx.SpecVersion1_7,
 				Version:     1,
 				Metadata: &cdx.Metadata{
 					Timestamp: "2025-01-01T00:00:00Z",


### PR DESCRIPTION
## What did you implement:

Bump `github.com/CycloneDX/cyclonedx-go` from 0.10.0 to 0.11.0.

cyclonedx-go v0.11.0 changes the default BOM spec version from 1.6 to 1.7, which broke `TestToCycloneDX` in the dependabot group PR #2584. This PR bumps only cyclonedx-go and updates the test expectations (XMLNS / JSONSchema / SpecVersion) to 1.7, so that #2584 can go in cleanly after a rebase.

## Type of change

- [x] Chore (deps update)

## How Has This Been Tested?

- `go build ./...`
- `go test ./reporter/... ./contrib/trivy/... ./saas/...` — all pass

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

🤖 Generated with [Claude Code](https://claude.com/claude-code)