### PR TITLE
chore(deps): bump vuls-data-update to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/CycloneDX/cyclonedx-go v0.11.0
 	github.com/MaineK00n/vuls-data-update v0.0.0-20260731094820-5b6752ad7cb8
-	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260729010730-7c9a9f98c44c
+	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260803023755-41f81556436c
 	github.com/Ullaakut/nmap/v2 v2.2.2
 	github.com/aquasecurity/trivy v0.72.0
 	github.com/aquasecurity/trivy-db v0.0.0-20260629102122-a0049d7ad12f

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/CycloneDX/cyclonedx-go v0.11.0
-	github.com/MaineK00n/vuls-data-update v0.0.0-20260725134449-c38b08335698
+	github.com/MaineK00n/vuls-data-update v0.0.0-20260731094820-5b6752ad7cb8
 	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260729010730-7c9a9f98c44c
 	github.com/Ullaakut/nmap/v2 v2.2.2
 	github.com/aquasecurity/trivy v0.72.0

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/MaineK00n/go-paloalto-version v0.0.0-20260324210858-f043171ba2bf h1:Q
 github.com/MaineK00n/go-paloalto-version v0.0.0-20260324210858-f043171ba2bf/go.mod h1:ELOxzfAd4oAe4niMmoZlSiJwzf1DF+DjNdjsUcuqAR8=
 github.com/MaineK00n/vuls-data-update v0.0.0-20260731094820-5b6752ad7cb8 h1:xrRzyYF9vPxxAMvIFyjXd3OONvOLEHjInTzrh/c0DDs=
 github.com/MaineK00n/vuls-data-update v0.0.0-20260731094820-5b6752ad7cb8/go.mod h1:hGIQnLcmU7TAmmmcawGjjGsgbKk/CahooO5iyC1mclQ=
-github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260729010730-7c9a9f98c44c h1:RbDCzYI9VWF/fUPQxSlqknYpNoi7kvRV011gAc6olZw=
-github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260729010730-7c9a9f98c44c/go.mod h1:d7pcp2pr4jmWhn9OVtTE3tNFkPfIya2egCSmkoQjtBA=
+github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260803023755-41f81556436c h1:PYvS0OWGBIRhq6FdJSuKjwbL2R5p5icGkrmht2zf7Lo=
+github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260803023755-41f81556436c/go.mod h1:ISQrBtx1Uwx/CqwSDOwoTFqwOoJ/i1zVZ3kUNEmO1P8=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc h1:
 github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc/go.mod h1:GNf+Vhnxk8/pW56jsxAeFCBP0VCgVQlLIJ812UnAj9c=
 github.com/MaineK00n/go-paloalto-version v0.0.0-20260324210858-f043171ba2bf h1:QDz92+GEPbIR4HTw2EGNgYqH+T9jxmO/OvFMfY715PE=
 github.com/MaineK00n/go-paloalto-version v0.0.0-20260324210858-f043171ba2bf/go.mod h1:ELOxzfAd4oAe4niMmoZlSiJwzf1DF+DjNdjsUcuqAR8=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260725134449-c38b08335698 h1:WeGgBU0x0iaI8qViFr7Rw6RTqnrlIsXWsFzhO8BtmxY=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260725134449-c38b08335698/go.mod h1:hGIQnLcmU7TAmmmcawGjjGsgbKk/CahooO5iyC1mclQ=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260731094820-5b6752ad7cb8 h1:xrRzyYF9vPxxAMvIFyjXd3OONvOLEHjInTzrh/c0DDs=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260731094820-5b6752ad7cb8/go.mod h1:hGIQnLcmU7TAmmmcawGjjGsgbKk/CahooO5iyC1mclQ=
 github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260729010730-7c9a9f98c44c h1:RbDCzYI9VWF/fUPQxSlqknYpNoi7kvRV011gAc6olZw=
 github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260729010730-7c9a9f98c44c/go.mod h1:d7pcp2pr4jmWhn9OVtTE3tNFkPfIya2egCSmkoQjtBA=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=


### PR DESCRIPTION
Fixes #2622

The scheduled check-enums run flagged enum vocabulary drift: the pinned vuls-data-update did not know the new `RangeType` value `fortinet-fortisiem_windows_agent`. Bumping along the dependency chain:

- **vuls-data-update** `c38b0833` → `5b6752ad` (nightly/main tip, the commit the drift was measured against)
- **vuls2** `7c9a9f98` → `41f81556` (the MaineK00n/vuls2#415 merge commit on vuls2 nightly, which carries the same vuls-data-update bump — pinned by commit hash rather than `@nightly` since the module proxy can lag behind the branch tip)

With both pins raised, the standalone vuls2 binary (nightly DB build) and this repo resolve the identical vocabulary.

## Incoming merged PRs

vuls2 (`7c9a9f98..41f81556`):
- MaineK00n/vuls2#415 chore(deps): bump vuls-data-update for FortiSIEM Windows Agent RangeType

vuls-data-update (`c38b0833..5b6752ad`):
- MaineK00n/vuls-data-update#895 fix(fetch/rocky/updateinfo): make the fetch robust to real-world repodata
- MaineK00n/vuls-data-update#897 fix(fetch/alma/updateinfo): drain decompressor to verify updateinfo integrity
- MaineK00n/vuls-data-update#898 fix(fetch/rocky/updateinfo): drain decompressor to verify updateinfo integrity
- MaineK00n/vuls-data-update#899 feat(fetch/nvd/api/cvehistory): add CVE change history fetcher
- MaineK00n/vuls-data-update#900 feat(fetch/openssl/secjson): add OpenSSL security advisory JSON fetcher
- MaineK00n/vuls-data-update#901 fix(extract/fortinet): add FortiSIEMWindowsAgent to the product whitelist — the source of the new enum value

## Verification

- `GOWORK=off GOEXPERIMENT=jsonv2 go run .../tools/print-enums` (pinned) vs `@5b6752ad` (nightly): identical — the check-enums diff is now empty
- `GOWORK=off go build ./...` and `GOWORK=off go test ./...`: pass (re-run after the vuls2 bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)