### PR TITLE
ci(check-enums): include a remediation playbook in drift issues

### DIFF
--- a/.github/workflows/check-enums.yml
+++ b/.github/workflows/check-enums.yml
@@ -117,9 +117,9 @@ jobs:
 
           Bump along the dependency chain, upstream first. Bumping vuls-data-update here alone is not enough: the standalone vuls2 binary (and the nightly DB build in vulsio/vuls-data-db) resolves vuls-data-update via vuls2's own go.mod, so it would keep skipping data carrying the new values.
 
-          1. In MaineK00n/vuls2: `go get github.com/MaineK00n/vuls-data-update@<nightly commit above> && go mod tidy`, test, PR, merge.
+          1. In MaineK00n/vuls2: `go get github.com/MaineK00n/vuls-data-update@$NIGHTLY && go mod tidy`, test, PR, merge.
           2. Here: `go get github.com/MaineK00n/vuls2@main && go mod tidy` — module graph resolution raises the direct vuls-data-update requirement to the same version. Open a PR with `Fixes #<this issue>`.
-          3. Verify parity before pushing: `GOEXPERIMENT=jsonv2 go run github.com/MaineK00n/vuls-data-update/tools/print-enums` for the pinned version vs `...@<nightly commit above>` — the diff must be empty (or re-run this workflow via workflow_dispatch on the PR branch).
+          3. Verify parity before pushing: `GOEXPERIMENT=jsonv2 go run github.com/MaineK00n/vuls-data-update/tools/print-enums` for the pinned version vs `...@$NIGHTLY` — the diff must be empty (or re-run this workflow via workflow_dispatch on the PR branch).
 
           In each bump PR, list the incoming merged PRs (`gh api 'repos/MaineK00n/<repo>/compare/<old>...<new>' --jq '.commits[].commit.message | split("\n")[0]'`) so reviewers can see what the bump pulls in.
           BODY_EOF

--- a/.github/workflows/check-enums.yml
+++ b/.github/workflows/check-enums.yml
@@ -98,12 +98,30 @@ jobs:
         run: |
           gh label create enum-drift -R "$GITHUB_REPOSITORY" --force --description "vuls-data-update enum vocabulary drift" --color D93F0B
           if [ -z "$(gh issue list -R "$GITHUB_REPOSITORY" --label enum-drift --state open --json number --jq '.[].number')" ]; then
-            {
-              printf 'The scheduled check-enums run failed: the vuls-data-update pinned in go.mod knows fewer enum values than the nightly branch (compared against commit %s). A dependency bump is due before data produced with the new values reaches detection.\n\n' "$NIGHTLY"
-              printf '%s\n' "\`\`\`diff"
-              printf '%s\n' "$DIFF"
-              printf '%s\n\n' "\`\`\`"
-              printf 'Run: %s\n' "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-            } > /tmp/enum-issue.md
+            # The body template is one quoted heredoc: the markdown is full of
+            # backticks, which an unquoted heredoc would run as command
+            # substitutions. envsubst fills in the dynamic values, restricted
+            # to the explicit list so nothing else that looks like $VAR is
+            # touched.
+            # shellcheck disable=SC2016 # the literal $NAMEs are envsubst's variable list
+            envsubst '$NIGHTLY $DIFF $GITHUB_SERVER_URL $GITHUB_REPOSITORY $GITHUB_RUN_ID' > /tmp/enum-issue.md <<'BODY_EOF'
+          The scheduled check-enums run failed: the vuls-data-update pinned in go.mod knows fewer enum values than the nightly branch (compared against commit $NIGHTLY). A dependency bump is due before data produced with the new values reaches detection.
+
+          ```diff
+          $DIFF
+          ```
+
+          Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+          ## Remediation
+
+          Bump along the dependency chain, upstream first. Bumping vuls-data-update here alone is not enough: the standalone vuls2 binary (and the nightly DB build in vulsio/vuls-data-db) resolves vuls-data-update via vuls2's own go.mod, so it would keep skipping data carrying the new values.
+
+          1. In MaineK00n/vuls2: `go get github.com/MaineK00n/vuls-data-update@<nightly commit above> && go mod tidy`, test, PR, merge.
+          2. Here: `go get github.com/MaineK00n/vuls2@main && go mod tidy` — module graph resolution raises the direct vuls-data-update requirement to the same version. Open a PR with `Fixes #<this issue>`.
+          3. Verify parity before pushing: `GOEXPERIMENT=jsonv2 go run github.com/MaineK00n/vuls-data-update/tools/print-enums` for the pinned version vs `...@<nightly commit above>` — the diff must be empty (or re-run this workflow via workflow_dispatch on the PR branch).
+
+          In each bump PR, list the incoming merged PRs (`gh api 'repos/MaineK00n/<repo>/compare/<old>...<new>' --jq '.commits[].commit.message | split("\n")[0]'`) so reviewers can see what the bump pulls in.
+          BODY_EOF
             gh issue create -R "$GITHUB_REPOSITORY" --title "vuls-data-update enum vocabulary drift" --label enum-drift --assignee MaineK00n,shino --body-file /tmp/enum-issue.md
           fi

--- a/.github/workflows/check-enums.yml
+++ b/.github/workflows/check-enums.yml
@@ -118,7 +118,7 @@ jobs:
           Bump along the dependency chain, upstream first. Bumping vuls-data-update here alone is not enough: the standalone vuls2 binary (and the nightly DB build in vulsio/vuls-data-db) resolves vuls-data-update via vuls2's own go.mod, so it would keep skipping data carrying the new values.
 
           1. In MaineK00n/vuls2: `go get github.com/MaineK00n/vuls-data-update@$NIGHTLY && go mod tidy`, test, PR, merge.
-          2. Here: `go get github.com/MaineK00n/vuls2@main && go mod tidy` — module graph resolution raises the direct vuls-data-update requirement to the same version. Open a PR with `Fixes #<this issue>`.
+          2. Here: `go get github.com/MaineK00n/vuls2@<commit the step-1 merge produced on vuls2 nightly> && go mod tidy` — vuls2 PRs land on its nightly branch; pin the merge commit hash rather than `@nightly`, which resolves through the module proxy and can lag behind the branch tip. Module graph resolution raises the direct vuls-data-update requirement to the same version. Open a PR with `Fixes #<this issue>`.
           3. Verify parity before pushing: `GOEXPERIMENT=jsonv2 go run github.com/MaineK00n/vuls-data-update/tools/print-enums` for the pinned version vs `...@$NIGHTLY` — the diff must be empty (or re-run this workflow via workflow_dispatch on the PR branch).
 
           In each bump PR, list the incoming merged PRs (`gh api 'repos/MaineK00n/<repo>/compare/<old>...<new>' --jq '.commits[].commit.message | split("\n")[0]'`) so reviewers can see what the bump pulls in.


### PR DESCRIPTION
Resolving #2622 showed the fix is a two-step bump along the dependency chain — vuls-data-update in MaineK00n/vuls2 first (the standalone vuls2 binary and the nightly DB build resolve vuls-data-update via vuls2's own go.mod), then vuls2 here, with `go mod tidy` raising the direct vuls-data-update requirement to the same version. None of that is obvious from the auto-filed drift issue, which only states the diff.

This appends a `## Remediation` section to the issue body of the `file-issue` job, so every future drift issue carries its own runbook: the two bump steps, the print-enums parity check, and the convention of listing incoming merged PRs in bump PR descriptions.

While at it, the body generation is unified into a single quoted heredoc rendered with `envsubst` (explicit variable list), replacing the previous printf sequence: the markdown is full of backticks, which an unquoted heredoc would execute as command substitutions, and mixing printf lines with a heredoc read poorly. `envsubst` is part of gettext-base, preinstalled on ubuntu-latest runners.

No behavior change to the diff job or the dedup logic; the issue body is byte-identical up to the new Remediation section.

## Verification

- `actionlint .github/workflows/check-enums.yml`: clean
- Extracted the `run:` script from the YAML and rendered the template with dummy env vars: output is byte-identical to the previous printf-based generation, plus the Remediation section as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)