### PR TITLE
chore(deps): bump vuls2 and vuls-data-update for openssh RangeType

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/CycloneDX/cyclonedx-go v0.11.0
-	github.com/MaineK00n/vuls-data-update v0.0.0-20260818033617-305a95f8ba56
-	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260818055218-7a8b91a51f44
+	github.com/MaineK00n/vuls-data-update v0.0.0-20260818092828-4b1dbcf513ff
+	github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260818122401-ab3a3111c7f1
 	github.com/Ullaakut/nmap/v2 v2.2.2
 	github.com/aquasecurity/trivy v0.72.0
 	github.com/aquasecurity/trivy-db v0.0.0-20260629102122-a0049d7ad12f

--- a/go.sum
+++ b/go.sum
@@ -68,10 +68,10 @@ github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc h1:
 github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc/go.mod h1:GNf+Vhnxk8/pW56jsxAeFCBP0VCgVQlLIJ812UnAj9c=
 github.com/MaineK00n/go-paloalto-version v0.0.0-20260324210858-f043171ba2bf h1:QDz92+GEPbIR4HTw2EGNgYqH+T9jxmO/OvFMfY715PE=
 github.com/MaineK00n/go-paloalto-version v0.0.0-20260324210858-f043171ba2bf/go.mod h1:ELOxzfAd4oAe4niMmoZlSiJwzf1DF+DjNdjsUcuqAR8=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260818033617-305a95f8ba56 h1:J6FQ2cEkqNSyKQEfzAJcMMen9B9zQQXxrlbWQi4HbgA=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260818033617-305a95f8ba56/go.mod h1:vH8USEvq0OVxOjD/WJMI18XkS4IXjwbXJWdlWbeyjm8=
-github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260818055218-7a8b91a51f44 h1:IVsteqt+RdX95p0L61lBYxKuD3KVAEI7bqPd2NEHr2c=
-github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260818055218-7a8b91a51f44/go.mod h1:wZJxDiPJXex4TXX9wUi0BCk4f03cFWjy+sI0xeZtXic=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260818092828-4b1dbcf513ff h1:sV6j5ZhoATbQKmP0tj+Uavnu1WMOffpmXD0pPnu76g8=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260818092828-4b1dbcf513ff/go.mod h1:vH8USEvq0OVxOjD/WJMI18XkS4IXjwbXJWdlWbeyjm8=
+github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260818122401-ab3a3111c7f1 h1:lAFiWlywzzM0DrMi4/gS3UJ3e6wpyD8EyvnGZZB9URw=
+github.com/MaineK00n/vuls2 v0.0.1-alpha.0.20260818122401-ab3a3111c7f1/go.mod h1:98n1xxcp0+XUqoa1FWv058vNChNdwCftWBUgnRSdAf4=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
Fixes #2642

## What

Bumps the vuls2 / vuls-data-update pins so the enum vocabulary matches the vuls-data-update nightly branch again:

- `github.com/MaineK00n/vuls2` `7a8b91a51f44` → `ab3a3111c7f1`
- `github.com/MaineK00n/vuls-data-update` `305a95f8ba56` → `4b1dbcf513ff`

The drift the scheduled `check-enums` run reported was a single new value:

```diff
> pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion/range.RangeType	openssh
```

Bumped upstream first, per the playbook in the issue: MaineK00n/vuls2#425 already pins vuls-data-update `4b1dbcf`, so pinning that vuls2 nightly merge commit here raises the direct vuls-data-update requirement to the same version through module graph resolution. That keeps this repo, the standalone vuls2 binary, and the vulsio/vuls-data-db nightly build on one vocabulary — bumping vuls-data-update here alone would leave the binary that builds the DB skipping data carrying the new range type.

## Incoming

vuls2 (`7a8b91a51f44...ab3a3111c7f1`):

- MaineK00n/vuls2#425 chore(deps): bump vuls-data-update for openssh security

vuls-data-update (`305a95f8ba56...4b1dbcf513ff`):

- MaineK00n/vuls-data-update#928 feat(openssh/security): add OpenSSH security advisory data source
- MaineK00n/vuls-data-update#939 fix(extract/apple): bound 10.x in-line updates below by their own line

## Verification

- `GOEXPERIMENT=jsonv2 go run github.com/MaineK00n/vuls-data-update/tools/print-enums` for the new pin vs `...@4b1dbcf513ff1522de398d087c29e44a9c5a38bf` — diff is empty (143 lines each).
- `go build ./...` and `go test ./...` pass (with the `integration` submodule checked out).

Converting the new source's detection results into vuls0 report models (CveContentType, confidences, advisory links) is separate follow-up work; this PR only realigns the pins so the values stop being dropped.