### PR TITLE
feat(detector/vuls2): ignore rejected/withdrawn CPE vulnerabilities

### DIFF
--- a/detector/vuls2/vendor.go
+++ b/detector/vuls2/vendor.go
@@ -101,10 +101,44 @@ func toVuls2Release(vuls0Family, vuls0Release string) string {
 	}
 }
 
-func ignoreVulnerability(e ecosystemTypes.Ecosystem, v vulnerabilityTypes.Vulnerability, as models.DistroAdvisories) bool {
+func ignoreVulnerability(e ecosystemTypes.Ecosystem, s sourceTypes.SourceID, v vulnerabilityTypes.Vulnerability, as models.DistroAdvisories) bool {
 	et, _, _ := strings.Cut(string(e), ":")
 
 	switch et {
+	case ecosystemTypes.EcosystemTypeCPE:
+		switch s {
+		case sourceTypes.NVDAPICVE, sourceTypes.NVDFeedCVEv1, sourceTypes.NVDFeedCVEv2, sourceTypes.VulnCheckNISTNVD2:
+			// NVD / VulnCheck (CVE-keyed CPE sources) publish the rejection in
+			// the vulnerability description itself ("** REJECT **",
+			// "[REJECTED CVE]", "Rejected reason:").
+			if strings.HasPrefix(v.Content.Description, "** REJECT **") ||
+				strings.HasPrefix(v.Content.Description, "[REJECTED CVE]") ||
+				strings.HasPrefix(v.Content.Description, "Rejected reason:") {
+				return true
+			}
+			return false
+		case sourceTypes.JVNFeedRSS, sourceTypes.JVNFeedDetail:
+			// JVN invalidates a JVNDB entry in place with a description marker
+			// ("** 削除 **" withdrawn, "** 未確定 **" unconfirmed,
+			// "** サポート外 **" unsupported); go-cve-dictionary drops all three
+			// at fetch. The JVN vulnerability content carries only the CVE id,
+			// so the marker is read from the advisory descriptions (the only
+			// field carried on models.DistroAdvisory).
+			//
+			// There is deliberately no len(as)==0 guard as in the RedHat/Ubuntu
+			// branches. Those keep the vulnerability when no advisory is present
+			// because their vulnerability content carries its own (NVD-sourced)
+			// description that was already checked for a reject marker. A JVN CPE
+			// vulnerability has no such description: the JVNDB advisory is the
+			// sole detection basis and shares this source's segment, so as is
+			// always non-empty here. Were it ever empty, filterDistroAdvisories
+			// returns empty and the CVE is dropped — acceptable, since a JVN
+			// detection with no backing advisory is malformed. Drop the
+			// vulnerability when every backing advisory is marked.
+			return len(filterDistroAdvisories(e, s, as)) == 0
+		default:
+			return false
+		}
 	case ecosystemTypes.EcosystemTypeRedHat:
 		if strings.Contains(v.Content.Description, "** REJECT **") || strings.HasPrefix(v.Content.Description, "[REJECTED CVE]") {
 			return true
@@ -114,7 +148,7 @@ func ignoreVulnerability(e ecosystemTypes.Ecosystem, v vulnerabilityTypes.Vulner
 			return false
 		}
 
-		if len(filterDistroAdvisories(e, as)) == 0 {
+		if len(filterDistroAdvisories(e, s, as)) == 0 {
 			return true
 		}
 
@@ -128,7 +162,7 @@ func ignoreVulnerability(e ecosystemTypes.Ecosystem, v vulnerabilityTypes.Vulner
 			return false
 		}
 
-		if len(filterDistroAdvisories(e, as)) == 0 {
+		if len(filterDistroAdvisories(e, s, as)) == 0 {
 			return true
 		}
 
@@ -138,7 +172,7 @@ func ignoreVulnerability(e ecosystemTypes.Ecosystem, v vulnerabilityTypes.Vulner
 	}
 }
 
-func filterDistroAdvisories(e ecosystemTypes.Ecosystem, as models.DistroAdvisories) models.DistroAdvisories {
+func filterDistroAdvisories(e ecosystemTypes.Ecosystem, s sourceTypes.SourceID, as models.DistroAdvisories) models.DistroAdvisories {
 	et, _, _ := strings.Cut(string(e), ":")
 
 	switch et {
@@ -150,6 +184,24 @@ func filterDistroAdvisories(e ecosystemTypes.Ecosystem, as models.DistroAdvisori
 			}
 		}
 		return fas
+	case ecosystemTypes.EcosystemTypeCPE:
+		switch s {
+		case sourceTypes.JVNFeedRSS, sourceTypes.JVNFeedDetail:
+			// Drop JVN advisories invalidated in place ("** 削除 **" withdrawn,
+			// "** 未確定 **" unconfirmed, "** サポート外 **" unsupported).
+			var fas models.DistroAdvisories
+			for _, a := range as {
+				if strings.Contains(a.Description, "** 削除 **") ||
+					strings.Contains(a.Description, "** 未確定 **") ||
+					strings.Contains(a.Description, "** サポート外 **") {
+					continue
+				}
+				fas = append(fas, a)
+			}
+			return fas
+		default:
+			return as
+		}
 	default:
 		return as
 	}

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -1627,7 +1627,7 @@ func walkVulnerabilityDatas(m map[source]sourceData, vds []detectTypes.Vulnerabi
 
 						srcsWithVulns[src] = struct{}{}
 
-						if ignoreVulnerability(src.Segment.Ecosystem, v, am[src]) {
+						if ignoreVulnerability(src.Segment.Ecosystem, src.SourceID, v, am[src]) {
 							continue
 						}
 
@@ -1637,7 +1637,7 @@ func walkVulnerabilityDatas(m map[source]sourceData, vds []detectTypes.Vulnerabi
 								return models.VulnInfo{}, xerrors.Errorf("Failed to marshal sources. err: %w", err)
 							}
 
-							fdas := filterDistroAdvisories(src.Segment.Ecosystem, am[src])
+							fdas := filterDistroAdvisories(src.Segment.Ecosystem, src.SourceID, am[src])
 							cctype := toCveContentType(src.Segment.Ecosystem, sid)
 							cvss2, cvss3, cvss40 := toCvss(src.Segment.Ecosystem, sid, v.Content.Severity)
 
@@ -1767,7 +1767,7 @@ func walkVulnerabilityDatas(m map[source]sourceData, vds []detectTypes.Vulnerabi
 				continue
 			}
 
-			fdas := filterDistroAdvisories(src.Segment.Ecosystem, das)
+			fdas := filterDistroAdvisories(src.Segment.Ecosystem, src.SourceID, das)
 			for _, da := range fdas {
 				bs, err := json.Marshal([]source{src})
 				if err != nil {

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -11199,6 +11199,195 @@ func Test_postConvert(t *testing.T) {
 			},
 		},
 		{
+			// The direct rejected counterpart of "cpe vulncheck exact accept ->
+			// Vulncheck content" above: identical scanned CPE and accepted CPE
+			// detection, but the vulnerability description is a CVE.org rejection
+			// ("Rejected reason: ..."). As of the "emit detections for rejected
+			// CVEs" change in vuls-data-update, the extractor keeps the detection
+			// for a rejected CVE (previously it dropped it), so the rejected CVE
+			// now reaches the detector with an accepted detection — and
+			// ignoreVulnerability drops it by that description, yielding no
+			// VulnInfo. Locks the NVD/VulnCheck description branch of
+			// ignoreVulnerability through postConvert.
+			name: "cpe vulncheck rejected (accepted detection) -> dropped, no VulnInfo",
+			args: args{
+				scanned: scanTypes.ScanResult{
+					CPE: []string{
+						"cpe:2.3:a:vendor:product:0.0.0:*:*:*:*:*:*:*",
+					},
+				},
+				fsToOriginalCPE: map[string][]string{
+					"cpe:2.3:a:vendor:product:0.0.0:*:*:*:*:*:*:*": {"cpe:/a:vendor:product:0.0.0"},
+				},
+				detected: detectTypes.DetectResult{
+					Detected: []detectTypes.VulnerabilityData{
+						{
+							ID: "CVE-2022-49267",
+							Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+								{
+									ID: "CVE-2022-49267",
+									Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+										sourceTypes.VulnCheckNISTNVD2: {
+											dataTypes.RootID("CVE-2022-49267"): {
+												{
+													Content: vulnerabilityContentTypes.Content{
+														ID:          "CVE-2022-49267",
+														Description: "Rejected reason: This CVE ID has been rejected or withdrawn by its CVE Numbering Authority.",
+														Published:   new(time.Date(2025, 2, 26, 0, 0, 0, 0, time.UTC)),
+													},
+													Segments: []segmentTypes.Segment{
+														{
+															Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Detections: []detectTypes.VulnerabilityDataDetection{
+								{
+									Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+									Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+										sourceTypes.VulnCheckNISTNVD2: {
+											{
+												Criteria: criteriaTypes.FilteredCriteria{
+													Operator: criteriaTypes.CriteriaOperatorTypeOR,
+													Criterions: []criterionTypes.FilteredCriterion{
+														{
+															Criterion: criterionTypes.Criterion{
+																Type: criterionTypes.CriterionTypeCPE,
+																CPE: new(ccTypes.Criterion{
+																	Vulnerable: true,
+																	FixStatus: new(vcFixStatusTypes.FixStatus{
+																		Class: vcFixStatusTypes.ClassUnknown,
+																	}),
+																	CPE: ccTypes.CPE("cpe:2.3:a:vendor:product:0.0.0:*:*:*:*:*:*:*"),
+																}),
+															},
+															Accepts: criterionTypes.AcceptQueries{
+																CPE: criterionTypes.CPEAccepts{Exact: []int{0}},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: models.VulnInfos{},
+		},
+		{
+			// A JVN CPE detection whose advisory is withdrawn in place
+			// ("** 削除 **"). The JVN vulnerability content carries only the CVE
+			// id, so ignoreVulnerability reads the marker from the advisory
+			// description (via am[src]) and drops the CVE — the result is empty.
+			// Locks the JVN advisory-marker branch of ignoreVulnerability through
+			// postConvert.
+			name: "cpe jvn 削除 (withdrawn) -> dropped, no VulnInfo",
+			args: args{
+				scanned: scanTypes.ScanResult{
+					CPE: []string{
+						"cpe:2.3:a:vendor:product:0.0.0:*:*:*:*:*:*:*",
+					},
+				},
+				fsToOriginalCPE: map[string][]string{
+					"cpe:2.3:a:vendor:product:0.0.0:*:*:*:*:*:*:*": {"cpe:/a:vendor:product:0.0.0"},
+				},
+				detected: detectTypes.DetectResult{
+					Detected: []detectTypes.VulnerabilityData{
+						{
+							ID: "JVNDB-2024-000456",
+							Advisories: []dbTypes.VulnerabilityDataAdvisory{
+								{
+									ID: "CVE-2024-30001",
+									Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]advisoryTypes.Advisory{
+										sourceTypes.JVNFeedRSS: {
+											dataTypes.RootID("JVNDB-2024-000456"): []advisoryTypes.Advisory{
+												{
+													Content: advisoryContentTypes.Content{
+														ID:          "JVNDB-2024-000456",
+														Title:       "** 削除 ** advisory title",
+														Description: "** 削除 ** 本件は、削除されました。",
+														Published:   new(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)),
+													},
+													Segments: []segmentTypes.Segment{
+														{
+															Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+								{
+									ID: "CVE-2024-30001",
+									Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+										sourceTypes.JVNFeedRSS: {
+											dataTypes.RootID("JVNDB-2024-000456"): {
+												{
+													Content: vulnerabilityContentTypes.Content{
+														ID:        "CVE-2024-30001",
+														Published: new(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+													},
+													Segments: []segmentTypes.Segment{
+														{
+															Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Detections: []detectTypes.VulnerabilityDataDetection{
+								{
+									Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+									Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+										sourceTypes.JVNFeedRSS: {
+											{
+												Criteria: criteriaTypes.FilteredCriteria{
+													Operator: criteriaTypes.CriteriaOperatorTypeOR,
+													Criterions: []criterionTypes.FilteredCriterion{
+														{
+															Criterion: criterionTypes.Criterion{
+																Type: criterionTypes.CriterionTypeCPE,
+																CPE: new(ccTypes.Criterion{
+																	Vulnerable: true,
+																	FixStatus: new(vcFixStatusTypes.FixStatus{
+																		Class: vcFixStatusTypes.ClassUnknown,
+																	}),
+																	CPE: ccTypes.CPE("cpe:2.3:a:vendor:product:0.0.0:*:*:*:*:*:*:*"),
+																}),
+															},
+															Accepts: criterionTypes.AcceptQueries{
+																CPE: criterionTypes.CPEAccepts{Exact: []int{0}},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: models.VulnInfos{},
+		},
+		{
 			// JVN's CPE entries carry no version data, so walkCPECriteria
 			// demotes even an exact accept to the vendor:product tier
 			// (isJVNCPESource): the CVE is reported with


### PR DESCRIPTION
## What

Filter invalidated CPE-ecosystem vulnerabilities (NVD / VulnCheck rejected, JVN withdrawn) in `detector/vuls2` so they no longer surface as detections.

## Why

`ignoreVulnerability` only handled the Red Hat and Ubuntu ecosystems; the CPE ecosystem fell through to `default: return false` (never ignore), so invalidated records were reported:

- **NVD / VulnCheck rejected CVEs.** VulnCheck (nist-nvd2) now emits detections for rejected CVEs in vuls-data-update (MaineK00n/vuls-data-update#873), so a rejected CVE reaches the detector with an *accepted* CPE detection and must be dropped here — by its vulnerability description (`** REJECT **`, `[REJECTED CVE]`, `Rejected reason:`), exactly as the Red Hat / Ubuntu branches already do.
- **JVN entries withdrawn in place** (`** 削除 **` / `** 未確定 **` / `** サポート外 **`). go-cve-dictionary dropped these at fetch; vuls2 kept them. JVN's CPE vulnerability content carries only the CVE id, so the marker is read from the advisory descriptions backing the detection.

This moves the drop decision to the consumer (matching how the sources publish rejected records whole) and brings vuls2 CPE detection back in line with go-cve-dictionary.

## How

- Thread `SourceID` through `ignoreVulnerability` and `filterDistroAdvisories` so the CPE case dispatches on the concrete source (NVD/VulnCheck by description; JVN by advisory marker) instead of string-matching blindly.
- Update the three call sites to pass `src.SourceID`.

## Testing

- `go test ./detector/vuls2/` — pass.
- New `Test_postConvert` cases exercise both branches end to end: a rejected VulnCheck CVE with an *accepted* detection, and a withdrawn JVN advisory, each yielding no `VulnInfo`. The rejected case is a direct A/B counterpart of the existing `cpe vulncheck exact accept` case (identical scanned CPE and accepted detection; only the description differs).

## Dependencies

No `go.mod` bump required. This relies only on the existing extracted `description` text and source IDs — it depends on no new vuls-data-update type. MaineK00n/vuls-data-update#873 changes only the extractor and its goldens (not the extracted types vuls imports); its effect reaches vuls through the rebuilt vuls2 DB at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)