### PR TITLE
Download vuls2 database (if enabled) on startup

### DIFF
--- a/detector/vuls2/db.go
+++ b/detector/vuls2/db.go
@@ -1,6 +1,7 @@
 package vuls2
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -32,9 +33,17 @@ var (
 // a background goroutine and immediately falls through to use the current
 // (stale) DB. Subsequent requests that arrive while the fetch is in flight
 // skip the download entirely.
+//
+// It also tracks whether the initial startup fetch has completed, allowing
+// the server's /health and /vuls endpoints to report readiness.
 type backgroundFetch struct {
 	mu          sync.Mutex
 	downloading bool
+
+	// initialDone is closed once the startup fetch completes (success or
+	// failure). A nil channel means no startup fetch was requested.
+	initialDone chan struct{}
+	initialErr  error
 }
 
 func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, error) {
@@ -217,4 +226,104 @@ func (bf *backgroundFetch) triggerAsync(vuls2Conf config.Vuls2Conf, noProgress b
 			logging.Log.Infof("Background vuls2 db fetch completed successfully")
 		}
 	}()
+}
+
+// StartInitialFetch triggers a one-time background download of the vuls2 DB at
+// server startup. It fills in the default repository/path just like openSession
+// does. The /health endpoint reports 503 until the download finishes. If the DB
+// already exists with a valid schema, the initial fetch is considered done
+// immediately and a normal background refresh is triggered instead.
+func StartInitialFetch(vuls2Conf config.Vuls2Conf, noProgress bool) {
+	if vuls2Conf.Repository == "" {
+		sv, err := session.SchemaVersion("boltdb")
+		if err != nil {
+			logging.Log.Warnf("StartInitialFetch: failed to get schema version: %+v", err)
+			return
+		}
+		vuls2Conf.Repository = fmt.Sprintf("%s:%d", defaultRegistory, sv)
+	}
+	if vuls2Conf.Path == "" {
+		vuls2Conf.Path = DefaultPath
+	}
+
+	syncRequired, err := mustFetchSync(vuls2Conf.Path)
+	if err != nil {
+		logging.Log.Warnf("StartInitialFetch: failed to check db state: %+v", err)
+		return
+	}
+
+	if !syncRequired {
+		// DB already usable — mark ready immediately, trigger a background
+		// refresh for staleness (same as a normal request would).
+		bgFetch.mu.Lock()
+		bgFetch.initialDone = make(chan struct{})
+		close(bgFetch.initialDone)
+		bgFetch.mu.Unlock()
+
+		willDownload, _ := shouldDownload(vuls2Conf, time.Now())
+		if willDownload {
+			bgFetch.triggerAsync(vuls2Conf, noProgress)
+		}
+		return
+	}
+
+	// DB doesn't exist or schema mismatch — download in background and mark
+	// not-ready until complete.
+	bgFetch.mu.Lock()
+	bgFetch.initialDone = make(chan struct{})
+	bgFetch.downloading = true
+	bgFetch.mu.Unlock()
+
+	logging.Log.Infof("Starting initial vuls2 db download. repository: %s", vuls2Conf.Repository)
+	go func() {
+		defer func() {
+			bgFetch.mu.Lock()
+			bgFetch.downloading = false
+			close(bgFetch.initialDone)
+			bgFetch.mu.Unlock()
+		}()
+
+		if err := fetch.Fetch(fetch.WithRepository(vuls2Conf.Repository), fetch.WithDBPath(vuls2Conf.Path), fetch.WithNoProgress(noProgress)); err != nil {
+			logging.Log.Errorf("Initial vuls2 db fetch failed: %+v", err)
+			bgFetch.mu.Lock()
+			bgFetch.initialErr = err
+			bgFetch.mu.Unlock()
+		} else {
+			logging.Log.Infof("Initial vuls2 db fetch completed successfully")
+		}
+	}()
+}
+
+// Ready reports whether the vuls2 DB is available for serving requests.
+// It returns false with a descriptive message while the initial startup
+// download is still in progress.
+func Ready() (ok bool, msg string) {
+	bgFetch.mu.Lock()
+	done := bgFetch.initialDone
+	bgFetch.mu.Unlock()
+
+	if done == nil {
+		// No startup fetch was requested (e.g. skipUpdate or not configured).
+		return true, "ok"
+	}
+
+	select {
+	case <-done:
+		bgFetch.mu.Lock()
+		err := bgFetch.initialErr
+		bgFetch.mu.Unlock()
+		if err != nil {
+			return false, fmt.Sprintf("initial vuls2 db fetch failed: %v", err)
+		}
+		return true, "ok"
+	default:
+		return false, "downloading vuls2"
+	}
+}
+
+// Downloading reports whether a background fetch is currently in progress.
+func Downloading() bool {
+	bgFetch.mu.Lock()
+	defer bgFetch.mu.Unlock()
+	return bgFetch.downloading
 }

--- a/detector/vuls2/db.go
+++ b/detector/vuls2/db.go
@@ -3,6 +3,7 @@ package vuls2
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -22,7 +23,19 @@ var (
 		wd, _ := os.Getwd()
 		return filepath.Join(wd, "vuls.db")
 	}()
+
+	bgFetch backgroundFetch
 )
+
+// backgroundFetch coordinates asynchronous DB downloads so that at most one
+// fetch runs at a time. When a request determines the DB is stale it triggers
+// a background goroutine and immediately falls through to use the current
+// (stale) DB. Subsequent requests that arrive while the fetch is in flight
+// skip the download entirely.
+type backgroundFetch struct {
+	mu          sync.Mutex
+	downloading bool
+}
 
 func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, error) {
 	willDownload, err := shouldDownload(vuls2Conf, time.Now())
@@ -31,9 +44,21 @@ func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, 
 	}
 
 	if willDownload {
-		logging.Log.Infof("Fetching vuls2 db. repository: %s", vuls2Conf.Repository)
-		if err := fetch.Fetch(fetch.WithRepository(vuls2Conf.Repository), fetch.WithDBPath(vuls2Conf.Path), fetch.WithNoProgress(noProgress)); err != nil {
-			return nil, xerrors.Errorf("Failed to fetch vuls2 db. err: %w", err)
+		syncRequired, err := mustFetchSync(vuls2Conf.Path)
+		if err != nil {
+			return nil, xerrors.Errorf("Failed to check db state. err: %w", err)
+		}
+
+		if syncRequired {
+			// DB does not exist or has incompatible schema — must download synchronously.
+			logging.Log.Infof("Fetching vuls2 db (sync). repository: %s", vuls2Conf.Repository)
+			if err := fetch.Fetch(fetch.WithRepository(vuls2Conf.Repository), fetch.WithDBPath(vuls2Conf.Path), fetch.WithNoProgress(noProgress)); err != nil {
+				return nil, xerrors.Errorf("Failed to fetch vuls2 db. err: %w", err)
+			}
+		} else {
+			// DB exists with correct schema but is stale — trigger a background
+			// refresh and continue with the current version.
+			bgFetch.triggerAsync(vuls2Conf, noProgress)
 		}
 	}
 
@@ -72,6 +97,43 @@ func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, 
 		Options:   session.StorageOptions{BoltDB: &bolt.Options{ReadOnly: true}},
 		WithCache: true,
 	}, nil
+}
+
+// mustFetchSync returns true when the DB cannot be used as-is and a
+// synchronous download is required: either the file does not exist, or it
+// exists but its schema version does not match the expected one.
+func mustFetchSync(dbpath string) (bool, error) {
+	if _, err := os.Stat(dbpath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+		return false, xerrors.Errorf("Failed to stat db. err: %w", err)
+	}
+
+	sv, err := session.SchemaVersion("boltdb")
+	if err != nil {
+		return false, xerrors.Errorf("Failed to get schema version. err: %w", err)
+	}
+
+	sesh, err := (&session.Config{
+		Type:    "boltdb",
+		Path:    dbpath,
+		Options: session.StorageOptions{BoltDB: &bolt.Options{ReadOnly: true}},
+	}).New()
+	if err != nil {
+		return true, nil
+	}
+	if err := sesh.Storage().Open(); err != nil {
+		return true, nil
+	}
+	defer sesh.Storage().Close()
+
+	metadata, err := sesh.Storage().GetMetadata()
+	if err != nil || metadata == nil {
+		return true, nil
+	}
+
+	return metadata.SchemaVersion != sv, nil
 }
 
 func shouldDownload(vuls2Conf config.Vuls2Conf, now time.Time) (bool, error) {
@@ -127,4 +189,32 @@ func shouldDownload(vuls2Conf config.Vuls2Conf, now time.Time) (bool, error) {
 		return false, nil
 	}
 	return metadata.LastModified.Add(6 * time.Hour).Before(now), nil
+}
+
+// triggerAsync starts a background fetch if no download is already in progress.
+// It returns immediately in all cases — the caller continues with the current DB.
+func (bf *backgroundFetch) triggerAsync(vuls2Conf config.Vuls2Conf, noProgress bool) {
+	bf.mu.Lock()
+	if bf.downloading {
+		bf.mu.Unlock()
+		logging.Log.Infof("vuls2 db download already in progress, using current db")
+		return
+	}
+	bf.downloading = true
+	bf.mu.Unlock()
+
+	logging.Log.Infof("Fetching vuls2 db in background. repository: %s", vuls2Conf.Repository)
+	go func() {
+		defer func() {
+			bf.mu.Lock()
+			bf.downloading = false
+			bf.mu.Unlock()
+		}()
+
+		if err := fetch.Fetch(fetch.WithRepository(vuls2Conf.Repository), fetch.WithDBPath(vuls2Conf.Path), fetch.WithNoProgress(noProgress)); err != nil {
+			logging.Log.Warnf("Background vuls2 db fetch failed: %+v", err)
+		} else {
+			logging.Log.Infof("Background vuls2 db fetch completed successfully")
+		}
+	}()
 }

--- a/detector/vuls2/db_test.go
+++ b/detector/vuls2/db_test.go
@@ -150,6 +150,62 @@ func Test_shouldDownload(t *testing.T) {
 
 }
 
+func Test_mustFetchSync(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata *types.Metadata
+		want     bool
+	}{
+		{
+			name: "no db file",
+			want: true,
+		},
+		{
+			name: "schema matches",
+			metadata: &types.Metadata{
+				LastModified:  *parse("2024-01-02T00:00:00Z"),
+				SchemaVersion: schemaVersionBoltDB(t),
+			},
+			want: false,
+		},
+		{
+			name: "schema mismatch",
+			metadata: &types.Metadata{
+				LastModified:  *parse("2024-01-02T00:00:00Z"),
+				SchemaVersion: schemaVersionBoltDB(t) + 1,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := t.TempDir()
+			dbpath := filepath.Join(d, "vuls.db")
+			if tt.metadata != nil {
+				if err := putMetadata(*tt.metadata, dbpath); err != nil {
+					t.Fatalf("putMetadata err = %v", err)
+				}
+			}
+			got, err := vuls2.MustFetchSync(dbpath)
+			if err != nil {
+				t.Fatalf("mustFetchSync() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("mustFetchSync() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_backgroundFetch_singleFlight(t *testing.T) {
+	vuls2.ResetBgFetch()
+	defer vuls2.ResetBgFetch()
+
+	if vuls2.BgFetchDownloading() {
+		t.Fatal("expected downloading=false initially")
+	}
+}
+
 func putMetadata(metadata types.Metadata, path string) error {
 	c := session.Config{
 		Type: "boltdb",

--- a/detector/vuls2/db_test.go
+++ b/detector/vuls2/db_test.go
@@ -206,6 +206,53 @@ func Test_backgroundFetch_singleFlight(t *testing.T) {
 	}
 }
 
+func Test_Ready(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func()
+		wantOK  bool
+		wantMsg string
+	}{
+		{
+			name:    "no startup fetch requested",
+			setup:   func() { vuls2.ResetBgFetch() },
+			wantOK:  true,
+			wantMsg: "ok",
+		},
+		{
+			name:    "startup fetch completed successfully",
+			setup:   func() { vuls2.SetInitialDone(nil) },
+			wantOK:  true,
+			wantMsg: "ok",
+		},
+		{
+			name:    "startup fetch in progress",
+			setup:   func() { vuls2.SetInitialInProgress() },
+			wantOK:  false,
+			wantMsg: "downloading vuls2",
+		},
+		{
+			name:   "startup fetch failed",
+			setup:  func() { vuls2.SetInitialDone(xerrors.New("network error")) },
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			defer vuls2.ResetBgFetch()
+
+			ok, msg := vuls2.Ready()
+			if ok != tt.wantOK {
+				t.Errorf("Ready() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if tt.wantMsg != "" && msg != tt.wantMsg {
+				t.Errorf("Ready() msg = %q, want %q", msg, tt.wantMsg)
+			}
+		})
+	}
+}
+
 func putMetadata(metadata types.Metadata, path string) error {
 	c := session.Config{
 		Type: "boltdb",

--- a/detector/vuls2/export_test.go
+++ b/detector/vuls2/export_test.go
@@ -32,5 +32,24 @@ func BgFetchDownloading() bool {
 func ResetBgFetch() {
 	bgFetch.mu.Lock()
 	bgFetch.downloading = false
+	bgFetch.initialDone = nil
+	bgFetch.initialErr = nil
+	bgFetch.mu.Unlock()
+}
+
+// SetInitialDone simulates a completed startup fetch for testing.
+func SetInitialDone(err error) {
+	bgFetch.mu.Lock()
+	bgFetch.initialDone = make(chan struct{})
+	close(bgFetch.initialDone)
+	bgFetch.initialErr = err
+	bgFetch.mu.Unlock()
+}
+
+// SetInitialInProgress simulates a startup fetch still in progress.
+func SetInitialInProgress() {
+	bgFetch.mu.Lock()
+	bgFetch.initialDone = make(chan struct{})
+	bgFetch.downloading = true
 	bgFetch.mu.Unlock()
 }

--- a/detector/vuls2/export_test.go
+++ b/detector/vuls2/export_test.go
@@ -2,6 +2,7 @@ package vuls2
 
 var (
 	ShouldDownload = shouldDownload
+	MustFetchSync  = mustFetchSync
 
 	PreConvertPkgs   = preConvertPkgs
 	PreConvertCPEs   = preConvertCPEs
@@ -19,3 +20,17 @@ var (
 )
 
 type Source source
+
+// BgFetchDownloading exposes the downloading state for tests.
+func BgFetchDownloading() bool {
+	bgFetch.mu.Lock()
+	defer bgFetch.mu.Unlock()
+	return bgFetch.downloading
+}
+
+// ResetBgFetch resets the background fetch state between tests.
+func ResetBgFetch() {
+	bgFetch.mu.Lock()
+	bgFetch.downloading = false
+	bgFetch.mu.Unlock()
+}

--- a/server/server.go
+++ b/server/server.go
@@ -27,6 +27,11 @@ type VulsHandler struct {
 
 // ServeHTTP is http handler
 func (h VulsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if ok, msg := vuls2.Ready(); !ok {
+		http.Error(w, msg, http.StatusServiceUnavailable)
+		return
+	}
+
 	var err error
 	r := models.ScanResult{ScannedCves: models.VulnInfos{}}
 

--- a/subcmds/server.go
+++ b/subcmds/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/subcommands"
 
 	"github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/detector/vuls2"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/server"
 )
@@ -106,11 +107,19 @@ func (p *ServerCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...any) subcom
 		return subcommands.ExitUsageError
 	}
 
+	if !config.Conf.Vuls2.SkipUpdate {
+		vuls2.StartInitialFetch(config.Conf.Vuls2, config.Conf.NoProgress)
+	}
+
 	http.Handle("/vuls", server.VulsHandler{
 		ToLocalFile: p.toLocalFile,
 	})
 	http.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
-		if _, err := fmt.Fprintf(w, "ok"); err != nil {
+		ok, msg := vuls2.Ready()
+		if !ok {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+		if _, err := fmt.Fprintf(w, "%s", msg); err != nil {
 			logging.Log.Errorf("Failed to print server health. err: %+v", err)
 		}
 	})


### PR DESCRIPTION
Note : This PR is based on https://github.com/future-architect/vuls/pull/2617 

The issue it solves is that with current behaviour, on startup : 
* vuls2 database is not fetched 
* the healthcheck becomes ready
* When first bunch of requests are made, each one starts a new download (which takes more than the client can wait)

The new behavior is : 

On server startup, if vuls2 is configured and skipUpdate is not set,
trigger a background download of the database immediately. Until the
download completes:

- /health returns 503 with body "downloading vuls2"
- /vuls returns 503 and does not trigger a redundant download

Once the initial fetch succeeds, both endpoints resume normal operation.
If the DB already exists with a valid schema at startup, readiness is
immediate and only a background staleness refresh is triggered.

This ensures Kubernetes/load-balancer health checks keep the server out
of rotation until it can actually serve vulnerability data, while
avoiding thundering-herd downloads from concurrent requests.