### PR TITLE
fix(release): resolve the pushed tag when multiple tags point at HEAD

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -43,3 +43,6 @@ jobs:
           args: release --clean --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pin the release tag to the pushed ref so goreleaser never picks
+          # another tag pointing at the same commit (e.g. an rc tag).
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,9 @@
 version: 2
 project_name: vuls
+git:
+  # Sort tags treating "-" as a pre-release suffix so that, when multiple tags
+  # point at HEAD (e.g. v0.40.0-rc.1 and v0.40.0), the final tag wins.
+  prerelease_suffix: "-"
 release:
   github:
     owner: future-architect


### PR DESCRIPTION
## What

Fixes goreleaser picking the wrong tag when multiple tags point at the same commit.

- `.goreleaser.yml`: set `git.prerelease_suffix: "-"` so tag sorting treats `-rc.N` as a pre-release suffix (adds `-c versionsort.suffix=-` to the underlying `git tag --sort=-version:refname`).
- `.github/workflows/goreleaser.yml`: set `GORELEASER_CURRENT_TAG: ${{ github.ref_name }}` so the released tag is always exactly the tag that triggered the run.

## Why

The v0.40.0 release build ([run 30433795759](https://github.com/future-architect/vuls/actions/runs/30433795759)) failed. Both `v0.40.0-rc.1` and `v0.40.0` point at the same commit, and goreleaser resolves the current tag via `git tag --points-at HEAD --sort=-version:refname`. Without `versionsort.suffix`, git sorts `v0.40.0-rc.1` **above** `v0.40.0` (the `-rc.1` part is treated as an extra version component, not a pre-release suffix). The run therefore built version `0.40.0-rc.1` and tried to upload assets to the existing rc.1 release, failing with `422 already_exists` on every asset.

Either change alone is sufficient; `GORELEASER_CURRENT_TAG` is the stronger guarantee and `prerelease_suffix` keeps local/manual goreleaser runs correct too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)