### PR TITLE
fix(scanner): guard short package tokens in parseApkVersion

### DIFF
--- a/scanner/alpine.go
+++ b/scanner/alpine.go
@@ -301,6 +301,9 @@ func (o *alpine) parseApkVersion(stdout string) (models.Packages, error) {
 		ss := strings.Split(line, "<")
 		namever := strings.TrimSpace(ss[0])
 		tt := strings.Split(namever, "-")
+		if len(tt) < 3 {
+			continue
+		}
 		name := strings.Join(tt[:len(tt)-2], "-")
 		packs[name] = models.Package{
 			Name:       name,


### PR DESCRIPTION
`parseApkVersion` splits each `apk version` line's package token on `-` and takes `tt[:len(tt)-2]` as the name. If the token has fewer than two `-` separators, `len(tt)-2` is negative and the slice panics (`slice bounds out of range`), which aborts the whole scan.

The two siblings in the same file already guard this: `parseApkInstalledList` and `parseApkUpgradableList` both `continue` on `len(...) < 3`. `parseApkVersion` was missing the equivalent check.

Repro: an `apk version` line whose name has fewer than two hyphens, e.g.

```
busybox < 1.36.1-r0
```

(the header line is skipped by the existing `strings.Contains(line, "<")` guard, so only a malformed data line reaches the split.) Before the fix this panics at `strings.Join(tt[:len(tt)-2], ...)`.

This adds the same `len(tt) < 3` guard the siblings use. `go test ./scanner/` passes.