### PR TITLE
fix(detector/vuls2): report NVD and VulnCheck CVSS per source, not whichever sorts first

### DIFF
--- a/detector/vuls2/testdata/fixtures/enrich/nvd-feed-cve-v2/data/CVE-2014-0160.json
+++ b/detector/vuls2/testdata/fixtures/enrich/nvd-feed-cve-v2/data/CVE-2014-0160.json
@@ -15,6 +15,15 @@
 							"base_score": 7.5,
 							"base_severity": "HIGH"
 						}
+					},
+					{
+						"type": "cvss_v31",
+						"source": "openssl-security@openssl.org",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+							"base_score": 5.3,
+							"base_severity": "MEDIUM"
+						}
 					}
 				],
 				"cwe": [
@@ -22,6 +31,12 @@
 						"source": "nvd@nist.gov",
 						"cwe": [
 							"CWE-125"
+						]
+					},
+					{
+						"source": "openssl-security@openssl.org",
+						"cwe": [
+							"CWE-126"
 						]
 					}
 				],

--- a/detector/vuls2/vendor.go
+++ b/detector/vuls2/vendor.go
@@ -1251,9 +1251,11 @@ func splitCveContentBySource(base models.CveContent, ss []severityTypes.Severity
 		cc.Cvss40Severity = cvss40.Severity
 		cc.CweIDs = b.cweIDs
 		if source != "" {
-			// Copy rather than mutate: base.Optional is shared by every entry.
-			o := make(map[string]string, len(base.Optional)+1)
-			maps.Copy(o, base.Optional)
+			// Clone rather than mutate: base.Optional is shared by every entry.
+			o := maps.Clone(base.Optional)
+			if o == nil {
+				o = make(map[string]string)
+			}
 			o["source"] = source
 			cc.Optional = o
 		}

--- a/detector/vuls2/vendor.go
+++ b/detector/vuls2/vendor.go
@@ -3,6 +3,7 @@ package vuls2
 import (
 	"cmp"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ import (
 
 	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
 	advisoryTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/advisory"
+	cweTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/cwe"
 	criterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion"
 	noneexistcriterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/noneexistcriterion"
 	vcAffectedRangeTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/range"
@@ -1186,6 +1188,80 @@ func toVuls0Confidence(e ecosystemTypes.Ecosystem, s sourceTypes.SourceID, sd so
 	}
 }
 
+// splitCveContentBySource expands base into one CveContent per severity/CWE
+// source. NVD (and VulnCheck's NVD++ mirror) publish both the CNA's metrics and
+// their own analysis for the same CVE, distinguished only by
+// severityTypes.Severity.Source; collapsing them into a single CveContent keeps
+// whichever the source-ordered severity sort happens to put first, which
+// depends on the CNA's source identifier rather than on any preference. Each
+// returned entry keeps base's shared fields (title, summary, references, source
+// link, dates) and carries only its own source's CVSS and CWE IDs, labelled by
+// Optional["source"] — the shape go-cve-dictionary's ConvertNvdToModel /
+// ConvertVulncheckToModel produced before NVD and VulnCheck moved to the vuls2
+// DB. base is returned as-is when there is neither severity nor CWE to
+// attribute, so a content without metrics is still reported.
+//
+// toCvss selects the CVSS of one source's severities; callers pass the selector
+// matching their path (enrichCvss for the enrich passes, toCvss for the CPE
+// detection path) so the split changes only the grouping, not the selection.
+func splitCveContentBySource(base models.CveContent, ss []severityTypes.Severity, cwes []cweTypes.CWE, toCvss func([]severityTypes.Severity) (v2.CVSSv2, v31.CVSSv31, v40.CVSSv40)) []models.CveContent {
+	type bySource struct {
+		severities []severityTypes.Severity
+		cweIDs     []string
+	}
+	bs := make(map[string]*bySource)
+	get := func(source string) *bySource {
+		b, ok := bs[source]
+		if !ok {
+			b = &bySource{}
+			bs[source] = b
+		}
+		return b
+	}
+	for _, s := range ss {
+		b := get(s.Source)
+		b.severities = append(b.severities, s)
+	}
+	for _, c := range cwes {
+		b := get(c.Source)
+		b.cweIDs = append(b.cweIDs, c.CWE...)
+	}
+	if len(bs) == 0 {
+		return []models.CveContent{base}
+	}
+
+	// Emit in source order so the per-source entries are stable regardless of
+	// map iteration order.
+	sources := slices.Sorted(maps.Keys(bs))
+
+	ccs := make([]models.CveContent, 0, len(sources))
+	for _, source := range sources {
+		b := bs[source]
+		cvss2, cvss3, cvss40 := toCvss(b.severities)
+
+		cc := base
+		cc.Cvss2Score = cvss2.BaseScore
+		cc.Cvss2Vector = cvss2.Vector
+		cc.Cvss2Severity = cvss2.NVDBaseSeverity
+		cc.Cvss3Score = cvss3.BaseScore
+		cc.Cvss3Vector = cvss3.Vector
+		cc.Cvss3Severity = cvss3.BaseSeverity
+		cc.Cvss40Score = cvss40.Score
+		cc.Cvss40Vector = cvss40.Vector
+		cc.Cvss40Severity = cvss40.Severity
+		cc.CweIDs = b.cweIDs
+		if source != "" {
+			// Copy rather than mutate: base.Optional is shared by every entry.
+			o := make(map[string]string, len(base.Optional)+1)
+			maps.Copy(o, base.Optional)
+			o["source"] = source
+			cc.Optional = o
+		}
+		ccs = append(ccs, cc)
+	}
+	return ccs
+}
+
 // enrichCvss extracts CVSS scores from severity data without ecosystem-specific handling.
 func enrichCvss(ss []severityTypes.Severity) (v2.CVSSv2, v31.CVSSv31, v40.CVSSv40) {
 	var (
@@ -1495,13 +1571,14 @@ func enrichRedHatCVE(vi *models.VulnInfo, rootMap map[dataTypes.RootID][]vulnera
 	}
 }
 
-// enrichNVD adds NVD data as CveContent. It mirrors the NVD branch of the CPE
-// detection path (see postConvert) so a CVE detected by another source carries
-// the same single nvd CveContent — plus NVD exploits/mitigations — that an
-// NVD-detected CVE gets. When the NVD CPE detection already filled that
-// CveContent, the content/exploits/mitigations are left in place; US-CERT
-// alerts are still derived here either way, since the detection path does not
-// populate AlertDict.
+// enrichNVD adds NVD data as CveContent, one entry per CVSS/CWE source (see
+// splitCveContentBySource) so the CNA's metrics and NVD's own analysis are
+// reported separately. It mirrors the NVD branch of the CPE detection path (see
+// postConvert) so a CVE detected by another source carries the same nvd
+// CveContents — plus NVD exploits/mitigations — that an NVD-detected CVE gets.
+// When the NVD CPE detection already filled those CveContents, the
+// content/exploits/mitigations are left in place; US-CERT alerts are still
+// derived here either way, since the detection path does not populate AlertDict.
 func enrichNVD(vi *models.VulnInfo, rootMap map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability) {
 	_, hasContent := vi.CveContents[models.Nvd]
 	for rootID, vulns := range rootMap {
@@ -1529,8 +1606,6 @@ func enrichNVD(vi *models.VulnInfo, rootMap map[dataTypes.RootID][]vulnerability
 				continue
 			}
 
-			cvss2, cvss3, cvss40 := enrichCvss(v.Content.Severity)
-
 			var rs models.References
 			for _, r := range v.Content.References {
 				rs = append(rs, toReference(r.URL))
@@ -1555,29 +1630,13 @@ func enrichNVD(vi *models.VulnInfo, rootMap map[dataTypes.RootID][]vulnerability
 				})
 			}
 
-			vi.CveContents[models.Nvd] = append(vi.CveContents[models.Nvd], models.CveContent{
-				Type:           models.Nvd,
-				CveID:          string(v.Content.ID),
-				Title:          v.Content.Title,
-				Summary:        v.Content.Description,
-				Cvss2Score:     cvss2.BaseScore,
-				Cvss2Vector:    cvss2.Vector,
-				Cvss2Severity:  cvss2.NVDBaseSeverity,
-				Cvss3Score:     cvss3.BaseScore,
-				Cvss3Vector:    cvss3.Vector,
-				Cvss3Severity:  cvss3.BaseSeverity,
-				Cvss40Score:    cvss40.Score,
-				Cvss40Vector:   cvss40.Vector,
-				Cvss40Severity: cvss40.Severity,
-				SourceLink:     cveContentSourceLink(models.Nvd, v, rootID),
-				References:     rs,
-				CweIDs: func() []string {
-					var cs []string //nolint:prealloc
-					for _, cwe := range v.Content.CWE {
-						cs = append(cs, cwe.CWE...)
-					}
-					return cs
-				}(),
+			vi.CveContents[models.Nvd] = append(vi.CveContents[models.Nvd], splitCveContentBySource(models.CveContent{
+				Type:       models.Nvd,
+				CveID:      string(v.Content.ID),
+				Title:      v.Content.Title,
+				Summary:    v.Content.Description,
+				SourceLink: cveContentSourceLink(models.Nvd, v, rootID),
+				References: rs,
 				Published: func() time.Time {
 					if v.Content.Published != nil {
 						return *v.Content.Published
@@ -1590,14 +1649,15 @@ func enrichNVD(vi *models.VulnInfo, rootMap map[dataTypes.RootID][]vulnerability
 					}
 					return time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
 				}(),
-			})
+			}, v.Content.Severity, v.Content.CWE, enrichCvss)...)
 		}
 	}
 }
 
 // enrichVulnCheck adds VulnCheck NVD++ (vulncheck-nist-nvd2) data as CveContent
 // under the models.Vulncheck source. VulnCheck mirrors and enriches NVD, so the
-// content (description, CVSS, CWE, references) parallels enrichNVD's.
+// content (description, CVSS, CWE, references) parallels enrichNVD's, including
+// the one-entry-per-CVSS/CWE-source split (see splitCveContentBySource).
 //
 // The CPE detection path already builds a Vulncheck CveContent for every CVE it
 // detects through VulnCheck's vcVulnerableCPEs; the early return when a
@@ -1613,36 +1673,18 @@ func enrichVulnCheck(vi *models.VulnInfo, rootMap map[dataTypes.RootID][]vulnera
 	}
 	for rootID, vulns := range rootMap {
 		for _, v := range vulns {
-			cvss2, cvss3, cvss40 := enrichCvss(v.Content.Severity)
-
 			var rs models.References
 			for _, r := range v.Content.References {
 				rs = append(rs, toReference(r.URL))
 			}
 
-			vi.CveContents[models.Vulncheck] = append(vi.CveContents[models.Vulncheck], models.CveContent{
-				Type:           models.Vulncheck,
-				CveID:          string(v.Content.ID),
-				Title:          v.Content.Title,
-				Summary:        v.Content.Description,
-				Cvss2Score:     cvss2.BaseScore,
-				Cvss2Vector:    cvss2.Vector,
-				Cvss2Severity:  cvss2.NVDBaseSeverity,
-				Cvss3Score:     cvss3.BaseScore,
-				Cvss3Vector:    cvss3.Vector,
-				Cvss3Severity:  cvss3.BaseSeverity,
-				Cvss40Score:    cvss40.Score,
-				Cvss40Vector:   cvss40.Vector,
-				Cvss40Severity: cvss40.Severity,
-				SourceLink:     cveContentSourceLink(models.Vulncheck, v, rootID),
-				References:     rs,
-				CweIDs: func() []string {
-					var cs []string //nolint:prealloc
-					for _, cwe := range v.Content.CWE {
-						cs = append(cs, cwe.CWE...)
-					}
-					return cs
-				}(),
+			vi.CveContents[models.Vulncheck] = append(vi.CveContents[models.Vulncheck], splitCveContentBySource(models.CveContent{
+				Type:       models.Vulncheck,
+				CveID:      string(v.Content.ID),
+				Title:      v.Content.Title,
+				Summary:    v.Content.Description,
+				SourceLink: cveContentSourceLink(models.Vulncheck, v, rootID),
+				References: rs,
 				Published: func() time.Time {
 					if v.Content.Published != nil {
 						return *v.Content.Published
@@ -1655,7 +1697,7 @@ func enrichVulnCheck(vi *models.VulnInfo, rootMap map[dataTypes.RootID][]vulnera
 					}
 					return time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
 				}(),
-			})
+			}, v.Content.Severity, v.Content.CWE, enrichCvss)...)
 		}
 	}
 }

--- a/detector/vuls2/vendor.go
+++ b/detector/vuls2/vendor.go
@@ -1210,35 +1210,32 @@ func splitCveContentBySource(base models.CveContent, ss []severityTypes.Severity
 		severities []severityTypes.Severity
 		cweIDs     []string
 	}
-	// order holds the groups in the order their source is first seen, so the
-	// entries follow the severity/CWE order the data carries instead of a
-	// second ordering imposed here (CveContents.Sort normalizes the output —
-	// see ScanResult.SortForJSONOutput).
-	var order []*bySource
-	bs := make(map[string]*bySource)
-	get := func(source string) *bySource {
-		b, ok := bs[source]
-		if !ok {
-			b = &bySource{source: source}
-			bs[source] = b
-			order = append(order, b)
+	// Groups stay in the order their source is first seen, so the entries
+	// follow the severity/CWE order the data carries instead of a second
+	// ordering imposed here (CveContents.Sort normalizes the output — see
+	// ScanResult.SortForJSONOutput).
+	var bss []bySource
+	index := func(source string) int {
+		if i := slices.IndexFunc(bss, func(b bySource) bool { return b.source == source }); i >= 0 {
+			return i
 		}
-		return b
+		bss = append(bss, bySource{source: source})
+		return len(bss) - 1
 	}
 	for _, s := range ss {
-		b := get(s.Source)
-		b.severities = append(b.severities, s)
+		i := index(s.Source)
+		bss[i].severities = append(bss[i].severities, s)
 	}
 	for _, c := range cwes {
-		b := get(c.Source)
-		b.cweIDs = append(b.cweIDs, c.CWE...)
+		i := index(c.Source)
+		bss[i].cweIDs = append(bss[i].cweIDs, c.CWE...)
 	}
-	if len(order) == 0 {
+	if len(bss) == 0 {
 		return []models.CveContent{base}
 	}
 
-	ccs := make([]models.CveContent, 0, len(order))
-	for _, b := range order {
+	ccs := make([]models.CveContent, 0, len(bss))
+	for _, b := range bss {
 		source := b.source
 		cvss2, cvss3, cvss40 := toCvss(b.severities)
 

--- a/detector/vuls2/vendor.go
+++ b/detector/vuls2/vendor.go
@@ -1206,15 +1206,22 @@ func toVuls0Confidence(e ecosystemTypes.Ecosystem, s sourceTypes.SourceID, sd so
 // detection path) so the split changes only the grouping, not the selection.
 func splitCveContentBySource(base models.CveContent, ss []severityTypes.Severity, cwes []cweTypes.CWE, toCvss func([]severityTypes.Severity) (v2.CVSSv2, v31.CVSSv31, v40.CVSSv40)) []models.CveContent {
 	type bySource struct {
+		source     string
 		severities []severityTypes.Severity
 		cweIDs     []string
 	}
+	// order holds the groups in the order their source is first seen, so the
+	// entries follow the severity/CWE order the data carries instead of a
+	// second ordering imposed here (CveContents.Sort normalizes the output —
+	// see ScanResult.SortForJSONOutput).
+	var order []*bySource
 	bs := make(map[string]*bySource)
 	get := func(source string) *bySource {
 		b, ok := bs[source]
 		if !ok {
-			b = &bySource{}
+			b = &bySource{source: source}
 			bs[source] = b
+			order = append(order, b)
 		}
 		return b
 	}
@@ -1226,17 +1233,13 @@ func splitCveContentBySource(base models.CveContent, ss []severityTypes.Severity
 		b := get(c.Source)
 		b.cweIDs = append(b.cweIDs, c.CWE...)
 	}
-	if len(bs) == 0 {
+	if len(order) == 0 {
 		return []models.CveContent{base}
 	}
 
-	// Emit in source order so the per-source entries are stable regardless of
-	// map iteration order.
-	sources := slices.Sorted(maps.Keys(bs))
-
-	ccs := make([]models.CveContent, 0, len(sources))
-	for _, source := range sources {
-		b := bs[source]
+	ccs := make([]models.CveContent, 0, len(order))
+	for _, b := range order {
+		source := b.source
 		cvss2, cvss3, cvss40 := toCvss(b.severities)
 
 		cc := base

--- a/detector/vuls2/vendor_test.go
+++ b/detector/vuls2/vendor_test.go
@@ -4,6 +4,10 @@ import (
 	"reflect"
 	"testing"
 
+	cweTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/cwe"
+	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
+	v31 "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v31"
+
 	"github.com/future-architect/vuls/constant"
 	"github.com/future-architect/vuls/models"
 )
@@ -75,6 +79,159 @@ func Test_MacOSCPEs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := MacOSCPEs(tt.args.r); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("MacOSCPEs() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_splitCveContentBySource(t *testing.T) {
+	base := models.CveContent{
+		Type:       models.Nvd,
+		CveID:      "CVE-0000-0000",
+		Summary:    "summary",
+		SourceLink: "https://nvd.nist.gov/vuln/detail/CVE-0000-0000",
+		// Filled from every source by the caller; the split overwrites both
+		// per source.
+		Cvss3Score:  7.5,
+		Cvss3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+		CweIDs:      []string{"CWE-125", "CWE-126"},
+		Optional:    map[string]string{"vuls2-sources": "[]"},
+	}
+
+	type args struct {
+		base models.CveContent
+		ss   []severityTypes.Severity
+		cwes []cweTypes.CWE
+	}
+	tests := []struct {
+		name string
+		args args
+		want []models.CveContent
+	}{
+		{
+			name: "one content per source, ordered by source",
+			args: args{
+				base: base,
+				ss: []severityTypes.Severity{
+					{
+						Type:    severityTypes.SeverityTypeCVSSv31,
+						Source:  "nvd@nist.gov",
+						CVSSv31: &v31.CVSSv31{Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N", BaseScore: 7.5, BaseSeverity: "HIGH"},
+					},
+					{
+						Type:    severityTypes.SeverityTypeCVSSv31,
+						Source:  "openssl-security@openssl.org",
+						CVSSv31: &v31.CVSSv31{Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N", BaseScore: 5.3, BaseSeverity: "MEDIUM"},
+					},
+				},
+				cwes: []cweTypes.CWE{
+					{Source: "nvd@nist.gov", CWE: []string{"CWE-125"}},
+					{Source: "openssl-security@openssl.org", CWE: []string{"CWE-126"}},
+				},
+			},
+			want: []models.CveContent{
+				{
+					Type:          models.Nvd,
+					CveID:         "CVE-0000-0000",
+					Summary:       "summary",
+					SourceLink:    "https://nvd.nist.gov/vuln/detail/CVE-0000-0000",
+					Cvss3Score:    7.5,
+					Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+					Cvss3Severity: "HIGH",
+					CweIDs:        []string{"CWE-125"},
+					Optional:      map[string]string{"vuls2-sources": "[]", "source": "nvd@nist.gov"},
+				},
+				{
+					Type:          models.Nvd,
+					CveID:         "CVE-0000-0000",
+					Summary:       "summary",
+					SourceLink:    "https://nvd.nist.gov/vuln/detail/CVE-0000-0000",
+					Cvss3Score:    5.3,
+					Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+					Cvss3Severity: "MEDIUM",
+					CweIDs:        []string{"CWE-126"},
+					Optional:      map[string]string{"vuls2-sources": "[]", "source": "openssl-security@openssl.org"},
+				},
+			},
+		},
+		{
+			name: "a source with only a CWE keeps its entry without CVSS",
+			args: args{
+				base: base,
+				ss: []severityTypes.Severity{
+					{
+						Type:    severityTypes.SeverityTypeCVSSv31,
+						Source:  "nvd@nist.gov",
+						CVSSv31: &v31.CVSSv31{Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N", BaseScore: 7.5, BaseSeverity: "HIGH"},
+					},
+				},
+				cwes: []cweTypes.CWE{
+					{Source: "psirt@example.com", CWE: []string{"CWE-126"}},
+				},
+			},
+			want: []models.CveContent{
+				{
+					Type:          models.Nvd,
+					CveID:         "CVE-0000-0000",
+					Summary:       "summary",
+					SourceLink:    "https://nvd.nist.gov/vuln/detail/CVE-0000-0000",
+					Cvss3Score:    7.5,
+					Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+					Cvss3Severity: "HIGH",
+					Optional:      map[string]string{"vuls2-sources": "[]", "source": "nvd@nist.gov"},
+				},
+				{
+					Type:       models.Nvd,
+					CveID:      "CVE-0000-0000",
+					Summary:    "summary",
+					SourceLink: "https://nvd.nist.gov/vuln/detail/CVE-0000-0000",
+					CweIDs:     []string{"CWE-126"},
+					Optional:   map[string]string{"vuls2-sources": "[]", "source": "psirt@example.com"},
+				},
+			},
+		},
+		{
+			name: "unattributed severity yields a single unlabelled content",
+			args: args{
+				base: base,
+				ss: []severityTypes.Severity{
+					{
+						Type:    severityTypes.SeverityTypeCVSSv31,
+						CVSSv31: &v31.CVSSv31{Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N", BaseScore: 7.5, BaseSeverity: "HIGH"},
+					},
+				},
+				cwes: []cweTypes.CWE{{CWE: []string{"CWE-125", "CWE-126"}}},
+			},
+			want: []models.CveContent{
+				{
+					Type:          models.Nvd,
+					CveID:         "CVE-0000-0000",
+					Summary:       "summary",
+					SourceLink:    "https://nvd.nist.gov/vuln/detail/CVE-0000-0000",
+					Cvss3Score:    7.5,
+					Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+					Cvss3Severity: "HIGH",
+					CweIDs:        []string{"CWE-125", "CWE-126"},
+					Optional:      map[string]string{"vuls2-sources": "[]"},
+				},
+			},
+		},
+		{
+			name: "nothing to attribute returns base as-is",
+			args: args{base: base},
+			want: []models.CveContent{base},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitCveContentBySource(tt.args.base, tt.args.ss, tt.args.cwes, enrichCvss)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitCveContentBySource() = %#v, want %#v", got, tt.want)
+			}
+			// Optional is shared with the caller's content, so the per-source
+			// label must never be written into it.
+			if _, ok := tt.args.base.Optional["source"]; ok {
+				t.Errorf("splitCveContentBySource() mutated base.Optional: %#v", tt.args.base.Optional)
 			}
 		})
 	}

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -1980,13 +1980,26 @@ func mergeVulnInfo(a, b models.VulnInfo) (models.VulnInfo, error) {
 	}
 	info.DistroAdvisories = slices.Collect(maps.Values(am))
 
-	ccm := make(map[cveContentKey]models.CveContent)
+	// Contents of one type stay in the order they arrive in; like the enrich
+	// passes, this leaves ordering to CveContents.Sort (see
+	// ScanResult.SortForJSONOutput) rather than imposing one of its own.
+	ccs := make(models.CveContents)
 	for _, cciter := range []iter.Seq[[]models.CveContent]{maps.Values(a.CveContents), maps.Values(b.CveContents)} {
 		for cc := range cciter {
 			for _, c := range cc {
-				key := cveContentKey{ctype: c.Type, source: c.Optional["source"]}
-				base, ok := ccm[key]
-				if ok {
+				// A type can hold several contents, one per CVSS/CWE source
+				// (nvd/vulncheck report both the CNA's metrics and their own,
+				// mitre one per CNA/ADP container). Those are separate metric
+				// sets rather than rival reports of the same one, so a content
+				// merges only into one of the same source — merging across
+				// sources would fabricate a set no source published. The
+				// source is empty for every single-content type, which leaves
+				// their merging keyed by type alone as before.
+				i := slices.IndexFunc(ccs[c.Type], func(e models.CveContent) bool {
+					return e.Optional["source"] == c.Optional["source"]
+				})
+				if i >= 0 {
+					base := ccs[c.Type][i]
 					var src1 []source
 					if err := json.Unmarshal([]byte(base.Optional["vuls2-sources"]), &src1); err != nil {
 						return models.VulnInfo{}, xerrors.Errorf("Failed to unmarshal sources. err: %w", err)
@@ -2092,37 +2105,16 @@ func mergeVulnInfo(a, b models.VulnInfo) (models.VulnInfo, error) {
 					}
 					merged.Optional["vuls2-sources"] = string(bs)
 
-					base = merged
+					ccs[c.Type][i] = merged
 				} else {
-					base = c
+					ccs[c.Type] = append(ccs[c.Type], c)
 				}
-				ccm[key] = base
 			}
 		}
-	}
-	ccs := make(models.CveContents)
-	// Sorted so the per-source entries of one type keep a stable order
-	// regardless of map iteration.
-	for _, key := range slices.SortedFunc(maps.Keys(ccm), func(x, y cveContentKey) int {
-		return cmp.Or(cmp.Compare(x.ctype, y.ctype), cmp.Compare(x.source, y.source))
-	}) {
-		ccs[key.ctype] = append(ccs[key.ctype], ccm[key])
 	}
 	info.CveContents = ccs
 
 	return info, nil
-}
-
-// cveContentKey identifies a CveContent within one CVE. A type can hold
-// several contents, one per CVSS/CWE source (nvd/vulncheck report both the
-// CNA's metrics and their own, mitre one per CNA/ADP container), and those are
-// separate metric sets rather than rival reports of the same one — merging
-// across sources would fabricate a content no source published, so the source
-// is part of the identity. It is empty for every single-content type, which
-// keeps their merging keyed by type alone as before.
-type cveContentKey struct {
-	ctype  models.CveContentType
-	source string
 }
 
 func toReference(ref string) models.Reference {

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -371,15 +371,19 @@ func mergeIntoScannedCves(r *models.ScanResult, vulnInfos models.VulnInfos) {
 			// types), so they cannot collide with each other. A caller-provided
 			// base (or the go-cve-dictionary pass) may already carry the same
 			// type for this CVE, though — vuls2 now emits Nvd/Jvn contents — so
-			// dedup on the (type, CVE, source link) identity before appending,
-			// mirroring the key-based dedup the sibling merges above use, to
-			// avoid repeating a source/link in reports. Reconciling genuinely
-			// conflicting contents of one source (e.g. differing CVSS) is out
-			// of scope: the existing entry is kept.
+			// dedup on the (type, CVE, source link, CVSS/CWE source) identity
+			// before appending, mirroring the key-based dedup the sibling
+			// merges above use, to avoid repeating a source/link in reports.
+			// The CVSS/CWE source belongs in that identity because the
+			// per-source contents of one type (nvd's own analysis and the
+			// CNA's) share a source link, and keying on the link alone would
+			// drop all but the first. Reconciling genuinely conflicting
+			// contents of one source (e.g. differing CVSS) is out of scope: the
+			// existing entry is kept.
 			for ccType, ccs := range vi.CveContents {
 				for _, cc := range ccs {
 					if slices.ContainsFunc(viBase.CveContents[ccType], func(e models.CveContent) bool {
-						return e.Type == cc.Type && e.CveID == cc.CveID && e.SourceLink == cc.SourceLink
+						return e.Type == cc.Type && e.CveID == cc.CveID && e.SourceLink == cc.SourceLink && e.Optional["source"] == cc.Optional["source"]
 					}) {
 						continue
 					}
@@ -1976,11 +1980,12 @@ func mergeVulnInfo(a, b models.VulnInfo) (models.VulnInfo, error) {
 	}
 	info.DistroAdvisories = slices.Collect(maps.Values(am))
 
-	ccm := make(map[models.CveContentType]models.CveContent)
+	ccm := make(map[cveContentKey]models.CveContent)
 	for _, cciter := range []iter.Seq[[]models.CveContent]{maps.Values(a.CveContents), maps.Values(b.CveContents)} {
 		for cc := range cciter {
 			for _, c := range cc {
-				base, ok := ccm[c.Type]
+				key := cveContentKey{ctype: c.Type, source: c.Optional["source"]}
+				base, ok := ccm[key]
 				if ok {
 					var src1 []source
 					if err := json.Unmarshal([]byte(base.Optional["vuls2-sources"]), &src1); err != nil {
@@ -2091,17 +2096,33 @@ func mergeVulnInfo(a, b models.VulnInfo) (models.VulnInfo, error) {
 				} else {
 					base = c
 				}
-				ccm[c.Type] = base
+				ccm[key] = base
 			}
 		}
 	}
 	ccs := make(models.CveContents)
-	for cctype, cc := range ccm {
-		ccs[cctype] = []models.CveContent{cc}
+	// Sorted so the per-source entries of one type keep a stable order
+	// regardless of map iteration.
+	for _, key := range slices.SortedFunc(maps.Keys(ccm), func(x, y cveContentKey) int {
+		return cmp.Or(cmp.Compare(x.ctype, y.ctype), cmp.Compare(x.source, y.source))
+	}) {
+		ccs[key.ctype] = append(ccs[key.ctype], ccm[key])
 	}
 	info.CveContents = ccs
 
 	return info, nil
+}
+
+// cveContentKey identifies a CveContent within one CVE. A type can hold
+// several contents, one per CVSS/CWE source (nvd/vulncheck report both the
+// CNA's metrics and their own, mitre one per CNA/ADP container), and those are
+// separate metric sets rather than rival reports of the same one — merging
+// across sources would fabricate a content no source published, so the source
+// is part of the identity. It is empty for every single-content type, which
+// keeps their merging keyed by type alone as before.
+type cveContentKey struct {
+	ctype  models.CveContentType
+	source string
 }
 
 func toReference(ref string) models.Reference {

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -32,6 +32,9 @@ import (
 	segmentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment"
 	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
 	severityTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity"
+	v2 "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v2"
+	v31 "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v31"
+	v40 "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/cvss/v40"
 	severityVendorTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/severity/vendor"
 	vulnerabilityContentTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/vulnerability/content"
 	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
@@ -1762,49 +1765,64 @@ func walkVulnerabilityDatas(m map[source]sourceData, vds []detectTypes.Vulnerabi
 								}
 							}
 
+							cc := models.CveContent{
+								Type:           cctype,
+								CveID:          string(v.Content.ID),
+								Title:          v.Content.Title,
+								Summary:        v.Content.Description,
+								Cvss2Score:     cvss2.BaseScore,
+								Cvss2Vector:    cvss2.Vector,
+								Cvss2Severity:  cvss2.NVDBaseSeverity,
+								Cvss3Score:     cvss3.BaseScore,
+								Cvss3Vector:    cvss3.Vector,
+								Cvss3Severity:  cvss3.BaseSeverity,
+								Cvss40Score:    cvss40.Score,
+								Cvss40Vector:   cvss40.Vector,
+								Cvss40Severity: cvss40.Severity,
+								SourceLink:     cveContentSourceLink(cctype, v, src.RootID),
+								References:     rs,
+								CweIDs: func() []string {
+									var cs []string
+									for _, cwe := range v.Content.CWE {
+										cs = append(cs, cwe.CWE...)
+									}
+									return cs
+								}(),
+								Published: func() time.Time {
+									if v.Content.Published != nil {
+										return *v.Content.Published
+									}
+									return time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
+								}(),
+								LastModified: func() time.Time {
+									if v.Content.Modified != nil {
+										return *v.Content.Modified
+									}
+									return time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
+								}(),
+								Optional: cveContentOptional(src.Segment.Ecosystem, v, string(bs)),
+							}
+
+							// NVD and VulnCheck carry both the CNA's metrics and
+							// their own, so they are reported as one CveContent
+							// per CVSS/CWE source; every other source publishes a
+							// single set and stays a single content.
+							ccs := []models.CveContent{cc}
+							switch cctype {
+							case models.Nvd, models.Vulncheck:
+								ccs = splitCveContentBySource(cc, v.Content.Severity, v.Content.CWE, func(ss []severityTypes.Severity) (v2.CVSSv2, v31.CVSSv31, v40.CVSSv40) {
+									return toCvss(src.Segment.Ecosystem, sid, ss)
+								})
+							default:
+							}
+
 							return models.VulnInfo{
 								CveID:            string(v.Content.ID),
 								Confidences:      models.Confidences{toVuls0Confidence(src.Segment.Ecosystem, src.SourceID, sd)},
 								DistroAdvisories: fdas,
 								Exploits:         exploits,
 								Mitigations:      mitigations,
-								CveContents: models.NewCveContents(models.CveContent{
-									Type:           cctype,
-									CveID:          string(v.Content.ID),
-									Title:          v.Content.Title,
-									Summary:        v.Content.Description,
-									Cvss2Score:     cvss2.BaseScore,
-									Cvss2Vector:    cvss2.Vector,
-									Cvss2Severity:  cvss2.NVDBaseSeverity,
-									Cvss3Score:     cvss3.BaseScore,
-									Cvss3Vector:    cvss3.Vector,
-									Cvss3Severity:  cvss3.BaseSeverity,
-									Cvss40Score:    cvss40.Score,
-									Cvss40Vector:   cvss40.Vector,
-									Cvss40Severity: cvss40.Severity,
-									SourceLink:     cveContentSourceLink(cctype, v, src.RootID),
-									References:     rs,
-									CweIDs: func() []string {
-										var cs []string
-										for _, cwe := range v.Content.CWE {
-											cs = append(cs, cwe.CWE...)
-										}
-										return cs
-									}(),
-									Published: func() time.Time {
-										if v.Content.Published != nil {
-											return *v.Content.Published
-										}
-										return time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
-									}(),
-									LastModified: func() time.Time {
-										if v.Content.Modified != nil {
-											return *v.Content.Modified
-										}
-										return time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC)
-									}(),
-									Optional: cveContentOptional(src.Segment.Ecosystem, v, string(bs)),
-								}),
+								CveContents:      models.NewCveContents(ccs...),
 							}, nil
 						}()
 						if err != nil {

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -10415,6 +10415,7 @@ func Test_postConvert(t *testing.T) {
 								Published:    time.Date(2025, 12, 10, 0, 0, 0, 0, time.UTC),
 								LastModified: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
 								Optional: map[string]string{
+									"source":        "nvd@nist.gov",
 									"vuls2-sources": "[{\"root_id\":\"CVE-2025-54838\",\"source_id\":\"nvd-feed-cve-v2\",\"segment\":{\"ecosystem\":\"cpe\"}}]",
 								},
 							},
@@ -13223,6 +13224,9 @@ func Test_enrich(t *testing.T) {
 			},
 		},
 		{
+			// The fixture carries both NVD's own metrics and the CNA's, so the
+			// enrich pass emits one nvd CveContent per source (ordered by
+			// source), each labelled by Optional["source"].
 			name: "enrich with nvd-feed-cve-v2 data (no pre-existing nvd content)",
 			args: args{
 				vim: models.VulnInfos{
@@ -13253,6 +13257,25 @@ func Test_enrich(t *testing.T) {
 								CweIDs:       []string{"CWE-125"},
 								Published:    time.Date(2014, 4, 7, 0, 0, 0, 0, time.UTC),
 								LastModified: time.Date(2014, 4, 8, 0, 0, 0, 0, time.UTC),
+								Optional:     map[string]string{"source": "nvd@nist.gov"},
+							},
+							{
+								Type:          models.Nvd,
+								CveID:         "CVE-2014-0160",
+								Title:         "OpenSSL Heartbleed",
+								Summary:       "The TLS and DTLS implementations in OpenSSL 1.0.1 before 1.0.1g do not properly handle Heartbeat Extension packets, which allows remote attackers to obtain sensitive information from process memory, aka the Heartbleed bug.",
+								Cvss3Score:    5.3,
+								Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+								Cvss3Severity: "MEDIUM",
+								SourceLink:    "https://nvd.nist.gov/vuln/detail/CVE-2014-0160",
+								References: models.References{
+									{Link: "http://www.us-cert.gov/ncas/alerts/TA14-098A", Source: "MISC"},
+									{Link: "https://nvd.nist.gov/vuln/detail/CVE-2014-0160", Source: "NVD", RefID: "CVE-2014-0160"},
+								},
+								CweIDs:       []string{"CWE-126"},
+								Published:    time.Date(2014, 4, 7, 0, 0, 0, 0, time.UTC),
+								LastModified: time.Date(2014, 4, 8, 0, 0, 0, 0, time.UTC),
+								Optional:     map[string]string{"source": "openssl-security@openssl.org"},
 							},
 						},
 					},
@@ -13492,6 +13515,7 @@ func Test_enrich(t *testing.T) {
 								CweIDs:       []string{"CWE-77"},
 								Published:    time.Date(2024, 4, 12, 0, 0, 0, 0, time.UTC),
 								LastModified: time.Date(2024, 4, 19, 0, 0, 0, 0, time.UTC),
+								Optional:     map[string]string{"source": "nvd@nist.gov"},
 							},
 						},
 					},

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -10244,6 +10244,19 @@ func Test_postConvert(t *testing.T) {
 																	EnvironmentalSeverity: "MEDIUM",
 																}),
 															},
+															{
+																Type:   severityTypes.SeverityTypeCVSSv31,
+																Source: "psirt@fortinet.com",
+																CVSSv31: new(cvssV31Types.CVSSv31{
+																	Vector:       "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H",
+																	BaseScore:    4.9,
+																	BaseSeverity: "MEDIUM",
+																}),
+															},
+														},
+														CWE: []cweTypes.CWE{
+															{Source: "nvd@nist.gov", CWE: []string{"CWE-863"}},
+															{Source: "psirt@fortinet.com", CWE: []string{"CWE-285"}},
 														},
 														References: []referenceTypes.Reference{
 															{Source: "nvd@nist.gov", URL: "https://nvd.nist.gov/vuln/detail/CVE-2025-54838"},
@@ -10399,6 +10412,10 @@ func Test_postConvert(t *testing.T) {
 						},
 					},
 					CveContents: models.CveContents{
+						// Both NVD metric sources survive the merge with the
+						// Fortinet-detected VulnInfo: mergeVulnInfo keys
+						// contents by (type, source), so they are not folded
+						// into one nvd content.
 						models.Nvd: []models.CveContent{
 							{
 								Type:          models.Nvd,
@@ -10412,10 +10429,31 @@ func Test_postConvert(t *testing.T) {
 								References: models.References{
 									{Link: "https://nvd.nist.gov/vuln/detail/CVE-2025-54838", Source: "NVD", RefID: "CVE-2025-54838"},
 								},
+								CweIDs:       []string{"CWE-863"},
 								Published:    time.Date(2025, 12, 10, 0, 0, 0, 0, time.UTC),
 								LastModified: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
 								Optional: map[string]string{
 									"source":        "nvd@nist.gov",
+									"vuls2-sources": "[{\"root_id\":\"CVE-2025-54838\",\"source_id\":\"nvd-feed-cve-v2\",\"segment\":{\"ecosystem\":\"cpe\"}}]",
+								},
+							},
+							{
+								Type:          models.Nvd,
+								CveID:         "CVE-2025-54838",
+								Title:         "Fortinet FortiPortal incorrect authorization",
+								Summary:       "NVD-side description for CVE-2025-54838",
+								Cvss3Score:    4.9,
+								Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:H",
+								Cvss3Severity: "MEDIUM",
+								SourceLink:    "https://nvd.nist.gov/vuln/detail/CVE-2025-54838",
+								References: models.References{
+									{Link: "https://nvd.nist.gov/vuln/detail/CVE-2025-54838", Source: "NVD", RefID: "CVE-2025-54838"},
+								},
+								CweIDs:       []string{"CWE-285"},
+								Published:    time.Date(2025, 12, 10, 0, 0, 0, 0, time.UTC),
+								LastModified: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
+								Optional: map[string]string{
+									"source":        "psirt@fortinet.com",
 									"vuls2-sources": "[{\"root_id\":\"CVE-2025-54838\",\"source_id\":\"nvd-feed-cve-v2\",\"segment\":{\"ecosystem\":\"cpe\"}}]",
 								},
 							},
@@ -12741,6 +12779,66 @@ func Test_mergeIntoScannedCves(t *testing.T) {
 					},
 					CveContents: models.CveContents{
 						models.Nvd: []models.CveContent{{Type: models.Nvd, CveID: "CVE-2025-1002"}},
+					},
+				},
+			},
+		},
+		{
+			// The per-CVSS-source nvd contents share one source link, so the
+			// dedup identity has to include Optional["source"] — keying on the
+			// link alone would append the first and drop the rest.
+			name: "per-source contents of one type all survive the dedup",
+			args: args{
+				r: models.ScanResult{ScannedCves: models.VulnInfos{
+					"CVE-2025-1003": {
+						CveID:       "CVE-2025-1003",
+						CveContents: models.CveContents{},
+					},
+				}},
+				vulnInfos: models.VulnInfos{
+					"CVE-2025-1003": {
+						CveID: "CVE-2025-1003",
+						CveContents: models.CveContents{
+							models.Nvd: []models.CveContent{
+								{
+									Type:       models.Nvd,
+									CveID:      "CVE-2025-1003",
+									Cvss3Score: 9.8,
+									SourceLink: "https://nvd.nist.gov/vuln/detail/CVE-2025-1003",
+									Optional:   map[string]string{"source": "nvd@nist.gov"},
+								},
+								{
+									Type:       models.Nvd,
+									CveID:      "CVE-2025-1003",
+									Cvss3Score: 7.3,
+									SourceLink: "https://nvd.nist.gov/vuln/detail/CVE-2025-1003",
+									Optional:   map[string]string{"source": "cna@example.com"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: models.VulnInfos{
+				"CVE-2025-1003": {
+					CveID: "CVE-2025-1003",
+					CveContents: models.CveContents{
+						models.Nvd: []models.CveContent{
+							{
+								Type:       models.Nvd,
+								CveID:      "CVE-2025-1003",
+								Cvss3Score: 9.8,
+								SourceLink: "https://nvd.nist.gov/vuln/detail/CVE-2025-1003",
+								Optional:   map[string]string{"source": "nvd@nist.gov"},
+							},
+							{
+								Type:       models.Nvd,
+								CveID:      "CVE-2025-1003",
+								Cvss3Score: 7.3,
+								SourceLink: "https://nvd.nist.gov/vuln/detail/CVE-2025-1003",
+								Optional:   map[string]string{"source": "cna@example.com"},
+							},
+						},
 					},
 				},
 			},

--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -26,7 +26,10 @@ func NewCveContents(conts ...CveContent) CveContents {
 				m[cont.Type] = append(m[cont.Type], cont)
 			}
 		default:
-			m[cont.Type] = []CveContent{cont}
+			// Append rather than replace: one type can legitimately carry
+			// several contents (e.g. the per-CVSS-source nvd entries), and
+			// replacing would keep only the last one passed.
+			m[cont.Type] = append(m[cont.Type], cont)
 		}
 	}
 	return m

--- a/models/cvecontents_test.go
+++ b/models/cvecontents_test.go
@@ -7,6 +7,54 @@ import (
 	"github.com/future-architect/vuls/constant"
 )
 
+func TestNewCveContents(t *testing.T) {
+	tests := []struct {
+		name  string
+		conts []CveContent
+		want  CveContents
+	}{
+		{
+			name: "several contents of one type are all kept",
+			conts: []CveContent{
+				{Type: Nvd, CveID: "CVE-0000-0000", Cvss3Score: 9.8, Optional: map[string]string{"source": "nvd@nist.gov"}},
+				{Type: Nvd, CveID: "CVE-0000-0000", Cvss3Score: 7.3, Optional: map[string]string{"source": "cna@example.com"}},
+			},
+			want: CveContents{
+				Nvd: []CveContent{
+					{Type: Nvd, CveID: "CVE-0000-0000", Cvss3Score: 9.8, Optional: map[string]string{"source": "nvd@nist.gov"}},
+					{Type: Nvd, CveID: "CVE-0000-0000", Cvss3Score: 7.3, Optional: map[string]string{"source": "cna@example.com"}},
+				},
+			},
+		},
+		{
+			name: "jvn contents are deduplicated by source link",
+			conts: []CveContent{
+				{Type: Jvn, CveID: "CVE-0000-0000", SourceLink: "https://jvndb.jvn.jp/ja/contents/2024/JVNDB-2024-000001.html"},
+				{Type: Jvn, CveID: "CVE-0000-0000", SourceLink: "https://jvndb.jvn.jp/ja/contents/2024/JVNDB-2024-000001.html"},
+				{Type: Jvn, CveID: "CVE-0000-0000", SourceLink: "https://jvndb.jvn.jp/ja/contents/2024/JVNDB-2024-000002.html"},
+			},
+			want: CveContents{
+				Jvn: []CveContent{
+					{Type: Jvn, CveID: "CVE-0000-0000", SourceLink: "https://jvndb.jvn.jp/ja/contents/2024/JVNDB-2024-000001.html"},
+					{Type: Jvn, CveID: "CVE-0000-0000", SourceLink: "https://jvndb.jvn.jp/ja/contents/2024/JVNDB-2024-000002.html"},
+				},
+			},
+		},
+		{
+			name:  "no contents",
+			conts: nil,
+			want:  CveContents{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewCveContents(tt.conts...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewCveContents() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCveContents_Except(t *testing.T) {
 	type args struct {
 		exceptCtypes []CveContentType

--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -516,7 +516,8 @@ func (v VulnInfo) Cvss2Scores() (values []CveContentCvss) {
 				}
 				// https://nvd.nist.gov/vuln-metrics/cvss
 				values = append(values, CveContentCvss{
-					Type: ctype,
+					Type:   ctype,
+					Source: cont.Optional["source"],
 					Value: Cvss{
 						Type:     CVSS2,
 						Score:    cont.Cvss2Score,
@@ -541,7 +542,8 @@ func (v VulnInfo) Cvss3Scores() (values []CveContentCvss) {
 				}
 				// https://nvd.nist.gov/vuln-metrics/cvss
 				values = append(values, CveContentCvss{
-					Type: ctype,
+					Type:   ctype,
+					Source: cont.Optional["source"],
 					Value: Cvss{
 						Type:     CVSS3,
 						Score:    cont.Cvss3Score,
@@ -613,7 +615,8 @@ func (v VulnInfo) Cvss40Scores() (values []CveContentCvss) {
 				}
 				// https://nvd.nist.gov/vuln-metrics/cvss
 				values = append(values, CveContentCvss{
-					Type: ctype,
+					Type:   ctype,
+					Source: cont.Optional["source"],
 					Value: Cvss{
 						Type:     CVSS40,
 						Score:    cont.Cvss40Score,
@@ -755,8 +758,22 @@ func (v VulnInfo) PatchStatus(packs Packages) string {
 
 // CveContentCvss has CVSS information
 type CveContentCvss struct {
-	Type  CveContentType `json:"type"`
-	Value Cvss           `json:"value"`
+	Type   CveContentType `json:"type"`
+	Source string         `json:"source,omitempty"`
+	Value  Cvss           `json:"value"`
+}
+
+// Label returns the content type, qualified by the per-source label when the
+// CveContent carries one (e.g. "nvd(nvd@nist.gov)"). One source can publish
+// several metric sets for a CVE — NVD and VulnCheck report both the CNA's and
+// their own, MITRE one per CNA/ADP container — and each becomes its own
+// CveContent, so reports need the source to tell the rows apart. Type alone
+// stays usable as a CveContents key.
+func (c CveContentCvss) Label() string {
+	if c.Source == "" {
+		return string(c.Type)
+	}
+	return fmt.Sprintf("%s(%s)", c.Type, c.Source)
 }
 
 // CvssType Represent the type of CVSS
@@ -842,6 +859,15 @@ func severityToCvssScoreRoughly(severity string) float64 {
 // FormatMaxCvssScore returns Max CVSS Score
 func (v VulnInfo) FormatMaxCvssScore() string {
 	cvss := v.MaxCvssScore()
+	// Not Label(): the type is already parenthesised here, so the source is
+	// listed alongside it rather than nested in a second pair of parens.
+	if cvss.Source != "" {
+		return fmt.Sprintf("%3.1f %s (%s, %s)",
+			cvss.Value.Score,
+			strings.ToUpper(cvss.Value.Severity),
+			cvss.Type,
+			cvss.Source)
+	}
 	return fmt.Sprintf("%3.1f %s (%s)",
 		cvss.Value.Score,
 		strings.ToUpper(cvss.Value.Severity),

--- a/models/vulninfos_test.go
+++ b/models/vulninfos_test.go
@@ -952,7 +952,8 @@ func TestMaxCvssScores(t *testing.T) {
 				},
 			},
 			out: CveContentCvss{
-				Type: Mitre,
+				Type:   Mitre,
+				Source: "CNA",
 				Value: Cvss{
 					Type:     CVSS40,
 					Score:    6.9,
@@ -978,6 +979,37 @@ func TestMaxCvssScores(t *testing.T) {
 		if !reflect.DeepEqual(tt.out, actual) {
 			t.Errorf("\n[%d] expected: %v\n  actual: %v\n", i, tt.out, actual)
 		}
+	}
+}
+
+func TestCveContentCvss_Label(t *testing.T) {
+	tests := []struct {
+		name string
+		in   CveContentCvss
+		want string
+	}{
+		{
+			name: "no source",
+			in:   CveContentCvss{Type: RedHatAPI},
+			want: "redhat_api",
+		},
+		{
+			name: "nvd's own metrics",
+			in:   CveContentCvss{Type: Nvd, Source: "nvd@nist.gov"},
+			want: "nvd(nvd@nist.gov)",
+		},
+		{
+			name: "mitre adp container",
+			in:   CveContentCvss{Type: Mitre, Source: "ADP:CISA-ADP"},
+			want: "mitre(ADP:CISA-ADP)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.in.Label(); got != tt.want {
+				t.Errorf("CveContentCvss.Label() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -1030,6 +1062,29 @@ func TestFormatMaxCvssScore(t *testing.T) {
 				},
 			},
 			out: "9.9 HIGH (redhat)",
+		},
+		{
+			// The max comes from a per-source nvd content, so the source is
+			// named alongside the type.
+			in: VulnInfo{
+				CveContents: CveContents{
+					Nvd: []CveContent{
+						{
+							Type:          Nvd,
+							Cvss3Score:    7.5,
+							Cvss3Severity: "HIGH",
+							Optional:      map[string]string{"source": "nvd@nist.gov"},
+						},
+						{
+							Type:          Nvd,
+							Cvss3Score:    5.3,
+							Cvss3Severity: "MEDIUM",
+							Optional:      map[string]string{"source": "openssl-security@openssl.org"},
+						},
+					},
+				},
+			},
+			out: "7.5 HIGH (nvd, nvd@nist.gov)",
 		},
 	}
 	for i, tt := range tests {
@@ -2080,7 +2135,8 @@ func TestVulnInfo_Cvss40Scores(t *testing.T) {
 			},
 			want: []CveContentCvss{
 				{
-					Type: Mitre,
+					Type:   Mitre,
+					Source: "CNA",
 					Value: Cvss{
 						Type:     CVSS40,
 						Score:    6.9,
@@ -2089,7 +2145,8 @@ func TestVulnInfo_Cvss40Scores(t *testing.T) {
 					},
 				},
 				{
-					Type: Nvd,
+					Type:   Nvd,
+					Source: "cna@vuldb.com",
 					Value: Cvss{
 						Type:     CVSS40,
 						Score:    6.9,
@@ -2142,7 +2199,8 @@ func TestVulnInfo_MaxCvss40Score(t *testing.T) {
 				},
 			},
 			want: CveContentCvss{
-				Type: Mitre,
+				Type:   Mitre,
+				Source: "CNA",
 				Value: Cvss{
 					Type:     CVSS40,
 					Score:    6.9,

--- a/reporter/slack.go
+++ b/reporter/slack.go
@@ -274,12 +274,19 @@ func (w SlackWriter) attachmentText(vinfo models.VulnInfo, cweDict models.CWEDic
 
 		if conts, ok := vinfo.CveContents[cvss.Type]; ok {
 			for _, cont := range conts {
+				// One score belongs to one content: a type can hold several
+				// (the per-CVSS-source nvd/vulncheck/mitre entries), and
+				// linking every one of them would repeat the same score once
+				// per content.
+				if cont.Optional["source"] != cvss.Source {
+					continue
+				}
 				v := fmt.Sprintf("<%s|%s> %s (<%s|%s>)",
 					calcURL,
 					fmt.Sprintf("%3.1f/%s", cvss.Value.Score, cvss.Value.Vector),
 					cvss.Value.Severity,
 					cont.SourceLink,
-					cvss.Type)
+					cvss.Label())
 				vectors = append(vectors, v)
 			}
 		} else {

--- a/reporter/util.go
+++ b/reporter/util.go
@@ -375,17 +375,17 @@ No CVE-IDs are found in updatable packages.
 		data = append(data, []string{"Max Score", vuln.FormatMaxCvssScore()})
 		for _, cvss := range vuln.Cvss40Scores() {
 			if cvssstr := cvss.Value.Format(); cvssstr != "" {
-				data = append(data, []string{string(cvss.Type), cvssstr})
+				data = append(data, []string{cvss.Label(), cvssstr})
 			}
 		}
 		for _, cvss := range vuln.Cvss3Scores() {
 			if cvssstr := cvss.Value.Format(); cvssstr != "" {
-				data = append(data, []string{string(cvss.Type), cvssstr})
+				data = append(data, []string{cvss.Label(), cvssstr})
 			}
 		}
 		for _, cvss := range vuln.Cvss2Scores() {
 			if cvssstr := cvss.Value.Format(); cvssstr != "" {
-				data = append(data, []string{string(cvss.Type), cvssstr})
+				data = append(data, []string{cvss.Label(), cvssstr})
 			}
 		}
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -1010,7 +1010,7 @@ func detailLines() (string, error) {
 	for _, score := range scores {
 		cols = []any{
 			score.Value.Format(),
-			score.Type,
+			score.Label(),
 		}
 		table.AddRow(cols...)
 	}


### PR DESCRIPTION
## What

NVD publishes both the CNA's metrics and its own analysis for one CVE, distinguished only by `severity.Source`, and VulnCheck's NVD++ mirror carries the same pair. Collapsing them into a single `CveContent` kept whichever the source-ordered severity sort happened to put first, so whether a report showed NVD's score or the CNA's depended on the CNA's source identifier:

- a UUID CNA (e.g. `134c704f-...`) sorts before `nvd@nist.gov` → the CNA won
- `security@apache.org` sorts after `nvd@nist.gov` → NVD won

`go-cve-dictionary`'s `ConvertNvdToModel` / `ConvertVulncheckToModel` emitted one `CveContent` per CVSS/CWE source until NVD and VulnCheck moved to the vuls2 DB (851aa34, #2590). This restores that shape.

## Changes

- **`splitCveContentBySource()`**: groups severity/CWE by `Source` and emits one `CveContent` per source (ordered by source), sharing the record-level fields (title, summary, references, source link, dates) and labelled by `Optional["source"]` — the same shape `enrichMitreCVE` already produces for CNA/ADP containers. Applied in `enrichNVD`, `enrichVulnCheck`, and the nvd/vulncheck branches of the CPE detection path, so an NVD-detected CVE and a cross-source-enriched one carry the same contents.
  Red Hat is deliberately left alone: every Red Hat severity is tagged `secalert@redhat.com` (`extract/redhat/{cve,csaf,oval}`), and the Security Data API payload has no NVD field, so there is no second source to attribute.
- **`models.NewCveContents`**: appends instead of replacing, so passing several contents of one type keeps them all rather than only the last. Every existing caller passes at most one content per type, so no behaviour change for them.
- **`CveContentCvss` gains `Source` + `Label()`**: the report table, TUI and Slack rows now read `nvd(nvd@nist.gov)` instead of two indistinguishable `nvd` rows (which is also what MITRE's per-container scores have been rendering as). `Type` stays the bare `CveContentType`, so it remains usable as a `CveContents` key. `FormatMaxCvssScore` lists the source alongside the type rather than nesting parens, and Slack links each score to the content it came from instead of to every content of that type.

```
Max Score                         7.5 HIGH (nvd, nvd@nist.gov)
redhat_api                        5.0/CVSS:3.1/... MEDIUM
nvd(nvd@nist.gov)                 7.5/CVSS:3.1/... HIGH
nvd(openssl-security@openssl.org) 5.3/CVSS:3.1/... MEDIUM
```

## Notes / open points

- `MaxCvssScore` now takes the max across a source's own and the CNA's metrics, which can raise the reported max — and what `-cvss-over` admits — where the CNA scored higher than NVD. Taking the max across sources is the existing principle, so this is not a new rule, but it is a visible change.
- `reporter/syslog.go` keys its kv pairs by type only (`cvss_score_nvd_v3`), so a CVE with both metric sets now emits that key twice. The writer already repeats keys across contents (`cwe_ids` in the `CveContents[Nvd]` loop), so this is left as-is rather than inventing a key naming scheme; happy to fold the source into the key if preferred.

## Tests

- `Test_splitCveContentBySource` (new): per-source split and ordering, CWE-only source, unattributed severity, empty input, and that `base.Optional` is never mutated
- `TestNewCveContents` (new): several contents of one type are kept; JVN source-link dedup preserved
- `TestCveContentCvss_Label` (new)
- `Test_enrich` / `Test_postConvert`: the `CVE-2014-0160` enrich fixture now carries a CNA (`openssl-security@openssl.org`) CVSS/CWE alongside NVD's, so the two-content split is exercised end to end
- `go test ./...` passes (the 6 `scanner` failures are the pre-existing missing integration submodule data), `golangci-lint run` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)