### PR TITLE
feat(detector): detect Seal Security patched library packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: vulsio/integration
-        ref: 9b7a17582cd4f4521f71fe64757c7397a47a36c3
+        ref: 46e6c9c3d3f4e55cfcdf06246bab4541f8f7d2c6
         path: integration
         persist-credentials: false
     - name: Set up Go 1.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: vulsio/integration
-        ref: 46e6c9c3d3f4e55cfcdf06246bab4541f8f7d2c6
+        ref: f1e643c892c9b2445a1a87c7b9cc56647bc40184
         path: integration
         persist-credentials: false
     - name: Set up Go 1.x

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -91,7 +91,7 @@ NOW=$(shell date '+%Y-%m-%dT%H-%M-%S%z')
 NOW_JSON_DIR := '${BASE_DIR}/$(NOW)'
 ONE_SEC_AFTER=$(shell date -d '+1 second' '+%Y-%m-%dT%H-%M-%S%z')
 ONE_SEC_AFTER_JSON_DIR := '${BASE_DIR}/$(ONE_SEC_AFTER)'
-LIBS := 'bundler' 'dart' 'elixir' 'pip' 'pipenv' 'poetry-v1' 'poetry-v2' 'pylock' 'uv' 'composer' 'composer-vendor-pear' 'composer-vendor-packagist' 'npm-v1' 'npm-v2' 'npm-v3' 'yarn' 'pnpm' 'pnpm-v9' 'bun' 'cargo' 'gomod' 'gosum' 'gobinary' 'jar' 'jar-wrong-name-log4j-core' 'war' 'pom' 'gradle' 'nuget-lock' 'nuget-config' 'dotnet-deps' 'dotnet-package-props' 'conan-v1' 'conan-v2' 'swift-cocoapods' 'swift-swift' 'rust-binary'
+LIBS := 'bundler' 'dart' 'elixir' 'pip' 'pipenv' 'poetry-v1' 'poetry-v2' 'pylock' 'uv' 'composer' 'composer-vendor-pear' 'composer-vendor-packagist' 'npm-v1' 'npm-v2' 'npm-v3' 'yarn' 'pnpm' 'pnpm-v9' 'bun' 'cargo' 'gomod' 'gosum' 'gobinary' 'jar' 'jar-wrong-name-log4j-core' 'war' 'pom' 'gradle' 'nuget-lock' 'nuget-config' 'dotnet-deps' 'dotnet-package-props' 'conan-v1' 'conan-v2' 'swift-cocoapods' 'swift-swift' 'rust-binary' 'seal-npm' 'seal-pip' 'seal-gomod'
 
 diff:
 	# git clone git@github.com:vulsio/vulsctl.git

--- a/detector/library.go
+++ b/detector/library.go
@@ -17,6 +17,10 @@ import (
 	"github.com/aquasecurity/trivy/pkg/db"
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/java/jar"
 	"github.com/aquasecurity/trivy/pkg/detector/library"
+
+	// Register vendor-specific advisory detection (e.g. Seal Security) to
+	// library.NewDriver, as trivy does in pkg/scan/langpkg.
+	_ "github.com/aquasecurity/trivy/pkg/detector/library/all"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/purl"

--- a/detector/library.go
+++ b/detector/library.go
@@ -18,8 +18,10 @@ import (
 	"github.com/aquasecurity/trivy/pkg/dependency/parser/java/jar"
 	"github.com/aquasecurity/trivy/pkg/detector/library"
 
-	// Register vendor-specific advisory detection (e.g. Seal Security) to
-	// library.NewDriver, as trivy does in pkg/scan/langpkg.
+	// Register vendor-specific advisory matchers (e.g. Seal Security) so
+	// that drivers created by library.NewDriver route vendor-patched
+	// packages to their vendor advisory buckets, as trivy does in
+	// pkg/scan/langpkg.
 	_ "github.com/aquasecurity/trivy/pkg/detector/library/all"
 	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/log"

--- a/scanner/analyze_golden_test.go
+++ b/scanner/analyze_golden_test.go
@@ -88,6 +88,13 @@ var lockfiles = []lockfileEntry{
 	// Swift
 	{"Podfile.lock", 0644, false},
 	{"Package.resolved", 0644, false},
+
+	// Seal Security patched packages (mixed with standard packages;
+	// detection via the "seal <eco>::" trivy-db buckets happens at report
+	// time, here we only pin the parsed package names/versions)
+	{"seal/package-lock.json", 0644, false},
+	{"seal/requirements.txt", 0644, false},
+	{"seal/go.mod", 0644, false},
 }
 
 // goldenFileName converts a lockfile path to a golden file name.

--- a/scanner/testdata/golden/seal_go.mod.json
+++ b/scanner/testdata/golden/seal_go.mod.json
@@ -1,0 +1,23 @@
+[
+  {
+    "type": "gomod",
+    "lockfilePath": "seal/go.mod",
+    "libs": [
+      {
+        "name": "example.com/seal-demo-app",
+        "version": "",
+        "purl": "pkg:golang/example.com/seal-demo-app",
+        "id": "example.com/seal-demo-app",
+        "dependsOn": [
+          "sealsecurity.io/golang.org/x/crypto@v0.26.0-sp1"
+        ]
+      },
+      {
+        "name": "sealsecurity.io/golang.org/x/crypto",
+        "version": "v0.26.0-sp1",
+        "purl": "pkg:golang/sealsecurity.io/golang.org/x/crypto@v0.26.0-sp1",
+        "id": "sealsecurity.io/golang.org/x/crypto@v0.26.0-sp1"
+      }
+    ]
+  }
+]

--- a/scanner/testdata/golden/seal_package-lock.json.json
+++ b/scanner/testdata/golden/seal_package-lock.json.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "npm",
+    "lockfilePath": "seal/package-lock.json",
+    "libs": [
+      {
+        "name": "@seal-security/ejs",
+        "version": "2.7.4-sp1",
+        "purl": "pkg:npm/%40seal-security/ejs@2.7.4-sp1",
+        "id": "@seal-security/ejs@2.7.4-sp1"
+      },
+      {
+        "name": "lodash",
+        "version": "4.17.21",
+        "purl": "pkg:npm/lodash@4.17.21",
+        "id": "lodash@4.17.21"
+      }
+    ]
+  }
+]

--- a/scanner/testdata/golden/seal_requirements.txt.json
+++ b/scanner/testdata/golden/seal_requirements.txt.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "pip",
+    "lockfilePath": "seal/requirements.txt",
+    "libs": [
+      {
+        "name": "requests",
+        "version": "2.32.3",
+        "purl": "pkg:pypi/requests@2.32.3"
+      },
+      {
+        "name": "seal-django",
+        "version": "3.2.18+sp1",
+        "purl": "pkg:pypi/seal-django@3.2.18%2Bsp1"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## What did you implement:

Trivy v0.71.0 introduced vendor-specific advisory detection for libraries (aquasecurity/trivy#10297): packages patched by [Seal Security](https://www.seal.security/) (e.g. `@seal-security/ejs`, `seal-django`, `sealsecurity.io/golang.org/x/crypto`) are routed to dedicated advisory buckets such as `seal npm::Seal Security Database` in trivy-db.

The vendor matchers are registered via a side-effect import of `pkg/detector/library/all`, which trivy itself does in `pkg/scan/langpkg`. Since vuls calls `library.NewDriver` directly, the registration was not linked in and Seal-patched packages were never matched against the seal buckets. This PR adds the blank import to `detector` so that `vuls report` detects CVEs for Seal-patched packages found by lockfile scan.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Verified end-to-end with a pseudo server scanning lockfiles containing real Seal-patched package names/versions taken from the current trivy-db (2026-07-03) seal buckets:

- `package-lock.json` (npm alias install form): `"ejs": "npm:@seal-security/ejs@2.7.4-sp1"` → CVE-2024-33883 detected, FixedIn `2.7.4-sp2` (`seal npm::` bucket)
- `requirements.txt`: `seal-django==3.2.18+sp1` → CVE-2024-27351 etc. (6 CVEs) detected, FixedIn `3.2.18+sp2` (`seal pip::` bucket, PEP440 local-version comparer)
- `go.mod` (replace directive form): `replace golang.org/x/crypto => sealsecurity.io/golang.org/x/crypto v0.26.0-sp1` → CVE-2025-22869 etc. detected, FixedIn `0.26.0-sp2` (`seal go::` bucket)
- non-seal packages in the same lockfiles (e.g. `requests==2.32.3`, `lodash@4.17.21`) keep matching the standard ecosystem buckets

Negative test: the same scan result reported with a binary built from master (0d41be0) detects only the 5 CVEs of the non-seal packages; none of the seal-named packages match anything. With this patch the same scan yields 28 CVEs including all the seal-bucket ones above.

## Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/future-architect/vuls/blob/master/.github/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes? -> covered by E2E verification above; the vendor routing itself is tested upstream in trivy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)