### PR TITLE
fix(detector/vuls2): prevent redundant parallel DB downloads in server mode

### DIFF
--- a/detector/vuls2/db.go
+++ b/detector/vuls2/db.go
@@ -3,6 +3,7 @@ package vuls2
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -22,7 +23,19 @@ var (
 		wd, _ := os.Getwd()
 		return filepath.Join(wd, "vuls.db")
 	}()
+
+	bgFetch backgroundFetch
 )
+
+// backgroundFetch coordinates asynchronous DB downloads so that at most one
+// fetch runs at a time. When a request determines the DB is stale it triggers
+// a background goroutine and immediately falls through to use the current
+// (stale) DB. Subsequent requests that arrive while the fetch is in flight
+// skip the download entirely.
+type backgroundFetch struct {
+	mu          sync.Mutex
+	downloading bool
+}
 
 func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, error) {
 	willDownload, err := shouldDownload(vuls2Conf, time.Now())
@@ -31,9 +44,21 @@ func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, 
 	}
 
 	if willDownload {
-		logging.Log.Infof("Fetching vuls2 db. repository: %s", vuls2Conf.Repository)
-		if err := fetch.Fetch(fetch.WithRepository(vuls2Conf.Repository), fetch.WithDBPath(vuls2Conf.Path), fetch.WithNoProgress(noProgress)); err != nil {
-			return nil, xerrors.Errorf("Failed to fetch vuls2 db. err: %w", err)
+		syncRequired, err := mustFetchSync(vuls2Conf.Path)
+		if err != nil {
+			return nil, xerrors.Errorf("Failed to check db state. err: %w", err)
+		}
+
+		if syncRequired {
+			// DB does not exist or has incompatible schema — must download synchronously.
+			logging.Log.Infof("Fetching vuls2 db (sync). repository: %s", vuls2Conf.Repository)
+			if err := fetch.Fetch(fetch.WithRepository(vuls2Conf.Repository), fetch.WithDBPath(vuls2Conf.Path), fetch.WithNoProgress(noProgress)); err != nil {
+				return nil, xerrors.Errorf("Failed to fetch vuls2 db. err: %w", err)
+			}
+		} else {
+			// DB exists with correct schema but is stale — trigger a background
+			// refresh and continue with the current version.
+			bgFetch.triggerAsync(vuls2Conf, noProgress)
 		}
 	}
 
@@ -72,6 +97,43 @@ func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, 
 		Options:   session.StorageOptions{BoltDB: &bolt.Options{ReadOnly: true}},
 		WithCache: true,
 	}, nil
+}
+
+// mustFetchSync returns true when the DB cannot be used as-is and a
+// synchronous download is required: either the file does not exist, or it
+// exists but its schema version does not match the expected one.
+func mustFetchSync(dbpath string) (bool, error) {
+	if _, err := os.Stat(dbpath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+		return false, xerrors.Errorf("Failed to stat db. err: %w", err)
+	}
+
+	sv, err := session.SchemaVersion("boltdb")
+	if err != nil {
+		return false, xerrors.Errorf("Failed to get schema version. err: %w", err)
+	}
+
+	sesh, err := (&session.Config{
+		Type:    "boltdb",
+		Path:    dbpath,
+		Options: session.StorageOptions{BoltDB: &bolt.Options{ReadOnly: true}},
+	}).New()
+	if err != nil {
+		return true, nil
+	}
+	if err := sesh.Storage().Open(); err != nil {
+		return true, nil
+	}
+	defer sesh.Storage().Close()
+
+	metadata, err := sesh.Storage().GetMetadata()
+	if err != nil || metadata == nil {
+		return true, nil
+	}
+
+	return metadata.SchemaVersion != sv, nil
 }
 
 func shouldDownload(vuls2Conf config.Vuls2Conf, now time.Time) (bool, error) {
@@ -127,4 +189,32 @@ func shouldDownload(vuls2Conf config.Vuls2Conf, now time.Time) (bool, error) {
 		return false, nil
 	}
 	return metadata.LastModified.Add(6 * time.Hour).Before(now), nil
+}
+
+// triggerAsync starts a background fetch if no download is already in progress.
+// It returns immediately in all cases — the caller continues with the current DB.
+func (bf *backgroundFetch) triggerAsync(vuls2Conf config.Vuls2Conf, noProgress bool) {
+	bf.mu.Lock()
+	if bf.downloading {
+		bf.mu.Unlock()
+		logging.Log.Infof("vuls2 db download already in progress, using current db")
+		return
+	}
+	bf.downloading = true
+	bf.mu.Unlock()
+
+	logging.Log.Infof("Fetching vuls2 db in background. repository: %s", vuls2Conf.Repository)
+	go func() {
+		defer func() {
+			bf.mu.Lock()
+			bf.downloading = false
+			bf.mu.Unlock()
+		}()
+
+		if err := fetch.Fetch(fetch.WithRepository(vuls2Conf.Repository), fetch.WithDBPath(vuls2Conf.Path), fetch.WithNoProgress(noProgress)); err != nil {
+			logging.Log.Warnf("Background vuls2 db fetch failed: %+v", err)
+		} else {
+			logging.Log.Infof("Background vuls2 db fetch completed successfully")
+		}
+	}()
 }

--- a/detector/vuls2/db_test.go
+++ b/detector/vuls2/db_test.go
@@ -150,6 +150,62 @@ func Test_shouldDownload(t *testing.T) {
 
 }
 
+func Test_mustFetchSync(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *types.Metadata
+		want     bool
+	}{
+		{
+			name: "no db file",
+			want: true,
+		},
+		{
+			name: "schema matches",
+			metadata: &types.Metadata{
+				LastModified:  *parse("2024-01-02T00:00:00Z"),
+				SchemaVersion: schemaVersionBoltDB(t),
+			},
+			want: false,
+		},
+		{
+			name: "schema mismatch",
+			metadata: &types.Metadata{
+				LastModified:  *parse("2024-01-02T00:00:00Z"),
+				SchemaVersion: schemaVersionBoltDB(t) + 1,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := t.TempDir()
+			dbpath := filepath.Join(d, "vuls.db")
+			if tt.metadata != nil {
+				if err := putMetadata(*tt.metadata, dbpath); err != nil {
+					t.Fatalf("putMetadata err = %v", err)
+				}
+			}
+			got, err := vuls2.MustFetchSync(dbpath)
+			if err != nil {
+				t.Fatalf("mustFetchSync() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("mustFetchSync() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_backgroundFetch_singleFlight(t *testing.T) {
+	vuls2.ResetBgFetch()
+	defer vuls2.ResetBgFetch()
+
+	if vuls2.BgFetchDownloading() {
+		t.Fatal("expected downloading=false initially")
+	}
+}
+
 func putMetadata(metadata types.Metadata, path string) error {
 	c := session.Config{
 		Type: "boltdb",

--- a/detector/vuls2/export_test.go
+++ b/detector/vuls2/export_test.go
@@ -2,6 +2,7 @@ package vuls2
 
 var (
 	ShouldDownload = shouldDownload
+	MustFetchSync  = mustFetchSync
 
 	PreConvertPkgs   = preConvertPkgs
 	PreConvertCPEs   = preConvertCPEs
@@ -19,3 +20,17 @@ var (
 )
 
 type Source source
+
+// BgFetchDownloading exposes the downloading state for tests.
+func BgFetchDownloading() bool {
+	bgFetch.mu.Lock()
+	defer bgFetch.mu.Unlock()
+	return bgFetch.downloading
+}
+
+// ResetBgFetch resets the background fetch state between tests.
+func ResetBgFetch() {
+	bgFetch.mu.Lock()
+	bgFetch.downloading = false
+	bgFetch.mu.Unlock()
+}


### PR DESCRIPTION
As discussed in https://github.com/future-architect/vuls/discussions/2613 , vuls2 has no limit on concurrent download when multiple HTTP requests arrive while the vuls2 database is stale, each one independently triggered a full download from the OCI registry. This wasted bandwidth, disk and I/O without any coordination.

This introduce a single-flight *async background fetch mechanism*: the first request that detects a stale DB spawns an async goroutine to download the update while immediately serving from the current (stale) DB. All concurrent requests that arrive while the download is in flight skip the fetch and use the existing DB.

This does not fix startup download (which will be part of another PR)

Safety guarantees are maintained: if the background fetch fails, temp files are cleaned up by the upstream fetch library and the lock is released so the next request can retry.


***Is this ready for review?:*** YES

