### PR TITLE
feat(detector/vuls2): detect OpenSSH security advisories

### DIFF
--- a/detector/vuls2/vendor.go
+++ b/detector/vuls2/vendor.go
@@ -599,6 +599,17 @@ func advisoryReference(e ecosystemTypes.Ecosystem, s sourceTypes.SourceID, da mo
 				Source: "APPLE",
 				RefID:  da.AdvisoryID,
 			}, nil
+		case sourceTypes.OpenSSHSecurity:
+			// OpenSSH publishes its entire security history on one page and
+			// assigns no per-advisory URL, so every entry points at that page.
+			// The advisory ID is synthesised by the extractor
+			// (OPENSSH-<date>-<n>) and exists only to key the entry, so it is
+			// kept as the RefID rather than built into a link.
+			return models.Reference{
+				Link:   "https://www.openssh.com/security.html",
+				Source: "OPENSSH",
+				RefID:  da.AdvisoryID,
+			}, nil
 		default:
 			return models.Reference{}, xerrors.Errorf("unsupported source: %s", s)
 		}
@@ -704,6 +715,10 @@ func cveContentSourceLink(ccType models.CveContentType, v vulnerabilityTypes.Vul
 		// Cisco content lives in the advisory, whose ID is the root ID, so the
 		// per-CVE source link points at that advisory page.
 		return fmt.Sprintf("https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/%s", rootID)
+	case models.OpenSSH:
+		// OpenSSH has no per-advisory page: the whole security history is one
+		// document, so every CVE's source link points at it.
+		return "https://www.openssh.com/security.html"
 	case models.Paloalto:
 		// Palo Alto publishes a page per CVE, so the source link is keyed by the
 		// CVE ID (which is the vulnerability content ID, e.g. CVE-2022-0778).
@@ -975,6 +990,8 @@ func toCveContentType(e ecosystemTypes.Ecosystem, s sourceTypes.SourceID) models
 			return models.Cisco
 		case sourceTypes.AppleSecurityReleases:
 			return models.Apple
+		case sourceTypes.OpenSSHSecurity:
+			return models.OpenSSH
 		default:
 			return models.Unknown
 		}
@@ -1142,6 +1159,8 @@ func toVuls0Confidence(e ecosystemTypes.Ecosystem, s sourceTypes.SourceID, sd so
 				return models.CiscoVendorProductMatch
 			case sourceTypes.AppleSecurityReleases:
 				return models.AppleVendorProductMatch
+			case sourceTypes.OpenSSHSecurity:
+				return models.OpenSSHVendorProductMatch
 			default:
 				return models.Confidence{
 					Score:           0,
@@ -1171,6 +1190,8 @@ func toVuls0Confidence(e ecosystemTypes.Ecosystem, s sourceTypes.SourceID, sd so
 			return models.CiscoExactVersionMatch
 		case sourceTypes.AppleSecurityReleases:
 			return models.AppleExactVersionMatch
+		case sourceTypes.OpenSSHSecurity:
+			return models.OpenSSHExactVersionMatch
 		default:
 			return models.Confidence{
 				Score:           0,

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -1291,6 +1291,11 @@ func isJVNCPESource(sourceID sourceTypes.SourceID) bool {
 	}
 }
 
+// OpenSSH belongs to the same category without a go-cve-dictionary counterpart:
+// openssh-security is the upstream project's own statement of which releases a
+// flaw applies to, stated as a bounded range per entry, so it dominates a
+// supplementary source's version-less openbsd:openssh match.
+//
 // verifiedCPESources are the "verified" CPE data sources whose
 // affected-configuration data go-cve-dictionary trusts over the supplementary
 // sources' coarser/auto-generated data: NVD, Fortinet, Cisco, PaloAlto. A
@@ -1311,6 +1316,7 @@ var verifiedCPESources = []sourceTypes.SourceID{
 	sourceTypes.PaloAltoCSAF, sourceTypes.PaloAltoJSON, sourceTypes.PaloAltoList,
 	sourceTypes.CiscoCSAF, sourceTypes.CiscoCVRF, sourceTypes.CiscoJSON,
 	sourceTypes.AppleSecurityReleases,
+	sourceTypes.OpenSSHSecurity,
 }
 
 // isSuppressedCPESource reports whether a CPE-ecosystem source's matches are

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -10636,6 +10636,157 @@ func Test_postConvert(t *testing.T) {
 			},
 		},
 		{
+			// The page assigns no per-advisory URL, so the link is the page and
+			// the synthesised advisory ID (OPENSSH-<date>-<n>) is carried as
+			// the RefID. The bound keeps its portable suffix, which is the
+			// whole point of the openssh range type: 9.9p1 is affected and the
+			// 9.9p2 that fixes it is not.
+			name: "cpe openssh detection emits CveContent (security page source link) + DistroAdvisory",
+			args: args{
+				scanned: scanTypes.ScanResult{
+					CPE: []string{
+						"cpe:2.3:a:openbsd:openssh:9.9:p1:*:*:*:*:*:*",
+					},
+				},
+				fsToOriginalCPE: map[string][]string{
+					"cpe:2.3:a:openbsd:openssh:9.9:p1:*:*:*:*:*:*": {"cpe:/a:openbsd:openssh:9.9:p1"},
+				},
+				detected: detectTypes.DetectResult{
+					Detected: []detectTypes.VulnerabilityData{
+						{
+							ID: "OPENSSH-2025-02-18-1",
+							Advisories: []dbTypes.VulnerabilityDataAdvisory{
+								{
+									ID: "OPENSSH-2025-02-18-1",
+									Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]advisoryTypes.Advisory{
+										sourceTypes.OpenSSHSecurity: {
+											dataTypes.RootID("OPENSSH-2025-02-18-1"): []advisoryTypes.Advisory{
+												{
+													Content: advisoryContentTypes.Content{
+														ID:    "OPENSSH-2025-02-18-1",
+														Title: "VerifyHostKeyDNS server impersonation.",
+														References: []referenceTypes.Reference{
+															{
+																Source: "openssh.com",
+																URL:    "https://www.openssh.com/security.html",
+															},
+														},
+														Published: new(time.Date(2025, 2, 18, 0, 0, 0, 0, time.UTC)),
+													},
+													Segments: []segmentTypes.Segment{
+														{
+															Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Vulnerabilities: []dbTypes.VulnerabilityDataVulnerability{
+								{
+									ID: "CVE-2025-26465",
+									Contents: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+										sourceTypes.OpenSSHSecurity: {
+											dataTypes.RootID("OPENSSH-2025-02-18-1"): []vulnerabilityTypes.Vulnerability{
+												{
+													Content: vulnerabilityContentTypes.Content{
+														ID: "CVE-2025-26465",
+														References: []referenceTypes.Reference{
+															{
+																Source: "openssh.com",
+																URL:    "https://www.cve.org/CVERecord?id=CVE-2025-26465",
+															},
+														},
+													},
+													Segments: []segmentTypes.Segment{
+														{
+															Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							Detections: []detectTypes.VulnerabilityDataDetection{
+								{
+									Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+									Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+										sourceTypes.OpenSSHSecurity: {
+											{
+												Criteria: criteriaTypes.FilteredCriteria{
+													Operator: criteriaTypes.CriteriaOperatorTypeOR,
+													Criterions: []criterionTypes.FilteredCriterion{
+														{
+															Criterion: criterionTypes.Criterion{
+																Type: criterionTypes.CriterionTypeCPE,
+																CPE: new(ccTypes.Criterion{
+																	Vulnerable: true,
+																	FixStatus: new(vcFixStatusTypes.FixStatus{
+																		Class:  vcFixStatusTypes.ClassFixed,
+																		Vendor: "openssh.com",
+																	}),
+																	CPE: ccTypes.CPE("cpe:2.3:a:openbsd:openssh:*:*:*:*:*:*:*:*"),
+																	Range: &ccRangeTypes.Range{
+																		Type:         ccRangeTypes.RangeTypeOpenSSH,
+																		GreaterEqual: "6.8p1",
+																		LessEqual:    "9.9p1",
+																	},
+																	Fixed: []string{"9.9p2"},
+																}),
+															},
+															Accepts: criterionTypes.AcceptQueries{
+																CPE: criterionTypes.CPEAccepts{Exact: []int{0}},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: models.VulnInfos{
+				"CVE-2025-26465": {
+					CveID:       "CVE-2025-26465",
+					Confidences: models.Confidences{models.OpenSSHExactVersionMatch},
+					CpeURIs:     []string{"cpe:/a:openbsd:openssh:9.9:p1"},
+					DistroAdvisories: models.DistroAdvisories{
+						{
+							AdvisoryID: "OPENSSH-2025-02-18-1",
+							Issued:     time.Date(2025, 2, 18, 0, 0, 0, 0, time.UTC),
+							Updated:    time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						},
+					},
+					CveContents: models.CveContents{
+						models.OpenSSH: []models.CveContent{
+							{
+								Type:       models.OpenSSH,
+								CveID:      "CVE-2025-26465",
+								SourceLink: "https://www.openssh.com/security.html",
+								References: models.References{
+									{Link: "https://www.openssh.com/security.html", Source: "OPENSSH", RefID: "OPENSSH-2025-02-18-1"},
+									{Link: "https://www.cve.org/CVERecord?id=CVE-2025-26465", Source: "CVE", RefID: "CVE-2025-26465"},
+								},
+								Published:    time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
+								LastModified: time.Date(1000, time.January, 1, 0, 0, 0, 0, time.UTC),
+								Optional: map[string]string{
+									"vuls2-sources": "[{\"root_id\":\"OPENSSH-2025-02-18-1\",\"source_id\":\"openssh-security\",\"segment\":{\"ecosystem\":\"cpe\"}}]",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			// A criterion accepted the query only at version-unconfirmed
 			// quality (the upstream matcher could not confirm the scanned
 			// version is affected), so the CVE is reported with the low

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/CycloneDX/cyclonedx-go v0.11.0
-	github.com/MaineK00n/vuls-data-update v0.0.0-20260818033617-305a95f8ba56
-	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260818055218-7a8b91a51f44
+	github.com/MaineK00n/vuls-data-update v0.0.0-20260818092828-4b1dbcf513ff
+	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260818122401-ab3a3111c7f1
 	github.com/Ullaakut/nmap/v2 v2.2.2
 	github.com/aquasecurity/trivy v0.72.0
 	github.com/aquasecurity/trivy-db v0.0.0-20260629102122-a0049d7ad12f

--- a/go.sum
+++ b/go.sum
@@ -68,10 +68,10 @@ github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc h1:
 github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc/go.mod h1:GNf+Vhnxk8/pW56jsxAeFCBP0VCgVQlLIJ812UnAj9c=
 github.com/MaineK00n/go-paloalto-version v0.0.0-20260324210858-f043171ba2bf h1:QDz92+GEPbIR4HTw2EGNgYqH+T9jxmO/OvFMfY715PE=
 github.com/MaineK00n/go-paloalto-version v0.0.0-20260324210858-f043171ba2bf/go.mod h1:ELOxzfAd4oAe4niMmoZlSiJwzf1DF+DjNdjsUcuqAR8=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260818033617-305a95f8ba56 h1:J6FQ2cEkqNSyKQEfzAJcMMen9B9zQQXxrlbWQi4HbgA=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260818033617-305a95f8ba56/go.mod h1:vH8USEvq0OVxOjD/WJMI18XkS4IXjwbXJWdlWbeyjm8=
-github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260818055218-7a8b91a51f44 h1:IVsteqt+RdX95p0L61lBYxKuD3KVAEI7bqPd2NEHr2c=
-github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260818055218-7a8b91a51f44/go.mod h1:wZJxDiPJXex4TXX9wUi0BCk4f03cFWjy+sI0xeZtXic=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260818092828-4b1dbcf513ff h1:sV6j5ZhoATbQKmP0tj+Uavnu1WMOffpmXD0pPnu76g8=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260818092828-4b1dbcf513ff/go.mod h1:vH8USEvq0OVxOjD/WJMI18XkS4IXjwbXJWdlWbeyjm8=
+github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260818122401-ab3a3111c7f1 h1:lAFiWlywzzM0DrMi4/gS3UJ3e6wpyD8EyvnGZZB9URw=
+github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260818122401-ab3a3111c7f1/go.mod h1:98n1xxcp0+XUqoa1FWv058vNChNdwCftWBUgnRSdAf4=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -489,6 +489,8 @@ const (
 
 	// Apple is Apple
 	Apple CveContentType = "apple"
+	// OpenSSH is OpenSSH
+	OpenSSH CveContentType = "openssh"
 
 	// RedHat is RedHat
 	RedHat CveContentType = "redhat"
@@ -661,6 +663,7 @@ var AllCveContetTypes = CveContentTypes{
 	Paloalto,
 	Cisco,
 	Apple,
+	OpenSSH,
 	RedHat,
 	RedHatAPI,
 	Alma,

--- a/models/vulninfos.go
+++ b/models/vulninfos.go
@@ -1163,6 +1163,11 @@ const (
 
 	// AppleVendorProductMatchStr :
 	AppleVendorProductMatchStr = "AppleVendorProductMatch"
+	// OpenSSHExactVersionMatchStr :
+	OpenSSHExactVersionMatchStr = "OpenSSHExactVersionMatch"
+
+	// OpenSSHVendorProductMatchStr :
+	OpenSSHVendorProductMatchStr = "OpenSSHVendorProductMatch"
 
 	// PkgAuditMatchStr :
 	PkgAuditMatchStr = "PkgAuditMatch"
@@ -1297,4 +1302,9 @@ var (
 
 	// AppleVendorProductMatch is a ranking how confident the CVE-ID was detected correctly
 	AppleVendorProductMatch = Confidence{10, AppleVendorProductMatchStr, 9}
+	// OpenSSHExactVersionMatch is a ranking how confident the CVE-ID was detected correctly
+	OpenSSHExactVersionMatch = Confidence{100, OpenSSHExactVersionMatchStr, 1}
+
+	// OpenSSHVendorProductMatch is a ranking how confident the CVE-ID was detected correctly
+	OpenSSHVendorProductMatch = Confidence{10, OpenSSHVendorProductMatchStr, 9}
 )


### PR DESCRIPTION
Routes the `openssh-security` data source ([MaineK00n/vuls-data-update#928](https://github.com/MaineK00n/vuls-data-update/pull/928), merged) through the vuls2 CPE detection path, so a host running OpenSSH is matched against what the upstream project itself states about each release.

## What

- `models.OpenSSH` CveContentType, and the `OpenSSHExactVersionMatch` / `OpenSSHVendorProductMatch` confidences, alongside the existing vendor sources.
- `detector/vuls2/vendor.go`: the source is advisory-shaped like Cisco, so it gets the same four hooks — the `DistroAdvisory` reference, `cveContentSourceLink`, `toCveContentType` and `detectionMethod`.
- `detector/vuls2/vuls2.go`: `sourceTypes.OpenSSHSecurity` joins `verifiedCPESources`.
- Bumps `vuls2` to [MaineK00n/vuls2#425](https://github.com/MaineK00n/vuls2/pull/425) (merged), which carries the `openssh` CPE range type.

## Why the link is not per-advisory

OpenSSH publishes its whole security history as a single page and assigns no per-entry URL. The advisory ID (`OPENSSH-<date>-<n>`) is synthesised by the extractor to key the entry, so it is carried as the `RefID` while the link points at <https://www.openssh.com/security.html>.

## Why it belongs in verifiedCPESources

`openssh-security` is the upstream project's own statement of which releases a flaw applies to, given as a bounded range per entry. It therefore dominates a supplementary source's version-less `openbsd:openssh` match, in the same way the Fortinet, Cisco and Palo Alto feeds do for their products. Suppression stays keyed per CVE, so it only fires where OpenSSH has an advisory for that very CVE.

## Testing

`go build ./...` clean; `go test ./detector/... ./models/...` pass. (`./scanner/` fails identically on `master` — it needs the `integration/data` submodule.)

Adds an end-to-end case to `Test_postConvert`, in the shape #2635 established for Apple:

```
--- PASS: Test_postConvert/cpe_openssh_detection_emits_CveContent_(security_page_source_link)_+_DistroAdvisory
```

It pins all four hooks at once — the page as `SourceLink`, `OPENSSH-2025-02-18-1` as the `RefID`, `models.OpenSSH` as the content type, and `OpenSSHExactVersionMatch` as the confidence — against a scan of `cpe:2.3:a:openbsd:openssh:9.9:p1`. The criterion carries the bound with its portable suffix (`6.8p1` to `9.9p1`, fixed in `9.9p2`), which is what the `openssh` range type exists for: under a general-purpose comparator `9.9p2` sorts *before* `9.9p1`, so the release carrying the fix would be reported as the vulnerability it fixes.

Rebased on `master` after #2635 merged; the two touch the same four files and the conflicts were both sources being added at the same spots, resolved by keeping each.