### PR TITLE
fix(models): map trivy-db julia, seal, and redhat-csaf-vex sources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -207,6 +207,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect
+	github.com/josephburnett/jd/v2 v2.3.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88 // indirect
 	github.com/kevinburke/ssh_config v1.4.0 // indirect
@@ -311,6 +312,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	go.yaml.in/yaml/v4 v4.0.0-rc.3 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
 	golang.org/x/mod v0.40.0 // indirect

--- a/models/cvecontents.go
+++ b/models/cvecontents.go
@@ -423,6 +423,12 @@ func NewCveContentType(name string) CveContentType {
 		return TrivyRootIO
 	case "trivy:rapidfort":
 		return TrivyRapidFort
+	case "trivy:julia":
+		return TrivyJulia
+	case "trivy:seal":
+		return TrivySeal
+	case "trivy:redhat-csaf-vex":
+		return TrivyRedHatCSAFVEX
 	case "GitHub":
 		return Trivy
 	default:
@@ -458,7 +464,7 @@ func GetCveContentTypes(family string) []CveContentType {
 	case constant.Windows:
 		return []CveContentType{Microsoft}
 	case string(Trivy):
-		return []CveContentType{Trivy, TrivyNVD, TrivyRedHat, TrivyRedHatOVAL, TrivyDebian, TrivyUbuntu, TrivyCentOS, TrivyRocky, TrivyFedora, TrivyAmazon, TrivyAzure, TrivyOracleOVAL, TrivySuseCVRF, TrivyAlpine, TrivyArchLinux, TrivyAlma, TrivyCBLMariner, TrivyPhoton, TrivyCoreOS, TrivyBottlerocket, TrivyRubySec, TrivyPhpSecurityAdvisories, TrivyNodejsSecurityWg, TrivyGHSA, TrivyGLAD, TrivyOSV, TrivyWolfi, TrivyChainguard, TrivyBitnamiVulndb, TrivyK8sVulnDB, TrivyGoVulnDB, TrivyAqua, TrivyEcho, TrivyMinimOS, TrivyRootIO, TrivyRapidFort}
+		return []CveContentType{Trivy, TrivyNVD, TrivyRedHat, TrivyRedHatOVAL, TrivyDebian, TrivyUbuntu, TrivyCentOS, TrivyRocky, TrivyFedora, TrivyAmazon, TrivyAzure, TrivyOracleOVAL, TrivySuseCVRF, TrivyAlpine, TrivyArchLinux, TrivyAlma, TrivyCBLMariner, TrivyPhoton, TrivyCoreOS, TrivyBottlerocket, TrivyRubySec, TrivyPhpSecurityAdvisories, TrivyNodejsSecurityWg, TrivyGHSA, TrivyGLAD, TrivyOSV, TrivyWolfi, TrivyChainguard, TrivyBitnamiVulndb, TrivyK8sVulnDB, TrivyGoVulnDB, TrivyAqua, TrivyEcho, TrivyMinimOS, TrivyRootIO, TrivyRapidFort, TrivyJulia, TrivySeal, TrivyRedHatCSAFVEX}
 	default:
 		return nil
 	}
@@ -647,6 +653,15 @@ const (
 	// TrivyRapidFort is TrivyRapidFort
 	TrivyRapidFort CveContentType = "trivy:rapidfort"
 
+	// TrivyJulia is TrivyJulia
+	TrivyJulia CveContentType = "trivy:julia"
+
+	// TrivySeal is TrivySeal
+	TrivySeal CveContentType = "trivy:seal"
+
+	// TrivyRedHatCSAFVEX is TrivyRedHatCSAFVEX
+	TrivyRedHatCSAFVEX CveContentType = "trivy:redhat-csaf-vex"
+
 	// GitHub is GitHub Security Alerts
 	GitHub CveContentType = "github"
 
@@ -719,6 +734,9 @@ var AllCveContetTypes = CveContentTypes{
 	TrivyMinimOS,
 	TrivyRootIO,
 	TrivyRapidFort,
+	TrivyJulia,
+	TrivySeal,
+	TrivyRedHatCSAFVEX,
 	GitHub,
 }
 

--- a/models/cvecontents_test.go
+++ b/models/cvecontents_test.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/aquasecurity/trivy-db/pkg/types"
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc"
 	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 
 	"github.com/future-architect/vuls/constant"
@@ -732,11 +734,30 @@ func TestNewCveContentType(t *testing.T) {
 // TestNewCveContentTypeCoversTrivyDBSourceIDs fails when a trivy-db bump adds
 // a vulnerability source that has no CveContentType yet. Contents of an
 // unmapped type still enter CveContents (detector/library.go keys them as
-// "trivy:<SourceID>"), but every ordering-based accessor skips them, so their
-// severities and references silently disappear from reports.
+// "trivy:<SourceID>" from VendorSeverity/CVSS), but every ordering-based
+// accessor skips them, so their severities and references silently disappear
+// from reports.
+//
+// Neither trivy-db list alone covers every source that can key VendorSeverity:
+// vulnerability.AllSourceIDs is the severity-precedence list and deliberately
+// excludes vendor databases such as seal, while vulnsrc.All is the registry of
+// active updaters and lacks sources whose updater was retired but whose data
+// remains (e.g. arch-linux, osv). Their union does.
 func TestNewCveContentTypeCoversTrivyDBSourceIDs(t *testing.T) {
-	// AllSourceIDs misses a few registered sources, so list them explicitly.
-	sourceIDs := append(slices.Clone(vulnerability.AllSourceIDs), vulnerability.Seal, vulnerability.RedHatCSAFVEX)
+	// Updater registry names that differ from the SourceID the updater stores
+	// vulnerability details under: the openSUSE variant of suse-cvrf saves
+	// details as vulnerability.SuseCVRF, so its registry name never keys
+	// VendorSeverity. When this test fails on a new name, either add a
+	// CveContentType for it or, if the updater stores under another SourceID,
+	// add the name here.
+	storageAliases := []types.SourceID{"opensuse-cvrf"}
+
+	sourceIDs := slices.Clone(vulnerability.AllSourceIDs)
+	for _, src := range vulnsrc.All {
+		if !slices.Contains(sourceIDs, src.Name()) && !slices.Contains(storageAliases, src.Name()) {
+			sourceIDs = append(sourceIDs, src.Name())
+		}
+	}
 	for _, id := range sourceIDs {
 		name := fmt.Sprintf("%s:%s", Trivy, id)
 		t.Run(name, func(t *testing.T) {

--- a/models/cvecontents_test.go
+++ b/models/cvecontents_test.go
@@ -1,8 +1,12 @@
 package models
 
 import (
+	"fmt"
 	"reflect"
+	"slices"
 	"testing"
+
+	"github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 
 	"github.com/future-architect/vuls/constant"
 )
@@ -700,6 +704,18 @@ func TestNewCveContentType(t *testing.T) {
 			want: TrivyRapidFort,
 		},
 		{
+			name: "trivy:julia",
+			want: TrivyJulia,
+		},
+		{
+			name: "trivy:seal",
+			want: TrivySeal,
+		},
+		{
+			name: "trivy:redhat-csaf-vex",
+			want: TrivyRedHatCSAFVEX,
+		},
+		{
 			name: "unknown",
 			want: Unknown,
 		},
@@ -708,6 +724,29 @@ func TestNewCveContentType(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := NewCveContentType(tt.name); got != tt.want {
 				t.Errorf("NewCveContentType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNewCveContentTypeCoversTrivyDBSourceIDs fails when a trivy-db bump adds
+// a vulnerability source that has no CveContentType yet. Contents of an
+// unmapped type still enter CveContents (detector/library.go keys them as
+// "trivy:<SourceID>"), but every ordering-based accessor skips them, so their
+// severities and references silently disappear from reports.
+func TestNewCveContentTypeCoversTrivyDBSourceIDs(t *testing.T) {
+	// AllSourceIDs misses a few registered sources, so list them explicitly.
+	sourceIDs := append(slices.Clone(vulnerability.AllSourceIDs), vulnerability.Seal, vulnerability.RedHatCSAFVEX)
+	for _, id := range sourceIDs {
+		name := fmt.Sprintf("%s:%s", Trivy, id)
+		t.Run(name, func(t *testing.T) {
+			got := NewCveContentType(name)
+			if got == Unknown {
+				t.Errorf("NewCveContentType(%q) = Unknown; add a CveContentType for the trivy-db source %q", name, id)
+				return
+			}
+			if !slices.Contains(GetCveContentTypes(string(Trivy)), got) {
+				t.Errorf("GetCveContentTypes(Trivy) does not contain %v for the trivy-db source %q", got, id)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

trivy-db has shipped the `julia`, `seal`, and `redhat-csaf-vex` vulnerability sources for a while, but vuls never registered `CveContentType`s for them. `detector/library.go` builds CveContents keys dynamically as `trivy:<SourceID>` from `vul.VendorSeverity` / `vul.CVSS`, so contents from these sources **do** enter `VulnInfo.CveContents` — but every ordering-based accessor (`Cvss3Scores`, `References`, `CweIDs`, ...) iterates only the registered type lists, so those contents are silently skipped.

Concrete failure: scan a project containing a Seal-patched package (vuls has registered Seal advisory matchers since #2596, and trivy 0.73 extended Seal detection to no-prefix packages via aquasecurity/trivy#10911). A CVE whose only vendor severity is `seal: HIGH` is reported with severity `-` / score 0.0, and any `--cvss-over` threshold filters the HIGH vulnerability out entirely.

Note on reachability (trivy-db@20260813): trivy-db's `getVendorSeverity` copies **every** key of the details map into `VendorSeverity` with no allow-list, so a source reaches vuls iff its updater calls `PutVulnerabilityDetail` — regardless of `AllSourceIDs`, which is only the pick-one precedence list. `seal` and `julia` do (via the OSV framework), so they actually reach vuls today. `redhat-csaf-vex` currently stores only advisories and CPE mappings, never details, so it cannot reach vuls yet; its mapping is a defensive registration of a declared SourceID.

## Change

- Register `TrivyJulia` (`trivy:julia`), `TrivySeal` (`trivy:seal`), and `TrivyRedHatCSAFVEX` (`trivy:redhat-csaf-vex`) in all four places: the `NewCveContentType` switch, `GetCveContentTypes(Trivy)`, the const block, and `AllCveContetTypes` — appended at the tail, following the convention of previous source additions.
- Add `TestNewCveContentTypeCoversTrivyDBSourceIDs`, driven by the union of trivy-db's `vulnerability.AllSourceIDs` and `vulnsrc.All` registry names. Neither list alone covers every source that can key `VendorSeverity` (`AllSourceIDs` deliberately excludes vendor databases such as seal; `vulnsrc.All` lacks retired-updater sources such as arch-linux and osv), but their union does. Registry names that store details under another SourceID are skipped (`opensuse-cvrf` saves as `suse-cvrf`). The next trivy-db bump that adds a source now fails the build loudly instead of silently dropping severities.
- `go.mod`: two indirect entries surfaced by the test-only import of `trivy-db/pkg/vulnsrc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
