### PR TITLE
fix(detector/vuls2): break CVSS merge score ties deterministically

### DIFF
--- a/detector/vuls2/export_test.go
+++ b/detector/vuls2/export_test.go
@@ -12,6 +12,7 @@ var (
 
 	WalkCPECriteria      = walkCPECriteria
 	MergeIntoScannedCves = mergeIntoScannedCves
+	MergeVulnInfo        = mergeVulnInfo
 
 	CollectVerifiedProducts = collectVerifiedProducts
 

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -1944,11 +1944,39 @@ func comparePack(a, b pack) (int, error) {
 // Score alone decided before, but tracker-derived contents (Ubuntu/Debian)
 // carry only a severity string — both scores are zero — which left the
 // winner to merge order, itself a map iteration order upstream, so
-// severities flipped between runs. Ties break by vendor severity rank (the
-// DistroAdvisories comparator), then by the raw severity and vector strings
-// so any two distinct candidates order decisively; the raw-string keys
-// matter because severities outside the vendor table (e.g. Debian's
-// "unimportant") all rank equal.
+// severities flipped between runs.
+//
+// Ties break by vendor severity rank, then by the raw severity and vector
+// strings. Notes on the severity comparison, which is a stopgap:
+//
+//   - The severity compared here is often a vendor severity squatting in
+//     the CVSS fields: models.CveContent has no vendor-severity field, so
+//     postConvert stores tracker severities as CvssNSeverity, and the
+//     (label, vendor scale) pairing the vuls-data-update model preserves is
+//     already lost by this point. Passing source "" ranks the bare label on
+//     the comparator's catch-all table — an empirical union of the
+//     vocabularies currently seen in the data, not part of any data model —
+//     the same compromise the DistroAdvisories merge above makes.
+//   - Do NOT pass a per-pair source to severityVendorTypes.Compare. This
+//     merge folds 3+ contents pairwise in map-iteration order, and a
+//     comparator that switches tables depending on the pair at hand is not
+//     associative: where a vendor table and the catch-all disagree (e.g.
+//     "moderate" ranks above "low" on the Alma table but below everything
+//     on the catch-all), the fold result would depend on merge order again
+//     — the very bug this function exists to fix. A source-aware version
+//     must rank each side on its own source's table (a per-content key
+//     keeps the fold order-free), and is only worth doing once the
+//     upstream tables cover the vocabularies they currently miss (Debian's
+//     "unimportant", the RHEL-family "moderate").
+//   - Distinct strings can still compare equal by rank — same rank group
+//     ("none" vs "unknown") or both absent from every table ("unimportant"
+//     vs "", both rank -1) — hence the raw severity string key after it:
+//     semantically meaningless, but decisive. Severity ranks above vector
+//     because it is the vendor's actual triage judgment, while the vector
+//     key is pure bytes for determinism.
+//
+// The chain returns 0 only when score, severity, and vector are all
+// byte-identical, in which case either side yields the same merged triple.
 func compareCvssContent(scoreA, scoreB float64, severityA, severityB, vectorA, vectorB string) int {
 	return cmp.Or(
 		cmp.Compare(scoreA, scoreB),

--- a/detector/vuls2/vuls2.go
+++ b/detector/vuls2/vuls2.go
@@ -1940,6 +1940,24 @@ func comparePack(a, b pack) (int, error) {
 	return r, nil
 }
 
+// compareCvssContent orders two same-type CVSS candidates during a merge.
+// Score alone decided before, but tracker-derived contents (Ubuntu/Debian)
+// carry only a severity string — both scores are zero — which left the
+// winner to merge order, itself a map iteration order upstream, so
+// severities flipped between runs. Ties break by vendor severity rank (the
+// DistroAdvisories comparator), then by the raw severity and vector strings
+// so any two distinct candidates order decisively; the raw-string keys
+// matter because severities outside the vendor table (e.g. Debian's
+// "unimportant") all rank equal.
+func compareCvssContent(scoreA, scoreB float64, severityA, severityB, vectorA, vectorB string) int {
+	return cmp.Or(
+		cmp.Compare(scoreA, scoreB),
+		severityVendorTypes.Compare("", severityA, severityB),
+		cmp.Compare(severityA, severityB),
+		cmp.Compare(vectorA, vectorB),
+	)
+}
+
 // mergeVulnInfo merges two VulnInfos for the same CVE WITHIN one vuls2 run:
 // postConvert builds one VulnInfo per detecting source segment (e.g. RHEL
 // CSAF and VEX, redhat:9 and epel:9) and folds them together here.
@@ -2049,12 +2067,11 @@ func mergeVulnInfo(a, b models.VulnInfo) (models.VulnInfo, error) {
 						}
 					}
 
-					switch cmp.Compare(base.Cvss40Score, c.Cvss40Score) {
-					case -1:
+					if compareCvssContent(base.Cvss40Score, c.Cvss40Score, base.Cvss40Severity, c.Cvss40Severity, base.Cvss40Vector, c.Cvss40Vector) < 0 {
 						merged.Cvss40Score = c.Cvss40Score
 						merged.Cvss40Vector = c.Cvss40Vector
 						merged.Cvss40Severity = c.Cvss40Severity
-					default:
+					} else {
 						merged.Cvss40Score = base.Cvss40Score
 						merged.Cvss40Vector = base.Cvss40Vector
 						merged.Cvss40Severity = base.Cvss40Severity
@@ -2070,24 +2087,22 @@ func mergeVulnInfo(a, b models.VulnInfo) (models.VulnInfo, error) {
 						merged.Cvss3Vector = base.Cvss3Vector
 						merged.Cvss3Severity = base.Cvss3Severity
 					default:
-						switch cmp.Compare(base.Cvss3Score, c.Cvss3Score) {
-						case -1:
+						if compareCvssContent(base.Cvss3Score, c.Cvss3Score, base.Cvss3Severity, c.Cvss3Severity, base.Cvss3Vector, c.Cvss3Vector) < 0 {
 							merged.Cvss3Score = c.Cvss3Score
 							merged.Cvss3Vector = c.Cvss3Vector
 							merged.Cvss3Severity = c.Cvss3Severity
-						default:
+						} else {
 							merged.Cvss3Score = base.Cvss3Score
 							merged.Cvss3Vector = base.Cvss3Vector
 							merged.Cvss3Severity = base.Cvss3Severity
 						}
 					}
 
-					switch cmp.Compare(base.Cvss2Score, c.Cvss2Score) {
-					case -1:
+					if compareCvssContent(base.Cvss2Score, c.Cvss2Score, base.Cvss2Severity, c.Cvss2Severity, base.Cvss2Vector, c.Cvss2Vector) < 0 {
 						merged.Cvss2Score = c.Cvss2Score
 						merged.Cvss2Vector = c.Cvss2Vector
 						merged.Cvss2Severity = c.Cvss2Severity
-					default:
+					} else {
 						merged.Cvss2Score = base.Cvss2Score
 						merged.Cvss2Vector = base.Cvss2Vector
 						merged.Cvss2Severity = base.Cvss2Severity

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -13136,6 +13136,62 @@ func Test_mergeVulnInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Exercises the last tiebreak key and the CVSS 4.0 selection
+			// branch: equal scores and severities leave only the vector
+			// strings to order the pair, and the lexicographically greater
+			// vector must win from either merge order.
+			name: "equal score and severity break by vector string",
+			args: args{
+				a: models.VulnInfo{
+					CveID: "CVE-2025-0004",
+					CveContents: models.CveContents{
+						models.UbuntuAPI: []models.CveContent{{
+							Type:           models.UbuntuAPI,
+							CveID:          "CVE-2025-0004",
+							Cvss40Score:    5.1,
+							Cvss40Vector:   "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N",
+							Cvss40Severity: "medium",
+							Optional: map[string]string{
+								"vuls2-sources": "[{\"root_id\":\"CVE-2025-0004\",\"source_id\":\"ubuntu-cve-tracker\",\"segment\":{\"ecosystem\":\"ubuntu:20.04\",\"tag\":\"esm-apps/focal\"}}]",
+							},
+						}},
+					},
+				},
+				b: models.VulnInfo{
+					CveID: "CVE-2025-0004",
+					CveContents: models.CveContents{
+						models.UbuntuAPI: []models.CveContent{{
+							Type:           models.UbuntuAPI,
+							CveID:          "CVE-2025-0004",
+							Title:          "title focal",
+							Cvss40Score:    5.1,
+							Cvss40Vector:   "CVSS:4.0/AV:L/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N",
+							Cvss40Severity: "medium",
+							Optional: map[string]string{
+								"vuls2-sources": "[{\"root_id\":\"CVE-2025-0004\",\"source_id\":\"ubuntu-cve-tracker\",\"segment\":{\"ecosystem\":\"ubuntu:20.04\",\"tag\":\"focal\"}}]",
+							},
+						}},
+					},
+				},
+			},
+			want: models.VulnInfo{
+				CveID: "CVE-2025-0004",
+				CveContents: models.CveContents{
+					models.UbuntuAPI: []models.CveContent{{
+						Type:           models.UbuntuAPI,
+						CveID:          "CVE-2025-0004",
+						Title:          "title focal",
+						Cvss40Score:    5.1,
+						Cvss40Vector:   "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N",
+						Cvss40Severity: "medium",
+						Optional: map[string]string{
+							"vuls2-sources": "[{\"root_id\":\"CVE-2025-0004\",\"source_id\":\"ubuntu-cve-tracker\",\"segment\":{\"ecosystem\":\"ubuntu:20.04\",\"tag\":\"esm-apps/focal\"}},{\"root_id\":\"CVE-2025-0004\",\"source_id\":\"ubuntu-cve-tracker\",\"segment\":{\"ecosystem\":\"ubuntu:20.04\",\"tag\":\"focal\"}}]",
+						},
+					}},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -2,6 +2,7 @@ package vuls2_test
 
 import (
 	"cmp"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -12961,6 +12962,211 @@ func Test_prunePkgCriteria(t *testing.T) {
 			}
 			if diff := gocmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("prunePkgCriteria() mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+// Test_mergeVulnInfo pins the CVSS winner selection to the content pair
+// itself, independent of merge order. postConvert folds VulnInfos in map
+// iteration order, so every case is run as both merge(a, b) and merge(b, a)
+// and must produce the same result. The tied-score cases mirror the
+// tracker-derived contents (severity string only, score 0 vs 0) whose
+// severities used to flip between runs.
+func Test_mergeVulnInfo(t *testing.T) {
+	type args struct {
+		a models.VulnInfo
+		b models.VulnInfo
+	}
+	tests := []struct {
+		name string
+		args args
+		want models.VulnInfo
+	}{
+		{
+			// Ubuntu emits per-release-tag segments for one CVE with severity
+			// strings only. The higher vendor severity rank must win the tie,
+			// even though the other segment ranks higher as a source (its
+			// "focal" tag wins the Title).
+			name: "tied zero scores break by vendor severity rank",
+			args: args{
+				a: models.VulnInfo{
+					CveID: "CVE-2025-0001",
+					CveContents: models.CveContents{
+						models.UbuntuAPI: []models.CveContent{{
+							Type:          models.UbuntuAPI,
+							CveID:         "CVE-2025-0001",
+							Title:         "title esm",
+							Cvss2Severity: "medium",
+							Cvss3Severity: "medium",
+							Optional: map[string]string{
+								"vuls2-sources": "[{\"root_id\":\"CVE-2025-0001\",\"source_id\":\"ubuntu-cve-tracker\",\"segment\":{\"ecosystem\":\"ubuntu:20.04\",\"tag\":\"esm-apps/focal\"}}]",
+							},
+						}},
+					},
+				},
+				b: models.VulnInfo{
+					CveID: "CVE-2025-0001",
+					CveContents: models.CveContents{
+						models.UbuntuAPI: []models.CveContent{{
+							Type:          models.UbuntuAPI,
+							CveID:         "CVE-2025-0001",
+							Title:         "title focal",
+							Cvss2Severity: "negligible",
+							Cvss3Severity: "negligible",
+							Optional: map[string]string{
+								"vuls2-sources": "[{\"root_id\":\"CVE-2025-0001\",\"source_id\":\"ubuntu-cve-tracker\",\"segment\":{\"ecosystem\":\"ubuntu:20.04\",\"tag\":\"focal\"}}]",
+							},
+						}},
+					},
+				},
+			},
+			want: models.VulnInfo{
+				CveID: "CVE-2025-0001",
+				CveContents: models.CveContents{
+					models.UbuntuAPI: []models.CveContent{{
+						Type:          models.UbuntuAPI,
+						CveID:         "CVE-2025-0001",
+						Title:         "title focal",
+						Cvss2Severity: "medium",
+						Cvss3Severity: "medium",
+						Optional: map[string]string{
+							"vuls2-sources": "[{\"root_id\":\"CVE-2025-0001\",\"source_id\":\"ubuntu-cve-tracker\",\"segment\":{\"ecosystem\":\"ubuntu:20.04\",\"tag\":\"esm-apps/focal\"}},{\"root_id\":\"CVE-2025-0001\",\"source_id\":\"ubuntu-cve-tracker\",\"segment\":{\"ecosystem\":\"ubuntu:20.04\",\"tag\":\"focal\"}}]",
+						},
+					}},
+				},
+			},
+		},
+		{
+			// Debian's "unimportant" is outside the vendor severity table, so
+			// it ranks equal to the empty string; the raw-string fallback has
+			// to make the choice decisive.
+			name: "severities outside the vendor table break by raw string",
+			args: args{
+				a: models.VulnInfo{
+					CveID: "CVE-2025-0002",
+					CveContents: models.CveContents{
+						models.DebianSecurityTracker: []models.CveContent{{
+							Type:          models.DebianSecurityTracker,
+							CveID:         "CVE-2025-0002",
+							Title:         "title buster",
+							Cvss2Severity: "unimportant",
+							Optional: map[string]string{
+								"vuls2-sources": "[{\"root_id\":\"CVE-2025-0002\",\"source_id\":\"debian-security-tracker-api\",\"segment\":{\"ecosystem\":\"debian:10\",\"tag\":\"buster\"}}]",
+							},
+						}},
+					},
+				},
+				b: models.VulnInfo{
+					CveID: "CVE-2025-0002",
+					CveContents: models.CveContents{
+						models.DebianSecurityTracker: []models.CveContent{{
+							Type:  models.DebianSecurityTracker,
+							CveID: "CVE-2025-0002",
+							Title: "title lts",
+							Optional: map[string]string{
+								"vuls2-sources": "[{\"root_id\":\"CVE-2025-0002\",\"source_id\":\"debian-security-tracker-api\",\"segment\":{\"ecosystem\":\"debian:10\",\"tag\":\"buster/lts\"}}]",
+							},
+						}},
+					},
+				},
+			},
+			want: models.VulnInfo{
+				CveID: "CVE-2025-0002",
+				CveContents: models.CveContents{
+					models.DebianSecurityTracker: []models.CveContent{{
+						Type:          models.DebianSecurityTracker,
+						CveID:         "CVE-2025-0002",
+						Title:         "title lts",
+						Cvss2Severity: "unimportant",
+						Optional: map[string]string{
+							"vuls2-sources": "[{\"root_id\":\"CVE-2025-0002\",\"source_id\":\"debian-security-tracker-api\",\"segment\":{\"ecosystem\":\"debian:10\",\"tag\":\"buster\"}},{\"root_id\":\"CVE-2025-0002\",\"source_id\":\"debian-security-tracker-api\",\"segment\":{\"ecosystem\":\"debian:10\",\"tag\":\"buster/lts\"}}]",
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "higher score still wins regardless of severity rank",
+			args: args{
+				a: models.VulnInfo{
+					CveID: "CVE-2025-0003",
+					CveContents: models.CveContents{
+						models.UbuntuAPI: []models.CveContent{{
+							Type:          models.UbuntuAPI,
+							CveID:         "CVE-2025-0003",
+							Cvss3Score:    7.5,
+							Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+							Cvss3Severity: "low",
+							Optional: map[string]string{
+								"vuls2-sources": "[{\"root_id\":\"CVE-2025-0003\",\"source_id\":\"ubuntu-cve-tracker\",\"segment\":{\"ecosystem\":\"ubuntu:20.04\",\"tag\":\"esm-apps/focal\"}}]",
+							},
+						}},
+					},
+				},
+				b: models.VulnInfo{
+					CveID: "CVE-2025-0003",
+					CveContents: models.CveContents{
+						models.UbuntuAPI: []models.CveContent{{
+							Type:          models.UbuntuAPI,
+							CveID:         "CVE-2025-0003",
+							Cvss3Score:    5.0,
+							Cvss3Vector:   "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+							Cvss3Severity: "critical",
+							Optional: map[string]string{
+								"vuls2-sources": "[{\"root_id\":\"CVE-2025-0003\",\"source_id\":\"ubuntu-cve-tracker\",\"segment\":{\"ecosystem\":\"ubuntu:20.04\",\"tag\":\"focal\"}}]",
+							},
+						}},
+					},
+				},
+			},
+			want: models.VulnInfo{
+				CveID: "CVE-2025-0003",
+				CveContents: models.CveContents{
+					models.UbuntuAPI: []models.CveContent{{
+						Type:          models.UbuntuAPI,
+						CveID:         "CVE-2025-0003",
+						Cvss3Score:    7.5,
+						Cvss3Vector:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+						Cvss3Severity: "low",
+						Optional: map[string]string{
+							"vuls2-sources": "[{\"root_id\":\"CVE-2025-0003\",\"source_id\":\"ubuntu-cve-tracker\",\"segment\":{\"ecosystem\":\"ubuntu:20.04\",\"tag\":\"esm-apps/focal\"}},{\"root_id\":\"CVE-2025-0003\",\"source_id\":\"ubuntu-cve-tracker\",\"segment\":{\"ecosystem\":\"ubuntu:20.04\",\"tag\":\"focal\"}}]",
+						},
+					}},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// mergeVulnInfo writes the combined vuls2-sources marker into the
+			// winning content's Optional map, so each order gets its own deep
+			// copy of the inputs.
+			clone := func(vi models.VulnInfo) models.VulnInfo {
+				bs, err := json.Marshal(vi)
+				if err != nil {
+					t.Fatalf("marshal vuln info: %s", err)
+				}
+				var c models.VulnInfo
+				if err := json.Unmarshal(bs, &c); err != nil {
+					t.Fatalf("unmarshal vuln info: %s", err)
+				}
+				return c
+			}
+			for _, order := range []struct {
+				name string
+				x, y models.VulnInfo
+			}{
+				{name: "merge(a, b)", x: tt.args.a, y: tt.args.b},
+				{name: "merge(b, a)", x: tt.args.b, y: tt.args.a},
+			} {
+				got, err := vuls2.MergeVulnInfo(clone(order.x), clone(order.y))
+				if err != nil {
+					t.Fatalf("%s: unexpected error: %s", order.name, err)
+				}
+				if diff := gocmp.Diff(got, tt.want); diff != "" {
+					t.Errorf("%s mismatch (-got +want):\n%s", order.name, diff)
+				}
 			}
 		})
 	}

--- a/detector/vuls2/vuls2_test.go
+++ b/detector/vuls2/vuls2_test.go
@@ -13145,11 +13145,11 @@ func Test_mergeVulnInfo(t *testing.T) {
 			clone := func(vi models.VulnInfo) models.VulnInfo {
 				bs, err := json.Marshal(vi)
 				if err != nil {
-					t.Fatalf("marshal vuln info: %s", err)
+					t.Fatalf("marshal vuln info: %v", err)
 				}
 				var c models.VulnInfo
 				if err := json.Unmarshal(bs, &c); err != nil {
-					t.Fatalf("unmarshal vuln info: %s", err)
+					t.Fatalf("unmarshal vuln info: %v", err)
 				}
 				return c
 			}
@@ -13162,7 +13162,7 @@ func Test_mergeVulnInfo(t *testing.T) {
 			} {
 				got, err := vuls2.MergeVulnInfo(clone(order.x), clone(order.y))
 				if err != nil {
-					t.Fatalf("%s: unexpected error: %s", order.name, err)
+					t.Fatalf("%s: unexpected error: %v", order.name, err)
 				}
 				if diff := gocmp.Diff(got, tt.want); diff != "" {
 					t.Errorf("%s mismatch (-got +want):\n%s", order.name, diff)


### PR DESCRIPTION
# What did you implement:

Fixes a run-to-run nondeterminism in vuls2 detection results: running `vuls report` twice on the same scan result with the same DB could flip CveContents severity values between runs, e.g.

- ubuntu_2004: `cvss2Severity` / `cvss3Severity` flipping `"medium"` ↔ `"negligible"`
- debian_10: `"unimportant"` ↔ `""` (empty)

## Mechanism

`mergeVulnInfo` picks the CVSS2/CVSS3/CVSS40 winner between two same-type contents by `cmp.Compare` on the score alone, keeping the base content on a tie. Tracker-derived contents (Ubuntu CVE tracker, Debian security tracker) carry only a severity string — both scores are zero — so every comparison is a tie and the winner is decided by which content became base first. That merge order comes from `postConvert` folding VulnInfos while iterating a map keyed by source/segment, so it changes between runs. The flip shows up when one CVE has contents from multiple segments with different severities (e.g. Ubuntu emitting both "medium" and "negligible" for release tags of the same CVE).

## Fix

Score ties now break deterministically, in order:

1. vendor severity rank — the same `severityVendorTypes.Compare` already used for the DistroAdvisories merge, so the semantically higher severity wins (`"medium"` beats `"negligible"`),
2. raw severity string, then raw vector string — needed because severities outside the vendor table (e.g. Debian's `"unimportant"`) all rank equal, and this makes the choice decisive for any distinct pair.

Applied to the CVSS40 / CVSS3 (score branch; the 3.1-over-3.0 vector-prefix preference is untouched) / CVSS2 selections, so the merge result no longer depends on merge order for these fields. As a side effect, reports get much closer to byte-stable across runs (the remaining known nondeterminism is array ordering), which also removes false positives from diff-based tooling.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- `go test ./detector/vuls2/`: added a `Test_mergeVulnInfo` table test that runs every case as both `merge(a, b)` and `merge(b, a)` and requires the identical result: vendor-rank tiebreak (Ubuntu medium vs negligible), raw-string fallback (Debian unimportant vs empty), and a guard that a higher score still wins regardless of severity rank.
- E2E identity check: run `vuls report` twice on the same scan result (ubuntu_2004 / debian_10 against a 2026-08-25 nightly vuls2 DB), normalize both JSONs (`del(.reportedAt, .reportedVersion, .reportedRevision, .config)` + recursive `sort_by(tojson)` of all arrays to neutralize the known array-order nondeterminism), and diff. Unpatched master reproduced DIFFERS 3/3 tries; with this fix repeated runs are IDENTICAL.

# Checklist:

- [x] Write tests
- [ ] Write documentation
- [x] Check that there aren't other open pull requests for the same issue/feature
- [x] Format your source code by `make fmt`
- [x] Pass the test by `make test`
- [x] Provide verification config / commands
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

***Is this ready for review?:*** YES

🤖 Generated with [Claude Code](https://claude.com/claude-code)