### PR TITLE
fix(server): own the vuls2 db for the process instead of per request

### DIFF
--- a/detector/vuls2/db.go
+++ b/detector/vuls2/db.go
@@ -1,6 +1,7 @@
 package vuls2
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"time"
@@ -8,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 	"golang.org/x/xerrors"
+	"oras.land/oras-go/v2/registry/remote"
 
 	"github.com/future-architect/vuls/config"
 	"github.com/future-architect/vuls/logging"
@@ -24,7 +26,18 @@ var (
 	}()
 )
 
-func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, error) {
+// newDBConfig downloads or refreshes the db if due, validates its schema
+// version, and returns the session config to open it with.
+//
+// withCache decides whether the returned session carries a read cache. Any
+// session that answers a detection wants one: without it, enrichment re-reads
+// and re-unmarshals the same advisory and vulnerability records once per root
+// that references them, ~60x slower on a 4873-CVE result. The cache is
+// unbounded (a sync.Map that never evicts), so it is only safe on a session
+// whose lifetime is bounded — one server's detection run, or one request. A
+// session meant to outlive those must pass false, which is why SharedDB opens
+// the db without one when it is only checking that the db is usable.
+func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress, withCache bool) (*session.Config, error) {
 	willDownload, err := shouldDownload(vuls2Conf, time.Now())
 	if err != nil {
 		return nil, xerrors.Errorf("Failed to check whether to download vuls2 db. err: %w", err)
@@ -70,8 +83,60 @@ func newDBConfig(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Config, 
 		Type:      "boltdb",
 		Path:      vuls2Conf.Path,
 		Options:   session.StorageOptions{BoltDB: &bolt.Options{ReadOnly: true}},
-		WithCache: true,
+		WithCache: withCache,
 	}, nil
+}
+
+// hasNewerRemote reports whether the repository holds a db other than the one on
+// disk, comparing the manifest digest that fetch recorded in the local db's
+// metadata against the digest the repository's reference resolves to now.
+//
+// shouldDownload can only tell that the local db is old enough to be worth
+// checking: it goes by timestamps, and the nightly db's LastModified is the
+// night it was built, so a db past the staleness window looks due on every
+// check until something replaces it. Downloading on that alone re-fetches
+// gigabytes on every check even when the tag has not moved. Resolving the
+// manifest costs one request, so it is worth asking before spending a download.
+func hasNewerRemote(ctx context.Context, vuls2Conf config.Vuls2Conf) (bool, error) {
+	sesh, err := (&session.Config{
+		Type:    "boltdb",
+		Path:    vuls2Conf.Path,
+		Options: session.StorageOptions{BoltDB: &bolt.Options{ReadOnly: true}},
+	}).New()
+	if err != nil {
+		return false, xerrors.Errorf("Failed to new vuls2 db connection. path: %s, err: %w", vuls2Conf.Path, err)
+	}
+
+	if err := sesh.Storage().Open(); err != nil {
+		return false, xerrors.Errorf("Failed to open vuls2 db. path: %s, err: %w", vuls2Conf.Path, err)
+	}
+	defer sesh.Storage().Close()
+
+	metadata, err := sesh.Storage().GetMetadata()
+	if err != nil {
+		return false, xerrors.Errorf("Failed to get vuls2 db metadata. path: %s, err: %w", vuls2Conf.Path, err)
+	}
+	if metadata == nil || metadata.Digest == nil {
+		// A db that was built locally rather than fetched carries no digest, so
+		// there is nothing to compare it by and the repository's db counts as
+		// the newer one.
+		return true, nil
+	}
+
+	repo, err := remote.NewRepository(vuls2Conf.Repository)
+	if err != nil {
+		return false, xerrors.Errorf("Failed to create client for %s. err: %w", vuls2Conf.Repository, err)
+	}
+	if repo.Reference.Reference == "" {
+		return false, xerrors.Errorf("unexpected repository format. expected: %q, actual: %q", []string{"<repository>@<digest>", "<repository>:<tag>", "<repository>:<tag>@<digest>"}, vuls2Conf.Repository)
+	}
+
+	desc, err := repo.Resolve(ctx, repo.Reference.Reference)
+	if err != nil {
+		return false, xerrors.Errorf("Failed to resolve %s. err: %w", vuls2Conf.Repository, err)
+	}
+
+	return desc.Digest.String() != *metadata.Digest, nil
 }
 
 func shouldDownload(vuls2Conf config.Vuls2Conf, now time.Time) (bool, error) {

--- a/detector/vuls2/db_test.go
+++ b/detector/vuls2/db_test.go
@@ -1,6 +1,7 @@
 package vuls2_test
 
 import (
+	"context"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -183,4 +184,63 @@ func schemaVersionBoltDB(t *testing.T) uint {
 		t.Fatalf("session.SchemaVersion() err: %v", err)
 	}
 	return sv
+}
+
+func Test_hasNewerRemote(t *testing.T) {
+	tests := []struct {
+		name       string
+		digest     *string
+		writeDB    bool
+		repository string
+		want       bool
+		wantErr    bool
+	}{
+		{
+			// A db that was built locally rather than fetched has no digest to
+			// compare, so the repository's db counts as newer and this answers
+			// without reaching the registry.
+			name:       "no digest recorded",
+			writeDB:    true,
+			repository: "ghcr.io/vulsio/vuls-nightly-db:nightly",
+			want:       true,
+		},
+		{
+			name:       "no db file",
+			repository: "ghcr.io/vulsio/vuls-nightly-db:nightly",
+			wantErr:    true,
+		},
+		{
+			name:       "unparsable repository",
+			digest:     func() *string { s := "sha256:a"; return &s }(),
+			writeDB:    true,
+			repository: "not a repository",
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := config.Vuls2Conf{
+				Path:       filepath.Join(t.TempDir(), "vuls.db"),
+				Repository: tt.repository,
+			}
+			if tt.writeDB {
+				if err := putMetadata(types.Metadata{
+					LastModified:  *parse("2024-01-02T00:00:00Z"),
+					Downloaded:    parse("2024-01-02T00:00:00Z"),
+					SchemaVersion: schemaVersionBoltDB(t),
+					Digest:        tt.digest,
+				}, conf.Path); err != nil {
+					t.Fatalf("putMetadata() err = %v", err)
+				}
+			}
+
+			got, err := vuls2.HasNewerRemote(context.Background(), conf)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("hasNewerRemote() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("hasNewerRemote() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/detector/vuls2/export_test.go
+++ b/detector/vuls2/export_test.go
@@ -1,7 +1,18 @@
 package vuls2
 
+import "github.com/MaineK00n/vuls2/pkg/db/session"
+
+// Open exposes Session.open so tests can force the lazy open and inspect what
+// it produced.
+func (s *Session) Open() (*session.Session, error) { return s.open() }
+
+// SkipsUpdate reports whether this Session is barred from downloading a db, so
+// a test can assert that the request path cannot fetch.
+func (s *Session) SkipsUpdate() bool { return s.vuls2Conf.SkipUpdate }
+
 var (
 	ShouldDownload = shouldDownload
+	HasNewerRemote = hasNewerRemote
 
 	PreConvertPkgs   = preConvertPkgs
 	PreConvertCPEs   = preConvertCPEs

--- a/detector/vuls2/shared.go
+++ b/detector/vuls2/shared.go
@@ -1,0 +1,223 @@
+package vuls2
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"golang.org/x/xerrors"
+
+	"github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/logging"
+)
+
+// SharedDB owns the vuls2 db's lifecycle for a server process: it downloads the
+// db, keeps it current in the background, and hands each request a session that
+// can only read what is already on disk.
+//
+// The failure it exists to fix is that fetching used to be request-scoped. A pod
+// that came up with no db started listening immediately, so every request that
+// arrived found the db missing and began its own multi-gigabyte fetch — several
+// at a time, into the same directory, each slow enough to trip the registry's
+// stream limits and start over. Here only Prepare and Run fetch, so a fetch is
+// single-flight and never blocks a request, and the sessions Acquire hands out
+// have SkipUpdate forced, so a request cannot become another thing that
+// downloads a db. Ready says whether there is anything to serve at all, so a
+// request arriving before the first fetch finishes is refused rather than made
+// to wait for it.
+//
+// It deliberately does not hold one db open for requests to share. Opening the
+// db read-only is an mmap of a file the page cache already holds: on a
+// full-size (~11 GB) db it measures ~50µs, nothing beside the seconds a
+// detection takes. Sharing one handle would save that and cost far more,
+// because a session shared across requests cannot carry vuls2's read cache —
+// the cache never evicts, so one that outlives a request grows until the
+// process is OOM-killed. Going without it makes enrichment re-read and
+// re-unmarshal the same advisory and vulnerability records once per root that
+// references them: enriching a 4873-CVE result measured 2.4s with a cache and
+// 150s without. A handle per request, with a cache per request, is both faster
+// and simpler.
+type SharedDB struct {
+	conf       config.Vuls2Conf
+	noProgress bool
+
+	// mu guards ready. Nothing else here is mutable: Prepare and Run are one
+	// goroutine, and requests only read conf.
+	mu    sync.Mutex
+	ready bool
+}
+
+// NewSharedDB returns a SharedDB with no db adopted yet. Nothing is fetched or
+// opened here, so this does not block; the caller is expected to run Prepare and
+// then Run, and to refuse what it cannot serve while Ready is false.
+func NewSharedDB(vuls2Conf config.Vuls2Conf, noProgress bool) (*SharedDB, error) {
+	// Resolve the defaults up front: Reload has to stat and read the metadata of
+	// the very file a request will open, and an empty Path would otherwise send
+	// the two at different files.
+	conf, err := withDefaults(vuls2Conf)
+	if err != nil {
+		return nil, xerrors.Errorf("Failed to apply vuls2 config defaults. err: %w", err)
+	}
+	return &SharedDB{conf: conf, noProgress: noProgress}, nil
+}
+
+// Ready reports whether a db this process has validated is on disk and can be
+// served. Prepare loops until it holds, and Reload uses it to tell a refresh
+// (keep serving what is there) from a first fetch (there is nothing to fall
+// back to).
+func (d *SharedDB) Ready() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.ready
+}
+
+// Acquire returns the db session for one request. The caller owns it and must
+// Close it (defer it). The db is opened lazily, on the first path that queries
+// it, so a request with nothing to detect never opens it at all.
+//
+// SkipUpdate is forced on, which is what keeps fetching off the request path: a
+// server reachable before its first fetch finishes fails the request instead of
+// starting a fetch of its own. The digest is not recorded either — SharedDB
+// recorded it for the db this session is about to open, and concurrent requests
+// writing that global would race the config copy DetectPkgCves makes.
+func (d *SharedDB) Acquire() *Session {
+	conf := d.conf
+	conf.SkipUpdate = true
+	return &Session{vuls2Conf: conf, noProgress: d.noProgress, withCache: true}
+}
+
+// OpenLocal adopts the db that is already on disk, without downloading
+// anything, and fails if there is no usable one there. It opens the db only to
+// check it and to read its digest, and closes it again: requests open their own.
+//
+// This is how a server starts. A db on disk that is merely due for a refresh is
+// still a db worth serving, so checking it first means a process that has one
+// answers requests as soon as it starts, instead of going without answering
+// anything for the length of a multi-gigabyte fetch. Bringing it up to date is
+// then the refresher's job, and happens with requests being served throughout.
+func (d *SharedDB) OpenLocal() error {
+	// SkipUpdate is what tells newDBConfig to open whatever is there and to
+	// refuse rather than download when it is missing or the wrong schema.
+	conf := d.conf
+	conf.SkipUpdate = true
+	return d.adopt(conf)
+}
+
+// Reload brings the db up to date, downloading it if one is due, and adopts it
+// for subsequent requests. The db already on disk keeps serving for the whole
+// fetch, and keeps serving if the fetch fails — a refresh that cannot complete
+// must not take a working db away.
+//
+// Only Prepare and Run call this, so at most one fetch is ever in flight.
+func (d *SharedDB) Reload(ctx context.Context) error {
+	willDownload, err := shouldDownload(d.conf, time.Now())
+	if err != nil {
+		return xerrors.Errorf("Failed to check whether to download vuls2 db. err: %w", err)
+	}
+
+	// With a db already serving, spend a manifest resolve before spending a
+	// download: shouldDownload goes by timestamps alone, so a nightly db that
+	// has not been rebuilt looks due on every check for as long as it lives.
+	// With no db yet there is nothing to compare and nothing to serve either
+	// way, so go straight to fetching one.
+	if willDownload && d.Ready() {
+		switch newer, err := hasNewerRemote(ctx, d.conf); {
+		case err != nil:
+			// A repository this process cannot resolve is one it cannot download
+			// gigabytes from either, so keep serving and retry on the next check
+			// rather than starting a fetch that is unlikely to finish.
+			logging.Log.Warnf("Failed to check for a newer vuls2 db, keeping the current one. err: %+v", err)
+			willDownload = false
+		case !newer:
+			logging.Log.Debugf("vuls2 db is up to date. repository: %s", d.conf.Repository)
+			willDownload = false
+		}
+	}
+
+	if !willDownload {
+		if d.Ready() {
+			// Nothing to fetch and something to serve: there is nothing to do.
+			return nil
+		}
+		return d.OpenLocal()
+	}
+
+	return d.adopt(d.conf)
+}
+
+// adopt opens the db conf points at — downloading it first if conf allows and
+// one is due — records its digest for the reports requests will produce, and
+// marks it ready. The handle is closed again immediately: it exists only to
+// prove the db is usable and to read its metadata.
+func (d *SharedDB) adopt(conf config.Vuls2Conf) error {
+	sesh, digest, err := openSession(conf, d.noProgress, false)
+	if err != nil {
+		return xerrors.Errorf("Failed to open vuls2 db. err: %w", err)
+	}
+	if err := sesh.Storage().Close(); err != nil {
+		logging.Log.Warnf("Failed to close vuls2 db. err: %+v", err)
+	}
+	sesh.Cache().Close()
+
+	// Safe to write here and nowhere else: Prepare and Run are the only callers
+	// and they are one goroutine, and this runs before any request opens the db
+	// it describes.
+	config.Conf.Vuls2.Digest = digest
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.ready = true
+	return nil
+}
+
+// Prepare gets a db ready to serve from and does not return until there is one
+// or ctx is done: it takes whatever is on disk if there is anything usable
+// there, and otherwise downloads one, retrying every retryInterval for as long
+// as that keeps failing.
+//
+// Server mode runs this in the background and reports Ready on its health
+// endpoint meanwhile, so a first start with nothing on disk is reachable and can
+// say why it is not serving, instead of going dark for the length of the fetch.
+func (d *SharedDB) Prepare(ctx context.Context, retryInterval time.Duration) error {
+	err := d.OpenLocal()
+	if err == nil {
+		return nil
+	}
+	logging.Log.Infof("No vuls2 db on disk to serve from, fetching one. err: %s", err)
+
+	for {
+		err := d.Reload(ctx)
+		if err == nil {
+			return nil
+		}
+		logging.Log.Errorf("Failed to prepare vuls2 db, retrying in %s. err: %+v", retryInterval, err)
+
+		select {
+		case <-ctx.Done():
+			return xerrors.Errorf("Failed to prepare vuls2 db. err: %w", ctx.Err())
+		case <-time.After(retryInterval):
+		}
+	}
+}
+
+// Run keeps the db current until ctx is done, re-checking every interval whether
+// a newer one is due. It expects Prepare to have adopted one already, and runs
+// in the background so a refresh never blocks a request.
+//
+// A failure is logged and retried on the next tick rather than propagated: the
+// point of the interval is that a fetch that keeps failing is retried at a
+// bounded rate, instead of being restarted by every request that arrives.
+func (d *SharedDB) Run(ctx context.Context, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := d.Reload(ctx); err != nil {
+				logging.Log.Warnf("Failed to refresh vuls2 db, serving the current one. err: %+v", err)
+			}
+		}
+	}
+}

--- a/detector/vuls2/shared_test.go
+++ b/detector/vuls2/shared_test.go
@@ -1,0 +1,298 @@
+package vuls2_test
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MaineK00n/vuls2/pkg/db/session"
+	"github.com/MaineK00n/vuls2/pkg/db/session/types"
+
+	"github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/detector/vuls2"
+)
+
+// newFixtureDB writes a db carrying digest as its metadata and returns its path,
+// so a test can tell which db it was handed.
+func newFixtureDB(t *testing.T, digest string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "vuls.db")
+	if err := putMetadata(types.Metadata{
+		LastModified:  *parse("2024-01-02T00:00:00Z"),
+		Downloaded:    parse("2024-01-02T00:00:00Z"),
+		SchemaVersion: schemaVersionBoltDB(t),
+		Digest:        &digest,
+	}, path); err != nil {
+		t.Fatalf("putMetadata() err = %v", err)
+	}
+	return path
+}
+
+// digestOf reads the db through sesh, which doubles as an is-it-still-open
+// check: a closed bolt db fails the read instead of serving it.
+func digestOf(t *testing.T, sesh *session.Session) (string, error) {
+	t.Helper()
+
+	metadata, err := sesh.Storage().GetMetadata()
+	if err != nil {
+		return "", err
+	}
+	if metadata == nil || metadata.Digest == nil {
+		t.Fatalf("GetMetadata() digest = nil, want a digest")
+	}
+	return *metadata.Digest, nil
+}
+
+func TestSharedDB_NotReadyBeforeOpen(t *testing.T) {
+	d, err := vuls2.NewSharedDB(config.Vuls2Conf{Path: newFixtureDB(t, "sha256:a"), SkipUpdate: true}, true)
+	if err != nil {
+		t.Fatalf("NewSharedDB() err = %v", err)
+	}
+
+	// A db on disk is not a db this process has checked: until OpenLocal or
+	// Reload validates one, the server has nothing it can promise to serve.
+	if d.Ready() {
+		t.Errorf("Ready() = true before OpenLocal, want false")
+	}
+}
+
+func TestSharedDB_OpenLocal(t *testing.T) {
+	// SkipUpdate is deliberately false and the fixture's LastModified is old
+	// enough that a refresh is due, so a fetch would be attempted if OpenLocal
+	// honoured the staleness rule. It must not: a db that is merely stale is
+	// still one worth serving while the refresher catches up, and this test
+	// would have to reach the registry otherwise.
+	d, err := vuls2.NewSharedDB(config.Vuls2Conf{Path: newFixtureDB(t, "sha256:a")}, true)
+	if err != nil {
+		t.Fatalf("NewSharedDB() err = %v", err)
+	}
+	if err := d.OpenLocal(); err != nil {
+		t.Fatalf("OpenLocal() err = %v", err)
+	}
+
+	if !d.Ready() {
+		t.Errorf("Ready() = false after OpenLocal, want true")
+	}
+
+	sesh := d.Acquire()
+	defer sesh.Close()
+	inner, err := sesh.Open()
+	if err != nil {
+		t.Fatalf("Open() err = %v", err)
+	}
+	got, err := digestOf(t, inner)
+	if err != nil {
+		t.Fatalf("GetMetadata() err = %v", err)
+	}
+	if want := "sha256:a"; got != want {
+		t.Errorf("digest = %v, want %v", got, want)
+	}
+}
+
+func TestSharedDB_OpenLocalWithoutDB(t *testing.T) {
+	// Nothing on disk: OpenLocal has to refuse rather than download, leaving that
+	// decision to Reload, which is the only path allowed to fetch.
+	d, err := vuls2.NewSharedDB(config.Vuls2Conf{Path: filepath.Join(t.TempDir(), "vuls.db")}, true)
+	if err != nil {
+		t.Fatalf("NewSharedDB() err = %v", err)
+	}
+	if err := d.OpenLocal(); err == nil {
+		t.Errorf("OpenLocal() err = nil with no db on disk, want an error")
+	}
+	if d.Ready() {
+		t.Errorf("Ready() = true after a failed OpenLocal, want false")
+	}
+}
+
+// TestSharedDB_AcquireCannotFetch is the guarantee that keeps multi-gigabyte
+// downloads off the request path: whatever the configured db policy, a session
+// handed to a request is barred from fetching.
+func TestSharedDB_AcquireCannotFetch(t *testing.T) {
+	// SkipUpdate false and a db stale enough that shouldDownload would say yes.
+	d, err := vuls2.NewSharedDB(config.Vuls2Conf{Path: newFixtureDB(t, "sha256:a")}, true)
+	if err != nil {
+		t.Fatalf("NewSharedDB() err = %v", err)
+	}
+
+	sesh := d.Acquire()
+	defer sesh.Close()
+	if !sesh.SkipsUpdate() {
+		t.Errorf("Acquire() session SkipUpdate = false, want the request path barred from fetching")
+	}
+
+	// It still opens the stale db, so a request is served rather than refused
+	// while the refresher catches up. Reaching the registry would fail this
+	// test by hanging or erroring instead.
+	if _, err := sesh.Open(); err != nil {
+		t.Errorf("Open() err = %v, want the stale db to be served", err)
+	}
+}
+
+// TestSharedDB_AcquireCarriesCache is what this whole shape exists for: an
+// unshared handle is only worth having because it can carry a read cache, and
+// enrichment measured ~60x slower without one.
+func TestSharedDB_AcquireCarriesCache(t *testing.T) {
+	d, err := vuls2.NewSharedDB(config.Vuls2Conf{Path: newFixtureDB(t, "sha256:a"), SkipUpdate: true}, true)
+	if err != nil {
+		t.Fatalf("NewSharedDB() err = %v", err)
+	}
+
+	sesh := d.Acquire()
+	defer sesh.Close()
+	inner, err := sesh.Open()
+	if err != nil {
+		t.Fatalf("Open() err = %v", err)
+	}
+	if inner.Cache() == nil {
+		t.Errorf("Acquire() session Cache() = nil, want a per-request read cache")
+	}
+}
+
+// TestSharedDB_AcquireIsIndependent checks that one request finishing does not
+// take the db away from another: each holds its own handle.
+func TestSharedDB_AcquireIsIndependent(t *testing.T) {
+	d, err := vuls2.NewSharedDB(config.Vuls2Conf{Path: newFixtureDB(t, "sha256:a"), SkipUpdate: true}, true)
+	if err != nil {
+		t.Fatalf("NewSharedDB() err = %v", err)
+	}
+	if err := d.OpenLocal(); err != nil {
+		t.Fatalf("OpenLocal() err = %v", err)
+	}
+
+	first := d.Acquire()
+	firstInner, err := first.Open()
+	if err != nil {
+		t.Fatalf("Open() err = %v", err)
+	}
+	second := d.Acquire()
+	defer second.Close()
+	secondInner, err := second.Open()
+	if err != nil {
+		t.Fatalf("second Open() err = %v", err)
+	}
+
+	first.Close()
+	if _, err := digestOf(t, secondInner); err != nil {
+		t.Errorf("GetMetadata() after the other request closed err = %v, want this db to stay open", err)
+	}
+	// The one that did close is closed, so a request does not leak its handle
+	// for the rest of the process's life.
+	if _, err := digestOf(t, firstInner); err == nil {
+		t.Errorf("GetMetadata() on the closed db err = nil, want it to be closed")
+	}
+}
+
+func TestSharedDB_Prepare(t *testing.T) {
+	// A db on disk is enough to be ready, so Prepare returns without reaching
+	// the registry even though this db is stale enough for a refresh to be due.
+	d, err := vuls2.NewSharedDB(config.Vuls2Conf{Path: newFixtureDB(t, "sha256:a")}, true)
+	if err != nil {
+		t.Fatalf("NewSharedDB() err = %v", err)
+	}
+	if err := d.Prepare(context.Background(), time.Minute); err != nil {
+		t.Fatalf("Prepare() err = %v", err)
+	}
+
+	if !d.Ready() {
+		t.Errorf("Ready() = false after Prepare, want true")
+	}
+}
+
+func TestSharedDB_PrepareCancelled(t *testing.T) {
+	// Nothing on disk and SkipUpdate to keep the retry loop from downloading:
+	// Prepare has to give up on ctx rather than block a shutdown forever.
+	d, err := vuls2.NewSharedDB(config.Vuls2Conf{Path: filepath.Join(t.TempDir(), "vuls.db"), SkipUpdate: true}, true)
+	if err != nil {
+		t.Fatalf("NewSharedDB() err = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := d.Prepare(ctx, time.Minute); err == nil {
+		t.Errorf("Prepare() err = nil on a cancelled context, want an error")
+	}
+	if d.Ready() {
+		t.Errorf("Ready() = true after a failed Prepare, want false")
+	}
+}
+
+func TestSharedDB_Reload(t *testing.T) {
+	d, err := vuls2.NewSharedDB(config.Vuls2Conf{Path: newFixtureDB(t, "sha256:a"), SkipUpdate: true}, true)
+	if err != nil {
+		t.Fatalf("NewSharedDB() err = %v", err)
+	}
+	if err := d.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload() err = %v", err)
+	}
+
+	if !d.Ready() {
+		t.Errorf("Ready() = false after Reload, want true")
+	}
+
+	// Nothing is due (SkipUpdate) and a db is already adopted, so a second
+	// Reload has nothing to do and must not fail.
+	if err := d.Reload(context.Background()); err != nil {
+		t.Fatalf("second Reload() err = %v", err)
+	}
+
+	sesh := d.Acquire()
+	defer sesh.Close()
+	inner, err := sesh.Open()
+	if err != nil {
+		t.Fatalf("Open() err = %v", err)
+	}
+	got, err := digestOf(t, inner)
+	if err != nil {
+		t.Fatalf("GetMetadata() err = %v", err)
+	}
+	if want := "sha256:a"; got != want {
+		t.Errorf("digest = %v, want %v", got, want)
+	}
+}
+
+func TestSharedDB_ConcurrentAcquire(t *testing.T) {
+	d, err := vuls2.NewSharedDB(config.Vuls2Conf{Path: newFixtureDB(t, "sha256:a"), SkipUpdate: true}, true)
+	if err != nil {
+		t.Fatalf("NewSharedDB() err = %v", err)
+	}
+	if err := d.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload() err = %v", err)
+	}
+
+	// Requests open, read and close their own handles on the same file while
+	// health checks read Ready: under -race, this is what says that giving every
+	// request its own handle is safe. bolt takes a shared lock in read-only mode,
+	// so these opens do not serialise against each other.
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			for range 20 {
+				sesh := d.Acquire()
+				inner, err := sesh.Open()
+				if err != nil {
+					t.Errorf("Open() err = %v", err)
+					sesh.Close()
+					return
+				}
+				if _, err := digestOf(t, inner); err != nil {
+					t.Errorf("GetMetadata() err = %v, want the acquired db to be readable", err)
+				}
+				sesh.Close()
+			}
+		})
+	}
+	for range 4 {
+		wg.Go(func() {
+			for range 50 {
+				if !d.Ready() {
+					t.Errorf("Ready() = false while serving, want true")
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -100,31 +100,43 @@ func DetectCPEs(r *models.ScanResult, cpes []CPE, sesh *Session) error {
 	return detectWith(r, vuls2Scanned, fsToOriginalCPE, noJVNCPEs, sesh)
 }
 
-// Session is a lazily-opened, shared vuls2 db handle scoped to one server's
-// detection and enrichment. The db is opened at most once — on the first path
-// that actually queries it — and reused by every later path, so the read cache
+// Session is a vuls2 db handle scoped to one server's detection and
+// enrichment. Every path of that turn queries the same db, so the read cache
 // that OS-package / CPE detection warms is still warm for the enrichment that
-// immediately follows instead of being discarded and rebuilt. It is opened
-// only when some path genuinely needs it, exactly as the unshared code did:
-// a family that skips vuls2 detection (FreeBSD, pseudo, trivy-scanned, ...)
-// does not open it during detection, but enrichment still opens it when the
-// result carries CVEs (e.g. FreeBSD's pkg-audit findings); a server with
-// nothing to detect and no CVEs to enrich never opens it at all. Create one
-// with NewSession, thread it through DetectPkgs / DetectCPEs /
-// EnrichVulnInfos, and Close it when the server is done. It is not safe for
-// concurrent use; one server's detection runs sequentially, which is the
-// intended scope.
+// immediately follows instead of being discarded and rebuilt. That cache is
+// what makes enrichment affordable: without it, every root that references an
+// advisory or a vulnerability re-reads and re-unmarshals the same record, which
+// measured ~60x slower on a 4873-CVE result (2.4s -> 150s).
+//
+// The db is opened lazily, on the first path that actually queries it: a family
+// that skips vuls2 detection (FreeBSD, pseudo, trivy-scanned, ...) does not open
+// it during detection, but enrichment still opens it when the result carries
+// CVEs (e.g. FreeBSD's pkg-audit findings); a server with nothing to detect and
+// no CVEs to enrich never opens it at all. Close releases the db.
+//
+// A Session is not safe for concurrent use; one server's detection runs
+// sequentially, which is the intended scope. Server mode gives each request its
+// own, from SharedDB.Acquire.
 type Session struct {
 	vuls2Conf  config.Vuls2Conf
 	noProgress bool
+	withCache  bool
+
+	// recordDigest records the db's digest on the global config when the db is
+	// opened, so the report this run produces says which db produced it. Server
+	// mode turns it off on the sessions it hands to requests: SharedDB has
+	// already recorded the digest of the db they are about to open, and letting
+	// concurrent requests write a global that detector.DetectPkgCves reads would
+	// be a data race.
+	recordDigest bool
 
 	sesh *session.Session
 }
 
-// NewSession returns a not-yet-opened shared Session; the db is opened lazily
-// on the first path that queries it (see Session).
+// NewSession returns a not-yet-opened Session; the db is opened lazily on the
+// first path that queries it (see Session).
 func NewSession(vuls2Conf config.Vuls2Conf, noProgress bool) *Session {
-	return &Session{vuls2Conf: vuls2Conf, noProgress: noProgress}
+	return &Session{vuls2Conf: vuls2Conf, noProgress: noProgress, withCache: true, recordDigest: true}
 }
 
 // open opens the db on the first call and reuses the connection on every later
@@ -138,16 +150,19 @@ func (s *Session) open() (*session.Session, error) {
 		return nil, xerrors.Errorf("db session is nil; create one with NewSession")
 	}
 	if s.sesh == nil {
-		sesh, err := openSession(s.vuls2Conf, s.noProgress)
+		sesh, digest, err := openSession(s.vuls2Conf, s.noProgress, s.withCache)
 		if err != nil {
 			return nil, xerrors.Errorf("Failed to open db session. err: %w", err)
+		}
+		if s.recordDigest {
+			config.Conf.Vuls2.Digest = digest
 		}
 		s.sesh = sesh
 	}
 	return s.sesh, nil
 }
 
-// Close releases the db storage and cache if this Session was opened. It is a
+// Close releases the db storage and cache if this Session opened one. It is a
 // no-op on a nil or never-opened Session, and clears the handle afterwards so a
 // second Close (or a stray open) neither double-closes nor reuses a closed
 // session — always safe to defer.
@@ -160,16 +175,15 @@ func (s *Session) Close() {
 	s.sesh = nil
 }
 
-// openSession opens a cache-backed vuls2 db session: it fills in the default
-// repository/path, downloads or refreshes the db if due and validates the
-// schema version (both inside newDBConfig), opens storage, and records the db
-// digest on the global config. The caller owns the returned session and must
-// close its Storage() and Cache().
-func openSession(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Session, error) {
+// withDefaults fills in the repository and path openSession falls back to when
+// the config leaves them empty. Callers that inspect the db before opening it
+// (SharedDB, which has to know which file shouldDownload should look at) go
+// through this first, so they and openSession agree on the target.
+func withDefaults(vuls2Conf config.Vuls2Conf) (config.Vuls2Conf, error) {
 	if vuls2Conf.Repository == "" {
 		sv, err := session.SchemaVersion("boltdb")
 		if err != nil {
-			return nil, xerrors.Errorf("Failed to get schema version. err: %w", err)
+			return config.Vuls2Conf{}, xerrors.Errorf("Failed to get schema version. err: %w", err)
 		}
 
 		vuls2Conf.Repository = fmt.Sprintf("%s:%d", defaultRegistory, sv)
@@ -177,36 +191,54 @@ func openSession(vuls2Conf config.Vuls2Conf, noProgress bool) (*session.Session,
 	if vuls2Conf.Path == "" {
 		vuls2Conf.Path = DefaultPath
 	}
+	return vuls2Conf, nil
+}
 
-	dbConfig, err := newDBConfig(vuls2Conf, noProgress)
+// openSession opens a vuls2 db session: it fills in the default
+// repository/path, downloads or refreshes the db if due and validates the
+// schema version (both inside newDBConfig), and opens storage. withCache is
+// passed through to newDBConfig, which documents when a read cache is worth
+// carrying. The caller owns the returned session and must close its Storage()
+// and Cache().
+//
+// The db's digest comes back alongside the session rather than being recorded
+// on the global config here, because who may write that global depends on the
+// caller: a report run is alone in the process, while a server has concurrent
+// requests reading it and records it once, from the goroutine that owns the db.
+func openSession(vuls2Conf config.Vuls2Conf, noProgress, withCache bool) (*session.Session, *string, error) {
+	vuls2Conf, err := withDefaults(vuls2Conf)
 	if err != nil {
-		return nil, xerrors.Errorf("Failed to get new db connection. err: %w", err)
+		return nil, nil, xerrors.Errorf("Failed to apply vuls2 config defaults. err: %w", err)
+	}
+
+	dbConfig, err := newDBConfig(vuls2Conf, noProgress, withCache)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("Failed to get new db connection. err: %w", err)
 	}
 
 	sesh, err := dbConfig.New()
 	if err != nil {
-		return nil, xerrors.Errorf("Failed to new db session. err: %w", err)
+		return nil, nil, xerrors.Errorf("Failed to new db session. err: %w", err)
 	}
 
 	if err := sesh.Storage().Open(); err != nil {
 		sesh.Cache().Close()
-		return nil, xerrors.Errorf("Failed to open db. err: %w", err)
+		return nil, nil, xerrors.Errorf("Failed to open db. err: %w", err)
 	}
 
 	metadata, err := sesh.Storage().GetMetadata()
 	if err != nil {
 		_ = sesh.Storage().Close()
 		sesh.Cache().Close()
-		return nil, xerrors.Errorf("Failed to get metadata. err: %w", err)
+		return nil, nil, xerrors.Errorf("Failed to get metadata. err: %w", err)
 	}
 	if metadata == nil {
 		_ = sesh.Storage().Close()
 		sesh.Cache().Close()
-		return nil, xerrors.Errorf("unexpected vuls2 db metadata. metadata: nil, path: %s", vuls2Conf.Path)
+		return nil, nil, xerrors.Errorf("unexpected vuls2 db metadata. metadata: nil, path: %s", vuls2Conf.Path)
 	}
-	config.Conf.Vuls2.Digest = metadata.Digest
 
-	return sesh, nil
+	return sesh, metadata.Digest, nil
 }
 
 // warningMessages renders the non-fatal evaluation warnings recorded on the
@@ -602,9 +634,17 @@ func detect(sesh *session.Session, sr scanTypes.ScanResult) (detectTypes.DetectR
 		return detectTypes.DetectResult{}, xerrors.Errorf("ScanResult carries both CPE and OS-package / Microsoft-KB inputs; DetectPkgs and DetectCPEs feed them exclusively")
 	}
 
+	// GOMAXPROCS, not NumCPU: NumCPU reports the machine's CPU count even when
+	// a cgroup CPU quota lets far fewer of them run at once, so under a
+	// container limit it sizes the worker pool for CPUs the detection will
+	// never get and the surplus workers only add scheduler and cgroup-throttle
+	// overhead. GOMAXPROCS is cgroup-aware since Go 1.25 and is also what an
+	// operator can turn down by hand.
+	concurrency := runtime.GOMAXPROCS(0)
+
 	detections, err := func() (map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection, error) {
 		if len(sr.CPE) > 0 {
-			m, err := cpe.Detect(sesh.Storage(), sr, runtime.NumCPU())
+			m, err := cpe.Detect(sesh.Storage(), sr, concurrency)
 			if err != nil {
 				return nil, xerrors.Errorf("Failed to detect cpe. err: %w", err)
 			}
@@ -614,7 +654,7 @@ func detect(sesh *session.Session, sr scanTypes.ScanResult) (detectTypes.DetectR
 		// either input being present — a Windows scan can carry KBs
 		// without any OS packages.
 		if len(sr.OSPackages) > 0 || len(sr.MicrosoftKB.Applied) > 0 || len(sr.MicrosoftKB.Unapplied) > 0 {
-			m, err := ospkg.Detect(sesh.Storage(), sr, runtime.NumCPU())
+			m, err := ospkg.Detect(sesh.Storage(), sr, concurrency)
 			if err != nil {
 				return nil, xerrors.Errorf("Failed to detect os packages. err: %w", err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	golang.org/x/term v0.45.0
 	golang.org/x/text v0.40.0
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da
+	oras.land/oras-go/v2 v2.6.2
 )
 
 require (
@@ -352,7 +353,6 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 	modernc.org/sqlite v1.53.0 // indirect
 	mvdan.cc/sh/v3 v3.12.0 // indirect
-	oras.land/oras-go/v2 v2.6.2 // indirect
 	sigs.k8s.io/controller-runtime v0.24.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect

--- a/server/server.go
+++ b/server/server.go
@@ -23,10 +23,35 @@ import (
 // VulsHandler is used for vuls server mode
 type VulsHandler struct {
 	ToLocalFile bool
+
+	// DB owns the vuls2 db for the lifetime of the process: it downloads it and
+	// keeps it current in the background, and hands each request a session that
+	// can only read what is already on disk. Nothing here downloads a db.
+	DB *vuls2.SharedDB
+
+	// sem bounds how many requests may detect at once, nil for no bound. One
+	// detection alone spawns GOMAXPROCS workers, holds every CVE it finds, and
+	// builds a read cache that measured 0.4-0.8 GB on heavy servers (4873-7466
+	// CVEs), all of it released when the request ends. So this is what puts a
+	// ceiling on the process: peak memory is roughly maxConcurrency times that,
+	// and letting an unbounded number run oversubscribes CPU and memory badly
+	// enough that each request takes minutes instead of seconds. Requests queue
+	// on it rather than being rejected.
+	sem chan struct{}
+}
+
+// NewVulsHandler returns the /vuls handler. maxConcurrency caps concurrent
+// detections; 0 or less leaves them unbounded.
+func NewVulsHandler(toLocalFile bool, db *vuls2.SharedDB, maxConcurrency int) *VulsHandler {
+	h := &VulsHandler{ToLocalFile: toLocalFile, DB: db}
+	if maxConcurrency > 0 {
+		h.sem = make(chan struct{}, maxConcurrency)
+	}
+	return h
 }
 
 // ServeHTTP is http handler
-func (h VulsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+func (h *VulsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var err error
 	r := models.ScanResult{ScannedCves: models.VulnInfos{}}
 
@@ -62,10 +87,35 @@ func (h VulsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Share one lazily-opened vuls2 db session across this request's package
-	// detection and the enrichment that follows, so the read cache detection
-	// warms is reused by enrichment rather than opened and rebuilt twice.
-	sesh := vuls2.NewSession(config.Conf.Vuls2, config.Conf.NoProgress)
+	// Bound concurrent detections before opening a db, so a queued request holds
+	// nothing but its own request body while it waits. Taking the slot here also
+	// puts its release after the session's Close in defer order, so the read
+	// cache a detection built is freed before the next request is let in.
+	if h.sem != nil {
+		select {
+		case h.sem <- struct{}{}:
+			defer func() { <-h.sem }()
+		case <-req.Context().Done():
+			// Client gave up while queued; nothing to report to.
+			return
+		}
+	}
+
+	// Refuse before doing any work if there is no db to answer from, so a server
+	// that is still downloading its first one says so plainly instead of failing
+	// somewhere inside detection.
+	if !h.DB.Ready() {
+		logging.Log.Errorf("vuls2 db is not ready")
+		http.Error(w, "vuls2 db is not ready", http.StatusServiceUnavailable)
+		return
+	}
+
+	// One db session for this request's package detection and the enrichment
+	// that follows, so both query the same db and the read cache detection warms
+	// is still warm for enrichment. Nothing here fetches: the session is barred
+	// from downloading, so a request can never become another thing that pulls
+	// a multi-gigabyte db.
+	sesh := h.DB.Acquire()
 	defer sesh.Close()
 
 	if err := detector.DetectPkgCves(&r, sesh); err != nil {

--- a/subcmds/server.go
+++ b/subcmds/server.go
@@ -9,19 +9,37 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
+	"time"
 
 	"github.com/google/subcommands"
 
 	"github.com/future-architect/vuls/config"
+	"github.com/future-architect/vuls/detector/vuls2"
 	"github.com/future-architect/vuls/logging"
 	"github.com/future-architect/vuls/server"
 )
 
+const (
+	// dbRefreshInterval is how often the server re-checks whether a newer vuls2
+	// db is due. Whether one actually gets downloaded is decided per check
+	// against the db's own metadata, so this only sets how promptly a due
+	// refresh is noticed.
+	dbRefreshInterval = 1 * time.Hour
+
+	// dbRetryInterval is how long the server waits before retrying a vuls2 db it
+	// has not managed to open yet, during startup. It bounds the retry rate of a
+	// fetch that keeps failing, which used to be driven by request arrivals
+	// instead.
+	dbRetryInterval = 1 * time.Minute
+)
+
 // ServerCmd is subcommand for server
 type ServerCmd struct {
-	configPath  string
-	listen      string
-	toLocalFile bool
+	configPath     string
+	listen         string
+	toLocalFile    bool
+	maxConcurrency int
 }
 
 // Name return subcommand name
@@ -47,6 +65,7 @@ func (*ServerCmd) Usage() string {
 		[-debug]
 		[-debug-sql]
 		[-listen=localhost:5515]
+		[-max-concurrency=4]
 
 		[RFC3339 datetime format under results dir]
 `
@@ -87,10 +106,13 @@ func (p *ServerCmd) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&p.toLocalFile, "to-localfile", false, "Write report to localfile")
 	f.StringVar(&p.listen, "listen", "localhost:5515",
 		"host:port (default: localhost:5515)")
+
+	f.IntVar(&p.maxConcurrency, "max-concurrency", runtime.GOMAXPROCS(0),
+		"Maximum number of scan results detected in parallel, 0 for unlimited (default: GOMAXPROCS)")
 }
 
 // Execute execute
-func (p *ServerCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...any) subcommands.ExitStatus {
+func (p *ServerCmd) Execute(ctx context.Context, _ *flag.FlagSet, _ ...any) subcommands.ExitStatus {
 	logging.Log = logging.NewCustomLogger(config.Conf.Debug, config.Conf.Quiet, config.Conf.LogToFile, config.Conf.LogDir, "", "")
 	logging.Log.Infof("vuls-%s-%s", config.Version, config.Revision)
 
@@ -106,10 +128,45 @@ func (p *ServerCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...any) subcom
 		return subcommands.ExitUsageError
 	}
 
-	http.Handle("/vuls", server.VulsHandler{
-		ToLocalFile: p.toLocalFile,
-	})
+	// Own the vuls2 db here, for the whole process, rather than per request: a
+	// request must never be the thing that downloads a multi-gigabyte db, and
+	// every request should read the one db this process already has open.
+	// Progress bars are off unconditionally — a server's fetch reports itself
+	// through the log, and a bar redrawing itself into a container log is
+	// unreadable.
+	db, err := vuls2.NewSharedDB(config.Conf.Vuls2, true)
+	if err != nil {
+		logging.Log.Errorf("Failed to configure vuls2 db. err: %+v", err)
+		return subcommands.ExitFailure
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Open the db in the background so the listener comes up right away and can
+	// say that it is still downloading, rather than the port simply being closed
+	// for the length of a multi-gigabyte fetch. Once a db is open, the same
+	// goroutine keeps it current, so a request never waits on a fetch and only
+	// one fetch ever runs at a time.
+	go func() {
+		if err := db.Prepare(ctx, dbRetryInterval); err != nil {
+			logging.Log.Errorf("Failed to prepare vuls2 db. err: %+v", err)
+			return
+		}
+		logging.Log.Infof("vuls2 db is ready")
+		db.Run(ctx, dbRefreshInterval)
+	}()
+
+	http.Handle("/vuls", server.NewVulsHandler(p.toLocalFile, db, p.maxConcurrency))
+	// /health reports whether this server can answer at all: with no db open,
+	// /vuls can only fail, so traffic should be kept away until it is. Point a
+	// readiness probe at it — a liveness probe would restart the process partway
+	// through the first fetch and start the download over from nothing.
 	http.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		if !db.Ready() {
+			http.Error(w, "vuls2 db is not ready", http.StatusServiceUnavailable)
+			return
+		}
 		if _, err := fmt.Fprintf(w, "ok"); err != nil {
 			logging.Log.Errorf("Failed to print server health. err: %+v", err)
 		}


### PR DESCRIPTION
# What did you implement:

Server mode created a vuls2 db session **per request**, so every request decided for itself whether the db was due for a download and fetched it. That is the root cause behind https://github.com/future-architect/vuls/discussions/2613: a pod that came up with no db on disk had each arriving request start its own multi-gigabyte fetch into the same directory, several at a time, all competing for bandwidth and disk until they tripped the registry's stream limits and started over.

This PR hoists the db's **lifecycle** out of the request path, while leaving the db handle itself per-request.

### `SharedDB` owns fetching and readiness

`SharedDB` downloads the db and keeps it current in the background, and hands each request a session with `SkipUpdate` forced on. Only the goroutine that prepares and refreshes ever fetches, so a fetch is single-flight by construction and a request can never become another thing that pulls a db. Until there is a db to serve, `/health` answers 503 and `/vuls` refuses.

> [!IMPORTANT]
> Point a **readiness** probe at `/health`. A liveness probe would restart the process partway through the first fetch and start the download over from nothing.

### Each request keeps its own handle and its own read cache

An earlier revision of this PR shared one open db handle across requests. That was wrong, and @maxenced caught it by testing a build — detection went from seconds to over 300s. Measured on a full-size (~11 GB) db with a 4873-CVE result:

| | detect | enrich | total |
|---|---|---|---|
| one shared handle, no read cache | 1.85s | **150.4s** | 152.3s |
| handle + cache per request | 1.91s | **2.43s** | 4.35s |

The reason is that a session shared across requests cannot carry vuls2's read cache: the cache never evicts, so one outliving a request grows until the process is OOM-killed. Without it, `GetVulnerabilityData` re-reads and re-unmarshals the same advisory and vulnerability records once per root that references them, and enrichment walks every CVE.

Sharing the handle bought nothing to pay for that. Opening the db read-only is an mmap of a file the page cache already holds — **~50µs** on the same ~11 GB db, next to nothing beside the seconds a detection takes, and the pages are shared by the OS either way. So each request opens its own handle, carries its own cache, and drops both when it ends. `SharedDB` shrank accordingly: no generations, no refcounting, no hot-swap.

### Startup serves from disk before considering a download

A db on disk that is merely due for a refresh is still worth serving, so a process that has one comes up in the time it takes to check a file instead of after a full fetch. Bringing it up to date is then the refresher's job, with requests served the whole time. A refresh that fails leaves the working db in place.

### Refreshes compare the repository digest first

`shouldDownload` goes by timestamps, and the nightly db's `LastModified` is the night it was built — so a db past the staleness window looks due on *every* check for as long as it lives, which would re-fetch gigabytes hourly. `hasNewerRemote` resolves the repository manifest and compares its digest against the one `fetch` recorded in the local db's metadata, so a download only happens when the tag has actually moved.

### Three adjacent fixes

- The db digest is recorded on the global config by `SharedDB` alone rather than by every session open. Concurrent requests wrote `config.Conf.Vuls2.Digest` while `detector.DetectPkgCves` read the same global to stamp the result — a data race that exists on master today.
- Detection workers are sized by `GOMAXPROCS` rather than `runtime.NumCPU()`, which reports the machine's CPU count even when a cgroup quota lets far fewer of them run. On a 2-vCPU pod scheduled on an 8-core host, every request was spawning 8 workers for CPUs it would never get.
- `-max-concurrency` (default `GOMAXPROCS`) bounds concurrent detections. One detection holds every CVE it finds plus a read cache that measured **0.4–0.8 GB** on heavy servers (4873–7466 CVEs), so this is what puts a ceiling on the process: peak ≈ `max-concurrency` × that. Master has no such bound at all. Requests **queue** rather than being rejected — clients with tight HTTP timeouts may see a timeout where they previously saw a slow response — and a slot is released only after the session it admitted has been closed, so the cache is freed before the next request is let in.

## Relation to #2617 / #2618

@maxenced opened #2617 and #2618 against discussion 2613, and the analysis in both is theirs — including the shape of the startup fix (fetch at startup, keep the server out of rotation until it completes). This PR arrives at the same behaviour for `/health` and the same single-flight guarantee.

Where it differs is scope: #2617/#2618 keep the per-request fetch decision and coordinate it, while this PR moves the decision out of the request path entirely, which is also what makes the digest precheck and the concurrency bound natural to add.

@maxenced also tested a build of the earlier revision and found the regression described above, which is why the shared-handle design is gone. Thank you — that was the useful kind of review.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Behaviour changes

| | before | after |
|---|---|---|
| db on disk, stale | request blocks on an 11 GB fetch | serves immediately, refreshes in the background |
| no db on disk | every request fetches its own copy | `/health` and `/vuls` 503, one fetch, retried every minute |
| db up to date but past the staleness window | re-fetched on every check | manifest resolve only |
| concurrent requests | unbounded | bounded by `-max-concurrency`, queued |
| detection worker count | `NumCPU` (ignores cgroup quota) | `GOMAXPROCS` |
| `/health` | always `200 ok` | `503` until there is a db to serve |

# How Has This Been Tested?

- `make fmt`, `go build ./...`, `go vet ./...`
- `go test -race ./detector/...`

New tests in `detector/vuls2/shared_test.go` (all run under `-race`):

- `TestSharedDB_NotReadyBeforeOpen` — a db on disk is not one this process has validated
- `TestSharedDB_OpenLocal` / `TestSharedDB_Prepare` — a stale db (`SkipUpdate: false`, `LastModified` old enough for a refresh to be due) is adopted without reaching the registry, which is what proves the staleness rule no longer blocks startup
- `TestSharedDB_OpenLocalWithoutDB` — refuses rather than downloading
- `TestSharedDB_AcquireCannotFetch` — the guarantee behind 2613: whatever the configured policy, a request's session is barred from fetching, and still serves the stale db
- `TestSharedDB_AcquireCarriesCache` — the regression test for what this revision fixes
- `TestSharedDB_AcquireIsIndependent` — one request closing does not take the db from another, and does not leak its own handle
- `TestSharedDB_PrepareCancelled` — gives up on ctx rather than blocking a shutdown
- `TestSharedDB_Reload` — a reload with nothing due is a no-op
- `TestSharedDB_ConcurrentAcquire` — 8 concurrent requests opening/reading/closing their own handles against 4 readers of `Ready`

`Test_hasNewerRemote` in `detector/vuls2/db_test.go` covers the branches reachable offline (no digest recorded, no db file, unparsable repository). The digest-match path needs a registry and is not covered.

The timing and memory figures above were measured against a real `ghcr.io/vulsio/vuls-nightly-db` db with real scan results, not fixtures. **Still not verified against a real deployment** — I don't have an environment that reproduces the discussion's symptoms at scale.

# Checklist:

- [x] Write tests
- [ ] Write documentation — `/health` must be a readiness probe, and `-max-concurrency` queues rather than rejects and is what bounds memory. Not written yet.
- [x] Check that there aren't other open pull requests for the same issue/feature — see the section on #2617 / #2618 above
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [ ] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

# Known gaps

Neither this PR nor #2617/#2618 addresses the fetch failure itself. In discussion 2613 the download dies at ~5 GB with `stream error: PROTOCOL_ERROR; received from peer`, and `fetch.Fetch` reads the layer as one stream with no retry and no ranged resume, so it starts over from zero every time. Fixing that belongs in `MaineK00n/vuls2`, along with the same digest precheck so `vuls2 db fetch` benefits too.

Until then, the reliable deployment is `SkipUpdate = true` with the db provided by an initContainer or a PVC — with this PR that path also gives the fastest startup.

Discussion 2615 asks for the per-request bolt opens to go away. They do not, and the measurement above is why: the open is ~50µs, and removing it costs the read cache, which is worth far more. What that discussion was feeling is most likely the unbounded concurrency, which `-max-concurrency` now bounds.

***Is this ready for review?:*** NO
