### PR TITLE
feat(server): log scan request received before vulnerability detection

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -62,6 +62,8 @@ func (h VulsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	logging.Log.Infof("%s: Scan request received. Detecting vulnerabilities...", r.FormatServerName())
+
 	// Share one lazily-opened vuls2 db session across this request's package
 	// detection and the enrichment that follows, so the read cache detection
 	// warms is reused by enrichment rather than opened and rebuilt twice.


### PR DESCRIPTION
Log an informational message in VulsHandler.ServeHTTP when a scan request is received, prior to starting package vulnerability detection and CVE data enrichment.